### PR TITLE
Increase base font-weight to 400

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -18,7 +18,7 @@ body {
     font-family: $base-font-family;
     font-size: $base-font-size;
     line-height: $base-line-height;
-    font-weight: 300;
+    font-weight: 400;
     color: $text-color;
     background-color: $background-color;
     -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
On Windows, the font weight of 300 is hard to read, and almost shimmers on big blocks of text.

Does this bother anyone else? Don't want to make it look pudgy on macOS etc., which generally have heavier antialiasing.

Proposed weight of **400**:
![400](http://i.imgur.com/F8MBqz1.png)

Default weight of **300**:
![300](http://i.imgur.com/gUPUFIi.png)