### PR TITLE
Increase stats graph margins on % Secure Connections

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -87,7 +87,7 @@ function plot(tIssued, tActive, tFqdn, tRegDom, tPctTLSAvg) {
   {
     traces = [ tActive, tFqdn, tRegDom ];
     layout = {
-      margin: { t: 0 },
+      margin: { t: 20 },
       yaxis: {
         title: 'Active Count',
       },
@@ -108,7 +108,7 @@ function plot(tIssued, tActive, tFqdn, tRegDom, tPctTLSAvg) {
   {
     traces = [ tIssued ];
     layout = {
-      margin: { t: 0 },
+      margin: { t: 20 },
       yaxis: {
         title: 'Issued Per Day',
       },
@@ -129,7 +129,7 @@ function plot(tIssued, tActive, tFqdn, tRegDom, tPctTLSAvg) {
   {
     traces = [ tPctTLSAvg ];
     layout = {
-      margin: { t: 0 },
+      margin: { t: 20 },
       yaxis: {
         title: 'Percent of Pageloads over HTTPS',
         rangemode: 'tozero',
@@ -154,7 +154,7 @@ function plot(tIssued, tActive, tFqdn, tRegDom, tPctTLSAvg) {
     tIssued.yaxis = "y2";
     traces = [ tActive, tFqdn, tRegDom, tIssued ];
     layout = {
-      margin: { t: 0 },
+      margin: { t: 20 },
       yaxis: {
         title: 'Active Count',
         side: 'right'


### PR DESCRIPTION
User feedback is that:
 1) The Percent Secure Connections graph's newest data is getting overlapped by
    the toolbar, and
 2) The Percent Secure Connections graph Y-range isn't dramatic

This change adds top-margins to all graphs sufficient to avoid overlapping the
data and the data-highlights on several tested platforms. It also re-enables
auto-ranging on the Percent Secure Connections graph.