### PR TITLE
Updates current ACME draft from 03 to 04.

### DIFF
--- a/docs/acme-protocol-updates.md
+++ b/docs/acme-protocol-updates.md
@@ -15,9 +15,9 @@ The ACME protocol is the cornerstone of how Let's Encrypt works. As the protocol
 We currently have the following API endpoints and associated ACME version implementations:
 
 * [Production] `https://acme-v01.api.letsencrypt.org/directory`
-  * ACME Version: [draft 03](https://tools.ietf.org/html/draft-ietf-acme-acme-03), with [some tweaks](https://github.com/letsencrypt/boulder/blob/release/docs/acme-divergences.md)
+  * ACME Version: [draft 04](https://tools.ietf.org/html/draft-ietf-acme-acme-04), with [some tweaks](https://github.com/letsencrypt/boulder/blob/release/docs/acme-divergences.md)
 * [Staging] `https://acme-staging.api.letsencrypt.org/directory`
-  * ACME Version: [draft 03](https://tools.ietf.org/html/draft-ietf-acme-acme-03), with [some tweaks](https://github.com/letsencrypt/boulder/blob/staging/docs/acme-divergences.md)
+  * ACME Version: [draft 04](https://tools.ietf.org/html/draft-ietf-acme-acme-04), with [some tweaks](https://github.com/letsencrypt/boulder/blob/staging/docs/acme-divergences.md)
 
 # New Backwards-Compatible ACME Features
 


### PR DESCRIPTION
This PR updates the current ACME version linked from draft-03 to draft-04.

<s>*Note*: This should **not** be merged until https://github.com/letsencrypt/boulder/pull/2356 is merged into
Boulder's master branch to catch the divergences document up to draft-04 as well.</s>

This is all ready to merge. https://github.com/letsencrypt/boulder/pull/2356 landed to master.