### PR TITLE
Adds Zappa to the list of projects integrating with LetsEncrypt

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -158,3 +158,4 @@ If certbot does not meet your needs, or you’d simply like to try something els
 - [Mesosphere DCOS](https://mesosphere.com/blog/2016/04/06/lets-encrypt-dcos/)
 - [Virtualmin Web Hosting Control Panel](https://www.virtualmin.com/)
 - [Plesk Web Hosting Control Panel](https://www.plesk.com/)
+- [Zappa](https://github.com/Miserlou/Zappa#lets-encrypt-ssl-domain-certification-and-installation)


### PR DESCRIPTION
I'm proud to say that [Zappa](https://github.com/Miserlou/Zappa) now has extremely tight integration with Let'sEncrypt, allowing AWS Lambda + API Gateway users to have one-command LE installation!

By calling `zappa certify`, Zappa will automatically verify the supplied domain using Route53 for DNS-based challenges, install the new LE Certificate in the API Gateway, and even schedule an AWS Schedule Event Function to renew the certificate automatically on Lambda before it expires!

Incredible stuff, thanks for building and maintaining Let's Encrypt!