### PR TITLE
Update CA id from X1 -> X3

### DIFF
--- a/certificates.md
+++ b/certificates.md
@@ -59,7 +59,7 @@ visually:
 We are dedicated to transparency in our operations and in the certificates we
 issue. We submit all certificates to [Certificate Transparency
 logs](https://www.certificate-transparency.org/) as we issue them. You can view [all
-issued Let's Encrypt certificates at crt.sh](https://crt.sh/?Identity=%25&iCAID=7395).
+issued Let's Encrypt certificates at crt.sh](https://crt.sh/?Identity=%25&iCAID=16418).
 
 # More Info
 


### PR DESCRIPTION
https://letsencrypt.org/certificates/ was using the old CA id.