### PR TITLE
Add lets-proxy to client options

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -47,6 +47,7 @@ third party clients.
 - [GoACME](https://github.com/google/goacme)
 - [hlandau/acme](https://github.com/hlandau/acme)
 - [ericchiang/letsencrypt](https://github.com/ericchiang/letsencrypt)
+- [Lets-proxy](https://github.com/rekby/lets-proxy) (Reverse proxy to handle https/tls)
 
 ## HAProxy
 


### PR DESCRIPTION
Easy to use reverse proxy.
It need zero settings to start (easy for home, vps and so on). Only extract binary from archive and start binary.
It is created for shared hosting (can handle thousands domains).
It is cross platform. Main platforms windows/linux.