### PR TITLE
added JDK 7u111 compatibility

### DIFF
--- a/docs/cert-compat.md
+++ b/docs/cert-compat.md
@@ -30,7 +30,8 @@ You may want to visit [this particular community forum discussion](https://commu
 * Cyanogen > v10
 * Jolla Sailfish OS > v1.1.2.16
 * Kindle > v3.4.1
-* Java >= JDK 7u111, 8u101
+* Java 7 >= 7u111
+* Java 8 >= 8u101
 
 # Possibly Incompatible
 
@@ -43,4 +44,5 @@ You may want to visit [this particular community forum discussion](https://commu
 * Nintendo 3DS
 * Windows XP prior to SP3
   * cannot handle SHA-2 signed certificates
-* Java < JDK 8u101
+* Java 7 < 7u111
+* Java 8 < 8u101

--- a/docs/cert-compat.md
+++ b/docs/cert-compat.md
@@ -30,7 +30,7 @@ You may want to visit [this particular community forum discussion](https://commu
 * Cyanogen > v10
 * Jolla Sailfish OS > v1.1.2.16
 * Kindle > v3.4.1
-* Java >= JDK 8u101
+* Java >= JDK 7u111, 8u101
 
 # Possibly Incompatible
 


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8154757

I tested validating an LE certificate under 7u111 successfully; previous versions failed as expected.