### PR TITLE
Updates some sponsor links to use `https://`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,14 +42,14 @@ layout: no-wrapper
             <h2 class="through-line"><a href="/sponsors/">Major Sponsors</a></h2>
             <div class="text-center">
               <a href="https://www.mozilla.org/"><img src="/images/sponsors/small/mozilla-logo.png" alt="Mozilla" width="80" height="48" style="padding: 10px;"></a>
-              <a href="http://www.akamai.com/"><img src="/images/sponsors/small/akamai-logo.png" alt="Akamai" width="80" height="48" style="padding: 10px;"></a>
-              <a href="http://www.cisco.com/"><img src="/images/sponsors/small/cisco-logo.png" alt="Cisco" width="80" height="48" style="padding: 10px;"></a>
+              <a href="https://www.akamai.com/"><img src="/images/sponsors/small/akamai-logo.png" alt="Akamai" width="80" height="48" style="padding: 10px;"></a>
+              <a href="https://www.cisco.com/"><img src="/images/sponsors/small/cisco-logo.png" alt="Cisco" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.eff.org/"><img src="/images/sponsors/small/eff-logo.png" alt="Electronic Frontier Foundation" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.ovh.com/"><img src="/images/sponsors/small/ovh-logo.png" alt="OVH" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.google.com/chrome/" rel="nofollow"><img src="/images/sponsors/small/chrome-logo.png" alt="Google Chrome" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.identrustssl.com/"><img src="/images/sponsors/small/identrust-logo.png" alt="IdenTrust" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.facebook.com/"><img src="/images/sponsors/small/facebook-logo.png" alt="Facebook" width="80" height="48" style="padding: 10px;"></a>
-              <a href="http://www.gemalto.com/"><img src="/images/sponsors/small/gemalto-logo.png" alt="Gemalto" width="80" height="48" style="padding: 10px;"></a>
+              <a href="https://www.gemalto.com/"><img src="/images/sponsors/small/gemalto-logo.png" alt="Gemalto" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://automattic.com/"><img src="/images/sponsors/small/automattic-logo.png" alt="Automattic" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.shopify.com/"><img src="/images/sponsors/small/shopify-logo.png" alt="Shopify" width="80" height="48" style="padding: 10px;"></a>
               <a href="http://www.ala.org/offices/oif"><img src="/images/sponsors/small/ala-logo.png" alt="American Library Association" width="80" height="48" style="padding: 10px;"></a>
@@ -71,9 +71,9 @@ layout: no-wrapper
               <a href="https://www.hpe.com/"><img src="/images/sponsors/small/hpe-logo.png" alt="HP Enterprise" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.fastly.com/"><img src="/images/sponsors/small/fastly-logo.png" alt="Fastly" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.dudamobile.com/"><img src="/images/sponsors/small/duda-logo.png" alt="Duda" width="80" height="48" style="padding: 10px;"></a>
-              <a href="http://www.reliablesite.net/"><img src="/images/sponsors/small/reliablesite-logo.png" alt="ReliableSite.net" width="80" height="48" style="padding: 10px;"></a>
+              <a href="https://www.reliablesite.net/"><img src="/images/sponsors/small/reliablesite-logo.png" alt="ReliableSite.net" width="80" height="48" style="padding: 10px;"></a>
               <a href="http://www.casino2k.com/"><img src="/images/sponsors/small/casino2k-logo.png" alt="Casino2k" width="80" height="48" style="padding: 10px;"></a>
-              <a href="http://www.3cx.com/"><img src="/images/sponsors/small/3cx-logo.png" alt="3CX" width="80" height="48" style="padding: 10px;"></a>
+              <a href="https://www.3cx.com/"><img src="/images/sponsors/small/3cx-logo.png" alt="3CX" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.sumologic.com/"><img src="/images/sponsors/small/sumo-logic-logo.png" alt="Sumo Logic" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.tintri.com/"><img src="/images/sponsors/small/tintri-logo.png" alt="Tintri" width="80" height="48" style="padding: 10px;"></a>
             </div>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ layout: no-wrapper
               <a href="https://www.google.com/chrome/" rel="nofollow"><img src="/images/sponsors/small/chrome-logo.png" alt="Google Chrome" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.identrustssl.com/"><img src="/images/sponsors/small/identrust-logo.png" alt="IdenTrust" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.facebook.com/"><img src="/images/sponsors/small/facebook-logo.png" alt="Facebook" width="80" height="48" style="padding: 10px;"></a>
-              <a href="https://www.gemalto.com/"><img src="/images/sponsors/small/gemalto-logo.png" alt="Gemalto" width="80" height="48" style="padding: 10px;"></a>
+              <a href="http://www.gemalto.com/"><img src="/images/sponsors/small/gemalto-logo.png" alt="Gemalto" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://automattic.com/"><img src="/images/sponsors/small/automattic-logo.png" alt="Automattic" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.shopify.com/"><img src="/images/sponsors/small/shopify-logo.png" alt="Shopify" width="80" height="48" style="padding: 10px;"></a>
               <a href="http://www.ala.org/offices/oif"><img src="/images/sponsors/small/ala-logo.png" alt="American Library Association" width="80" height="48" style="padding: 10px;"></a>
@@ -71,9 +71,9 @@ layout: no-wrapper
               <a href="https://www.hpe.com/"><img src="/images/sponsors/small/hpe-logo.png" alt="HP Enterprise" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.fastly.com/"><img src="/images/sponsors/small/fastly-logo.png" alt="Fastly" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.dudamobile.com/"><img src="/images/sponsors/small/duda-logo.png" alt="Duda" width="80" height="48" style="padding: 10px;"></a>
-              <a href="https://www.reliablesite.net/"><img src="/images/sponsors/small/reliablesite-logo.png" alt="ReliableSite.net" width="80" height="48" style="padding: 10px;"></a>
+              <a href="http://www.reliablesite.net/"><img src="/images/sponsors/small/reliablesite-logo.png" alt="ReliableSite.net" width="80" height="48" style="padding: 10px;"></a>
               <a href="http://www.casino2k.com/"><img src="/images/sponsors/small/casino2k-logo.png" alt="Casino2k" width="80" height="48" style="padding: 10px;"></a>
-              <a href="https://www.3cx.com/"><img src="/images/sponsors/small/3cx-logo.png" alt="3CX" width="80" height="48" style="padding: 10px;"></a>
+              <a href="http://www.3cx.com/"><img src="/images/sponsors/small/3cx-logo.png" alt="3CX" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.sumologic.com/"><img src="/images/sponsors/small/sumo-logic-logo.png" alt="Sumo Logic" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.tintri.com/"><img src="/images/sponsors/small/tintri-logo.png" alt="Tintri" width="80" height="48" style="padding: 10px;"></a>
             </div>

--- a/sponsors.html
+++ b/sponsors.html
@@ -12,8 +12,8 @@ top_graphic: 1
     <h2>Platinum</h2>
     <div align="center">
       <a href="https://www.mozilla.org/"><img src="/images/sponsors/mozilla-logo.png" alt="Mozilla" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="http://www.akamai.com/"><img src="/images/sponsors/akamai-logo.png" alt="Akamai" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="http://www.cisco.com/"><img src="/images/sponsors/cisco-logo.png" alt="Cisco" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="https://www.akamai.com/"><img src="/images/sponsors/akamai-logo.png" alt="Akamai" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="https://www.cisco.com/"><img src="/images/sponsors/cisco-logo.png" alt="Cisco" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.eff.org/"><img src="/images/sponsors/eff-logo.png"  alt="Electronic Frontier Foundation" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.ovh.com/"><img src="/images/sponsors/ovh-logo.png" alt="OVH" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.google.com/chrome/" rel="nofollow"><img src="/images/sponsors/chrome-logo.png" alt="Google Chrome" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
@@ -25,7 +25,7 @@ top_graphic: 1
     <div align="center">
       <a href="https://www.identrustssl.com/"><img src="/images/sponsors/identrust-logo.png" alt="IdenTrust" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.facebook.com/"><img src="/images/sponsors/facebook-logo.png" alt="Facebook" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="http://www.gemalto.com/"><img src="/images/sponsors/gemalto-logo.png" alt="Gemalto" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="https://www.gemalto.com/"><img src="/images/sponsors/gemalto-logo.png" alt="Gemalto" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
     </div>
   </div>
 
@@ -53,9 +53,9 @@ top_graphic: 1
       <a href="https://www.hpe.com/"><img src="/images/sponsors/hpe-logo.png" alt="HP Enterprise" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.fastly.com/"><img src="/images/sponsors/fastly-logo.png" alt="Fastly" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.dudamobile.com/"><img src="/images/sponsors/duda-logo.png" alt="Duda" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="http://www.reliablesite.net/"><img src="/images/sponsors/reliablesite-logo.png" alt="ReliableSite.net" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="https://www.reliablesite.net/"><img src="/images/sponsors/reliablesite-logo.png" alt="ReliableSite.net" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="http://www.casino2k.com/"><img src="/images/sponsors/casino2k-logo.png" alt="Casino2k" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="http://www.3cx.com/"><img src="/images/sponsors/3cx-logo.png" alt="3CX" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="https://www.3cx.com/"><img src="/images/sponsors/3cx-logo.png" alt="3CX" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.sumologic.com/"><img src="/images/sponsors/sumo-logic-logo.png" alt="Sumo Logic" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.tintri.com/"><img src="/images/sponsors/tintri-logo.png" alt="Tintri" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
     </div>

--- a/sponsors.html
+++ b/sponsors.html
@@ -25,7 +25,7 @@ top_graphic: 1
     <div align="center">
       <a href="https://www.identrustssl.com/"><img src="/images/sponsors/identrust-logo.png" alt="IdenTrust" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.facebook.com/"><img src="/images/sponsors/facebook-logo.png" alt="Facebook" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="https://www.gemalto.com/"><img src="/images/sponsors/gemalto-logo.png" alt="Gemalto" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="http://www.gemalto.com/"><img src="/images/sponsors/gemalto-logo.png" alt="Gemalto" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
     </div>
   </div>
 
@@ -53,9 +53,9 @@ top_graphic: 1
       <a href="https://www.hpe.com/"><img src="/images/sponsors/hpe-logo.png" alt="HP Enterprise" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.fastly.com/"><img src="/images/sponsors/fastly-logo.png" alt="Fastly" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.dudamobile.com/"><img src="/images/sponsors/duda-logo.png" alt="Duda" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="https://www.reliablesite.net/"><img src="/images/sponsors/reliablesite-logo.png" alt="ReliableSite.net" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="http://www.reliablesite.net/"><img src="/images/sponsors/reliablesite-logo.png" alt="ReliableSite.net" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="http://www.casino2k.com/"><img src="/images/sponsors/casino2k-logo.png" alt="Casino2k" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="https://www.3cx.com/"><img src="/images/sponsors/3cx-logo.png" alt="3CX" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="http://www.3cx.com/"><img src="/images/sponsors/3cx-logo.png" alt="3CX" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.sumologic.com/"><img src="/images/sponsors/sumo-logic-logo.png" alt="Sumo Logic" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.tintri.com/"><img src="/images/sponsors/tintri-logo.png" alt="Tintri" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
     </div>


### PR DESCRIPTION
A member of the community forum (Hi @jomo!) reported[0] that some of our sponsor links use `http://` for the protocol even though the target server supports `https://`.

This commit updates the following sponsor links to use https:
  * Akamai
  * Cisco

The following were not updated because they are just HTTPS->HTTP redirects:
  * Gemalto
  * 3cx

The following were not updated because of errors only present with the HTTPS version (mixed content warnings, 404, etc):
  * ALA
  * WPBeginner
  * Casino2k
  * Reliable Site

[0] - https://community.letsencrypt.org/t/some-sponsor-links-on-the-website-are-http/21119