### PR TITLE
Removes Boulder `test.js` client from client-options.

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -131,7 +131,6 @@ third party clients.
 ## Node.js
 
 - [Daplie/node-greenlock](https://git.daplie.com/Daplie/node-greenlock)
-- [letsencrypt/boulder](https://github.com/letsencrypt/boulder/tree/master/test/js)
 
 ## Perl
 


### PR DESCRIPTION
The `test/js/test.js` client from the Boulder repo was removed in https://github.com/letsencrypt/boulder/pull/2549

The Website CI caught this broken link :tada: 