### PR TITLE
Adds travis ci 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 .jekyll-metadata
 js/*.tsv
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 2.2
+script:
+  - bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'jekyll'


### PR DESCRIPTION
This PR adds a `.travis.yml` for doing continuous integration builds of the website. Once builds are running it would be sensible to enable the branch protection that requires a PR have green CI before being merged. This will help keep pull requests from breaking the build accidentally and also gives a starting point that can be extended to run a lint of the website (e.g. to find 404's, broken content).