### PR TITLE
Fixes broken link to intermediate cert

### DIFF
--- a/docs/staging-environment.md
+++ b/docs/staging-environment.md
@@ -25,4 +25,4 @@ The staging environment uses the same rate limits as [described for the producti
 
 # Root Certificate
 
-The staging environment intermediate certificate (["Fake LE Intermediate X1"](/certs/fakeleintermediate.pem)) is issued by a root certificate **not present** in browser/client trust stores. If you wish to modify a client to trust the staging environment for testing purposes you can do so by adding the ["Fake LE Root X1"](/certs/fakelerootx1.pem) certificate from the [certificates](/certificates/) page to your testing trust store.
+The staging environment intermediate certificate (["Fake LE Intermediate X1"](/certs/fakeleintermediatex1.pem)) is issued by a root certificate **not present** in browser/client trust stores. If you wish to modify a client to trust the staging environment for testing purposes you can do so by adding the ["Fake LE Root X1"](/certs/fakelerootx1.pem) certificate from the [certificates](/certificates/) page to your testing trust store.


### PR DESCRIPTION
In https://github.com/letsencrypt/website/pull/112 I introduced a link to the staging intermediate certificate, but the path was wrong and leads to a 404. Doh!

This PR fixes the link.