### PR TITLE
Only install 'html-proofer' for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.2.2
+gemfile: Gemfile.ci
 script:
   - bundle exec jekyll build
   - rake test

--- a/Gemfile.ci
+++ b/Gemfile.ci
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+gem 'jekyll'
+gem 'html-proofer'


### PR DESCRIPTION
Until there are clear instructions for how to get a sane Ruby 2.2+ install on dev machines that will cleanly install the `html-proofer` gem it should only be required for CI.

This PR tells travis to use the `Gemfile.ci` gemfile instead of the default `Gemfile`. Only the `Gemfile.ci` has `html-proofer` included.