### PR TITLE
Improves the "Get Involved" page.

### DIFF
--- a/getinvolved.md
+++ b/getinvolved.md
@@ -11,18 +11,16 @@ We can always use help answering questions at [Let's Encrypt Community Support](
 
 ## Code
 
-We can also use help with software development. All of our code and protocol specifications are on [GitHub](https://github.com/letsencrypt/).
+We can also use help with software development. All of our code is on [GitHub](https://github.com/letsencrypt/).
 
 ### Client Software
 
-[Certbot](https://github.com/certbot/certbot) is a Python-based utility that works alongside Apache to automatically obtain a certificate and convert a website to HTTPS.
+[Certbot](https://github.com/certbot/certbot) is a Python-based utility that works alongside your webserver to automatically obtain a certificate and convert a website to HTTPS. Certbot is the client we recommend that most people start with. Many other [third party client options](https://letsencrypt.org/docs/client-options/) are available.
 
 ### Server-side CA Software
 
-[Boulder](https://github.com/letsencrypt/boulder) is the primary Let's Encrypt CA implementation. It's based on the [ACME](https://github.com/letsencrypt/acme-spec) protocol, and written primarily in Go.
+[Boulder](https://github.com/letsencrypt/boulder) is the Let's Encrypt CA implementation. It's based on the [ACME](https://github.com/ietf-wg-acme/acme) protocol, and written primarily in Go. A great place to start is with the list of ['help wanted' issues](https://github.com/letsencrypt/boulder/issues?q=is%3Aopen+is%3Aissue+label%3Astatus%2Fhelp-wanted) and the [contributors guide](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
 
 ## Protocol
 
-The Let's Encrypt CA talks to certificate management software running on web servers.  The protocol for this is called ACME, for "Automated Certificate Management Environment." You can [view the draft ACME spec](https://github.com/letsencrypt/acme-spec) now.  We plan to propose work on this protocol in the IETF soon, to make it a truly open standard.
-
-ACME protocol development can be discussed on [this IETF mailing list](https://www.ietf.org/mailman/listinfo/acme).
+The Let's Encrypt CA talks to certificate management software running on web servers.  The protocol for this is called ACME, for "Automated Certificate Management Environment." The draft ACME spec is [available on Github](https://github.com/ietf-wg-acme/acme). Work is underway within the IETF to finalize ACME as a truly open standard. You can join the ACME protocol development discussion on [this IETF mailing list](https://www.ietf.org/mailman/listinfo/acme).


### PR DESCRIPTION
This commit improves the "Get Involved" website page in a few ways. The certbot language is updated, the ACME references are changed to the IETF repos instead of our forks, the Boulder get involved steps are more detailed.