### PR TITLE
Removes 404 link for "What is a Certificate?"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,6 @@ top_graphic: 1
 * [Getting Started](/getting-started/)
 * [How Let's Encrypt Works](/how-it-works/)
 * [Frequently Asked Questions (FAQ)](/docs/faq/)
-* [What is a Certificate?](/docs/what-is-a-certificate/)
 
 # Subscriber Information
 


### PR DESCRIPTION
In https://github.com/letsencrypt/website/pull/102 it looks like we mistakenly [added a new link](https://github.com/letsencrypt/website/pull/102/files#diff-1a523bd9fa0dbf998008b37579210e12) to `index.md` pointing to a "What is a Certificate?" page that wasn't included in the PR.

This PR removes that link - it seems to me like it was accidentally included into #102 but is unrelated.

Thanks to [the community forum](https://community.letsencrypt.org/t/missing-page-on-site/24811) & @viklele for flagging this!