### PR TITLE
Add description of the staging env. rate limits.

### DIFF
--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -15,3 +15,11 @@ The ACME URL for our staging environment is:
 `https://acme-staging.api.letsencrypt.org/directory`
 
 Please see your client's instructions for information on testing with our staging environment.
+
+# Rate Limits
+
+The staging environment uses the same rate limits as [described for the production environment](/docs/rate-limits/) with the following exceptions:
+
+* The **Certificates per Registered Domain** limit is 30,000 per week.
+* The **Duplicate Certificate** limit is 30,000 per week.
+* The **Registrations Per IP Address** limit is 100 per week.


### PR DESCRIPTION
Prior to this PR we do not describe the differences between staging & prod from a rate-limit perspective.

*Note*: Currently the `registrationsPerIP` limit is actually **lower** in staging than in prod. I have documented the current difference while I stage a PR with ops to update the staging environment to use the same value as production. I will update this section of the staging docs when the updated policy is deployed to staging.

Staging:
```
    registrationsPerIP:
      window: 168h # 1 week
      threshold: 100
```
Prod:
```
    registrationsPerIP:
      window: 3h
      threshold: 500
```