### PR TITLE
adds a docker option

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -36,6 +36,9 @@ third party clients.
 ## C
 - [acme-client](https://kristaps.bsd.lv/acme-client/)
 
+## Docker
+- [cloud_letsencrypt](https://github.com/leandromoreira/cloud_letsencrypt)
+
 ## Go
 
 - [Caddy](https://caddyserver.com)

--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -37,7 +37,7 @@ third party clients.
 - [acme-client](https://kristaps.bsd.lv/acme-client/)
 
 ## Docker
-- [cloud_letsencrypt](https://github.com/leandromoreira/cloud_letsencrypt)
+- [tls_certificate_generation](https://github.com/leandromoreira/tls_certificate_generation.git)
 
 ## Go
 

--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -37,7 +37,7 @@ third party clients.
 - [acme-client](https://kristaps.bsd.lv/acme-client/)
 
 ## Docker
-- [tls_certificate_generation](https://github.com/leandromoreira/tls_certificate_generation.git)
+- [tls_certificate_generation](https://github.com/leandromoreira/tls_certificate_generation)
 
 ## Go
 


### PR DESCRIPTION
It let's you create / renew let's encrypt certificates using temporary Amazon EC2 / Digital Ocean machines.