### PR TITLE
Add retry info and API announcements page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ top_graphic: 1
 * [Getting Started](/getting-started/)
 * [How Let's Encrypt Works](/how-it-works/)
 * [Frequently Asked Questions (FAQ)](/docs/faq/)
+* [What is a Certificate?](/docs/what-is-a-certificate/)
 
 # Subscriber Information
 

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -122,7 +122,18 @@ quickly, which is fine. You can then spread out renewal times by doing a
 one-time process of renewing some certificates 1 day ahead of when you would
 normally renew, some of them 2 days ahead, and so on.
 
+# Retrying failures
+
 Renewal failure should not be treated as a fatal error. You should implement
 graceful retry logic in your issuing services using an exponential backoff
-pattern. However, errors should be sent to the administrator in charge, in order
-to see if problems need fixing.
+pattern, maxing out at once per day per certificate. For instance, it would be
+suitable to automatically retry a failed renewal after 1 minute, 10 minutes,
+100 minutes, and 1440 minutes, absent specific administrator intervention. This
+means that your issuance software should keep track of failures as well as
+successes, and check if there was a recent failure before attempting a fresh
+issuance. There's no point in attempting issuance hundreds of times per hour,
+since repeated failures are likely to be persistent.
+
+Alternately, defaulting to once a day renewal attempts is reasonable. All
+errors should be sent to the administrator in charge, in order to see if
+specific problems need fixing.

--- a/docs/integration-guide.md
+++ b/docs/integration-guide.md
@@ -14,13 +14,33 @@ This document contains helpful advice if you are a hosting provider or large web
 
 Both Let's Encrypt and the Web PKI will continue to evolve over time.  You should make sure you have the ability to easily update all services that use Let's Encrypt. If you're also deploying clients that rely on Let's Encrypt certificates, make especially sure that those clients receive regular updates.
 
-In the future, we're likely to change: the root and intermediate certificates from which we issue; the hash algorithms we use when signing certificates; the types of keys and key strength checks for which we are willing to sign end-entity certificates; and the ACME protocol. We will always aim to give as much advance notice as possible for such changes, though if a serious security flaw is found in some component we may need to make changes on a very short term or immediately. For intermediate changes in particular, you should not hardcode the intermediate to use, but should use the [`Link: rel="up"`](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.3.1) header from the ACME protocol, since intermediates are likely to change.
+In the future, these things are likely to change:
 
-Similarly, we're likely to change the URL of the terms of service (ToS) as we update it. Avoid hardcoding the ToS URL and instead rely on the [`Link: rel="terms-of-service"`](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.2) header to determine which ToS URL to submit with new registrations.
+  * the root and intermediate certificates from which we issue
+  * the hash algorithms we use when signing certificates
+  * the types of keys and key strength checks for which we are willing to sign end-entity certificates
+  * and the ACME protocol
+
+We will always aim to give as much advance notice as possible for such changes, though if a serious security flaw is found in some component we may need to make changes on a very short term or immediately. For intermediate changes in particular, you should not hardcode the intermediate to use, but should use the [`Link: rel="up"`](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.3.1) header from the ACME protocol, since intermediates are likely to change.
+
+Similarly, we're likely to change the URL of the terms of service (ToS) as we update it. Avoid hardcoding the ToS URL and instead rely on the [`Link: rel="terms-of-service"`](https://tools.ietf.org/html/draft-ietf-acme-acme-03#section-6.2) header to determine which ToS URL to use.
 
 You will also want a way to keep your TLS configuration up-to-date as new attacks are found on cipher suites or protocol versions.
 
-We will be providing a low-volume developers' mailing list to receive news of important changes like the above (watch this space).
+# Get Updates
+
+To receive low-volume updates about important changes like the ones described
+above, subscribe to our
+[API Announcements](https://community.letsencrypt.org/t/about-the-api-announcements-category/23836) group.
+This is useful for both client developers and hosting providers.
+
+For higher-volume updates about maintenances and outages, visit our [status
+page](https://letsencrypt.status.io/) and hit Subscribe in the upper right. This
+is most useful for hosting providers.
+
+Also, make sure you use a valid email address for your ACME account. We will use
+that email to send you expiration notices and communicate about any issues
+specific to your account.
 
 # Who is the Subscriber
 
@@ -126,14 +146,16 @@ normally renew, some of them 2 days ahead, and so on.
 
 Renewal failure should not be treated as a fatal error. You should implement
 graceful retry logic in your issuing services using an exponential backoff
-pattern, maxing out at once per day per certificate. For instance, it would be
-suitable to automatically retry a failed renewal after 1 minute, 10 minutes,
-100 minutes, and 1440 minutes, absent specific administrator intervention. This
-means that your issuance software should keep track of failures as well as
-successes, and check if there was a recent failure before attempting a fresh
-issuance. There's no point in attempting issuance hundreds of times per hour,
-since repeated failures are likely to be persistent.
+pattern, maxing out at once per day per certificate. For instance, a reasonable
+backoff schedul would be: 1st retry after one minute, 2nd retry after ten
+minutes, third retry after 100 minutes, 4th and subsequent retries after one
+day. You should of course have a way for administrators to
+request early retries on a per-domain or global basis.
 
-Alternately, defaulting to once a day renewal attempts is reasonable. All
-errors should be sent to the administrator in charge, in order to see if
+Backoffs on retry means that your issuance software should keep track of
+failures as well as successes, and check if there was a recent failure before
+attempting a fresh issuance. There's no point in attempting issuance hundreds
+of times per hour, since repeated failures are likely to be persistent.
+
+All errors should be sent to the administrator in charge, in order to see if
 specific problems need fixing.


### PR DESCRIPTION
We see a fair number of repeated validation failures from some hosts. This guidance can help reduce that failed validation volume.

This also adds a link to the new API announcements page on the community forums.