### PR TITLE
Tighten CSP

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -66,4 +66,6 @@
   </div>
 
   <script src="/js/main.js"></script>
+  <script src="/js/ga.js"></script>
+  <script async src='https://www.google-analytics.com/analytics.js'></script>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,14 +27,4 @@
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
     <link rel="alternate" href="https://letsencrypt.org/feed.xml" type="application/rss+xml" title="Let's Encrypt Blog Feed" />
-
-    <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-56433935-1', 'auto');
-          ga('send', 'pageview');
-    </script>
 </head>

--- a/js/ga.js
+++ b/js/ga.js
@@ -1,0 +1,5 @@
+// Google Analytics startup, per:
+// https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tracking_snippet
+window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+ga('create', 'UA-56433935-1', 'auto');
+ga('send', 'pageview');


### PR DESCRIPTION
Move Google Analytics to its own file and load it per guidance:

https://developers.google.com/analytics/devguides/collection/analyticsjs/#alternative_async_tracking_snippet

This in combination with PR #61 permits the following, much tighter CSP
policy:

> Content-Security-Policy "default-src 'self'; style-src 'unsafe-inline' 'self'; script-src 'unsafe-eval' 'self' https://www.google-analytics.com; img-src 'self' data: https://www.google-analytics.com;"

This can land whenever, but the CSP policy shouldn't be updated until #61 lands.
Additionally, the CSP policy should be updated with care and tested as well as
possible before being left alone.

For reference, the current CSP policy is:
>Content-Security-Policy "default-src 'self' https://letsencrypt.org; style-src 'unsafe-inline' 'self' https://letsencrypt.org; script-src 'unsafe-inline' 'self' https://letsencrypt.org https://www.google-analytics.com https://plot.ly; img-src 'self' https://letsencrypt.org https://www.google-analytics.com https://www.paypal.com https://www.paypalobjects.com https://ak2s.abmr.net https://ak1s.abmr.net https://plot.ly; child-src https://plot.ly; frame-src https://plot.ly;"

(Note: Most of that is antique to the first rev of the site, as we moved assets onto the main site over time.)