### PR TITLE
Restore Daplie clients/libs.

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -62,6 +62,11 @@ third party clients.
 - [lua-resty-auto-ssl](https://github.com/GUI/lua-resty-auto-ssl)
 - [acme-nginx](https://github.com/kshcherban/acme-nginx)
 
+## Node.js
+
+- [Daplie/letsencrypt-cli](https://gitlab.com/Daplie/letsencrypt-cli)
+- [Daplie/letsencrypt-express](https://gitlab.com/Daplie/letsencrypt-express)
+
 ## Perl
 
 - [le.pl](https://github.com/do-know/Crypt-LE) (aka [ZeroSSL](https://ZeroSSL.com/))
@@ -124,6 +129,7 @@ third party clients.
 
 ## Node.js
 
+- [Daplie/letsencrypt](https://gitlab.com/Daplie/node-letsencrypt)
 - [letsencrypt/boulder](https://github.com/letsencrypt/boulder/tree/master/test/js)
 
 ## Perl


### PR DESCRIPTION
In #120 I removed the Daplie client/libs from the `client-options.md` page because their entire GH org was 404ing. I assumed they closed their account but it seems like they have migrated to [Gitlab](https://gitlab.com/Daplie) after Github closed their account on [short notice](https://daplie.com/articles/why-github-took-down-daplie/).

I think its fair to restore the links pointing to the new location. I originally removed the links instead of replacing them only because I was unaware of the new location.