### PR TITLE
Further reorganization.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,42 +21,20 @@
     <nav class="site-nav" id="menu">
       <div class="pure-menu pure-menu-horizontal custom-can-transform">
           <ul class="pure-menu-list">
-              <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-                  <a href="#" id="menuLink1" class="pure-menu-link">Technology</a>
-                  <ul class="pure-menu-children">
-                      <li class="pure-menu-item">
-                        <a href="/how-it-works/" class="pure-menu-link">How It Works</a>
-                      </li>
-                      <li class="pure-menu-item">
-                        <a href="/certificates/" class="pure-menu-link">Chain of Trust</a>
-                      </li>
-                      <li class="pure-menu-item">
-                        <a href="/upcoming-features/" class="pure-menu-link">Upcoming Features</a>
-                      </li>
-                      <li class="pure-menu-item">
-                        <a href="/stats/" class="pure-menu-link">Stats</a>
-                      </li>
-                  </ul>
+              <li class="pure-menu-item">
+                <a class="pure-menu-link" href="/getting-started/">Get Started</a>
               </li>
-              <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-                  <a href="#" id="menuLink3" class="pure-menu-link">Support</a>
-                  <ul class="pure-menu-children">
-                      <li class="pure-menu-item">
-                        <a href="/getting-started/" class="pure-menu-link">Getting Started</a>
-                      </li>
-                      <li class="pure-menu-item">
-                        <a href="https://community.letsencrypt.org/" class="pure-menu-link">Community Support</a>
-                      </li>
-                      <li class="pure-menu-item">
-                        <a href="/docs/" class="pure-menu-link">Documentation</a>
-                      </li>
-                      <li class="pure-menu-item">
-                        <a href="https://letsencrypt.status.io/" class="pure-menu-link">Service Status</a>
-                      </li>
-                  </ul>
+
+              <li class="pure-menu-item">
+                <a class="pure-menu-link" href="https://community.letsencrypt.org/">Get Help</a>
               </li>
+
+              <li class="pure-menu-item">
+                <a href="/docs/" class="pure-menu-link">Documentation</a>
+              </li>
+
               <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-                  <a href="#" id="menuLink2" class="pure-menu-link">Donate</a>
+                  <a href="/donate/" class="pure-menu-link">Donate</a>
                   <ul class="pure-menu-children">
                       <li class="pure-menu-item">
                         <a href="/donate/" class="pure-menu-link">Make a Donation</a>
@@ -73,16 +51,19 @@
                   </ul>
               </li>
               <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-                  <a href="#" id="menuLink4" class="pure-menu-link">About Us</a>
+                  <a href="/about/" class="pure-menu-link">About Us</a>
                   <ul class="pure-menu-children">
-                      <li class="pure-menu-item">
-                        <a href="/about/" class="pure-menu-link">Let's Encrypt</a>
-                      </li>
                       <li class="pure-menu-item">
                         <a href="/isrg/" class="pure-menu-link">Internet Security Research Group (ISRG)</a>
                       </li>
                       <li class="pure-menu-item">
                         <a href="/repository/" class="pure-menu-link">Policy and Legal Repository</a>
+                      </li>
+                      <li class="pure-menu-item">
+                        <a href="https://letsencrypt.status.io/" class="pure-menu-link">Service Status</a>
+                      </li>
+                      <li class="pure-menu-item">
+                        <a href="/stats/" class="pure-menu-link">Statistics</a>
                       </li>
                       <li class="pure-menu-item">
                         <a class="pure-menu-link" href="/contact/">Contact</a>

--- a/about.md
+++ b/about.md
@@ -17,17 +17,11 @@ The key principles behind Let's Encrypt are:
 * <strong>Open:</strong> The automatic issuance and renewal protocol will be published as an open standard that others can adopt.
 * <strong>Cooperative:</strong> Much like the underlying Internet protocols themselves, Let's Encrypt is a joint effort to benefit the community, beyond the control of any one organization.
 
-## Technical Advisory Board (TAB)
+### More information:
 
-Our TAB consists of technical experts from major supporting organizations, as well as independent experts with strong CA/PKI industry experience.
-
-* <strong>Rich Salz</strong> (Akamai)
-* <strong>Joe Hildebrand</strong> (Cisco)
-* <strong>Jacob Hoffman-Andrews</strong> (Electronic Frontier Foundation)
-* <strong>J.C. Jones</strong> (Mozilla)
-* <strong>Russ Housley</strong> (Independent)
-* <strong>Ryan Hurst</strong> (Independent)
-* <strong>Stephen Kent</strong> (Independent)
-* <strong>Karen O'Donoghue</strong> (Internet Society)
-
-We also have a [corporate board](/isrg/).
+- [Internet Security Research Group (ISRG)](/isrg/)
+- [Policy and Legal Repository](/repository/)
+- [Service Status](https://letsencrypt.status.io/)
+- [Statistics](/stats/)
+- [Contact](/contact/)
+- [Jobs](/jobs/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,9 @@ top_graphic: 1
 * [ACME Protocol Updates](/docs/acme-protocol-updates/)
 * [Finding Your Account ID](/docs/account-id/)
 * [Frequently Asked Questions (FAQ)](/docs/faq/)
+* [How Let's Encrypt Works](/how-it-works/)
+* [Root and Intermediate Certificates](/certificates/)
+* [Upcoming Features](/upcoming-features/)
 
 # Large Scale Providers and Integrators
 

--- a/isrg.md
+++ b/isrg.md
@@ -20,3 +20,16 @@ Our current board members are:
 * <strong>Peter Eckersley</strong> (EFF)
 * <strong>Alex Polvi</strong> (CoreOS)
 * <strong>Pascal Jaillon</strong> (OVH)
+
+## Technical Advisory Board (TAB)
+
+Our TAB consists of technical experts from major supporting organizations, as well as independent experts with strong CA/PKI industry experience.
+
+* <strong>Rich Salz</strong> (Akamai)
+* <strong>Joe Hildebrand</strong> (Cisco)
+* <strong>Jacob Hoffman-Andrews</strong> (Electronic Frontier Foundation)
+* <strong>J.C. Jones</strong> (Mozilla)
+* <strong>Russ Housley</strong> (Independent)
+* <strong>Ryan Hurst</strong> (Independent)
+* <strong>Stephen Kent</strong> (Independent)
+* <strong>Karen O'Donoghue</strong> (Internet Society)


### PR DESCRIPTION
@bdaehlie Nice start! I think Support / Donate has the same semantic ambiguity as I mentioned in #31, with Contribute / Donate. I've tried another round of iteration, please let me know what you think!

Add top-level links for Get Started, Get Help, and Documentation links.
Move Technology links into the Documentation page.
Move Statistics and Service Status into About menu.
Make Donate and About headings into actual links. This is better for screen
readers, people with JavaScript disabled, and potentially for SEO.
Add links to /about/ to copy what's in the menu.
Move TAB section of /about/ into /isrg/, alongside board member list.