### PR TITLE
Adds Windows Live Mail to incompat list

### DIFF
--- a/docs/cert-compat.md
+++ b/docs/cert-compat.md
@@ -46,3 +46,5 @@ You may want to visit [this particular community forum discussion](https://commu
   * cannot handle SHA-2 signed certificates
 * Java 7 < 7u111
 * Java 8 < 8u101
+* Windows Live Mail (2012 mail client, not webmail)
+  * cannot handle certificates without a CRL


### PR DESCRIPTION
Based on [a community forum thread](https://community.letsencrypt.org/t/windows-live-mail-revocation-warning/26310) it appears Windows Live Mail (the discontinued, 2002 era "freeware" mail client) is not compatible with Let's Encrypt certificates because we do not maintain a CRL for end entity certificates.