### PR TITLE
Remove RegPerIP staging limit.

### DIFF
--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -22,4 +22,3 @@ The staging environment uses the same rate limits as [described for the producti
 
 * The **Certificates per Registered Domain** limit is 30,000 per week.
 * The **Duplicate Certificate** limit is 30,000 per week.
-* The **Registrations Per IP Address** limit is 100 per week.


### PR DESCRIPTION
Previously the Registrations Per IP Address limit differed from production and so was described on the staging environment page. Since the staging limit has been changed (IN-799) to match production the staging page needs to be updated to remove the old reg per IP limit.