### PR TITLE
Fix year in Faild Validation announcement

### DIFF
--- a/docs/rate-limits.md
+++ b/docs/rate-limits.md
@@ -63,7 +63,7 @@ renewals of existing certificates.
 Revoking certificates does not reset rate limits, because the resources used to
 issue those certificates have already been consumed.
 
-We will soon (February 2016) introduce a **Failed Validation** limit of 5 failures
+We will soon (February 2017) introduce a **Failed Validation** limit of 5 failures
 per account, per hostname, per hour. This limit will be higher on staging so you
 can use staging to debug connectivity problems.
 


### PR DESCRIPTION
User 'tjs' [found](https://community.letsencrypt.org/t/is-the-recently-announced-failed-validation-limit-effective/27806) an error in the Failed Validation announcement. It says February 2016 when the announcement was made after that date. Ergo, it should be 2017 :P