### PR TITLE
Add rhabenbacher/letsencryptclient

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -66,6 +66,7 @@ third party clients.
 
 - [Daplie/letsencrypt-cli](https://gitlab.com/Daplie/letsencrypt-cli)
 - [Daplie/letsencrypt-express](https://gitlab.com/Daplie/letsencrypt-express)
+- [rhabenbacher/letsencryptclient](https://github.com/rhabenbacher/letsencryptclient)
 
 ## Perl
 


### PR DESCRIPTION
I developed a new node.js client with a demo server and added it to the node.js section in this document.