### PR TITLE
Adds a integration guide link to ratelimit page.

### DIFF
--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -17,6 +17,8 @@ without requiring intervention from Let's Encrypt.
 
 If you're actively developing or testing a Let's Encrypt client, please utilize
 our [staging environment](/docs/staging-environment/) instead of the production API.
+If you're working on integrating Let's Encrypt as a provider or with a large
+website please [review our Integration Guide](/docs/integration-guide).
 
 The main limit is **Certificates per Registered Domain** (20 per week). A
 registered domain is, generally speaking, the part of the domain you purchased


### PR DESCRIPTION
An individual in the #letsencrypt IRC channel mentioned that it would have been helpful to find a link to the integration guide somewhere on the rate limits page.

I agree and think it would help make the integration guide more discoverable. Thinking as a large provider/integrator I'm likely to check the rate limits page as one of my first excursions into evaluating Let's Encrypt and familiarizing myself with the documentation.

This PR adds a sentence pointing to the integration guide.