### PR TITLE
Add link to Boulder's ACME Divergences doc.

### DIFF
--- a/docs/acme-protocol-updates.md
+++ b/docs/acme-protocol-updates.md
@@ -14,9 +14,9 @@ The ACME protocol is the cornerstone of how Let's Encrypt works. As the protocol
 We currently have the following API endpoints and associated ACME version implementations:
 
 * [Production] acme-v01.api.letsencrypt.org
-  * ACME Version: [draft 01](https://tools.ietf.org/html/draft-ietf-acme-acme-01), with some tweaks
+  * ACME Version: [draft 01](https://tools.ietf.org/html/draft-ietf-acme-acme-01), with [some tweaks](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
 * [Staging] acme-staging.api.letsencrypt.org
-  * ACME Version: [draft 01](https://tools.ietf.org/html/draft-ietf-acme-acme-01), with some tweaks
+  * ACME Version: [draft 01](https://tools.ietf.org/html/draft-ietf-acme-acme-01), with [some tweaks](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
 
 # New Backwards-Compatible ACME Features
 


### PR DESCRIPTION
The ACME Protocol Updates page of the documentation described the two
currently implemented ACME versions and indicated each were implementing
draft 01 "with some tweaks".

Since we now have a shiny new ACME Divergences document in the Boulder
repo that describes these tweaks we can link to it directly. This commit
introduces the links.
