### PR TITLE
Tightens up CI for htmlproofer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - 2.2.2
+sudo: required
 gemfile: Gemfile.ci
 script:
   - bundle exec jekyll build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.2.2
-sudo: required
+dist: trusty
 gemfile: Gemfile.ci
 script:
   - bundle exec jekyll build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.2.2
-dist: trusty
+sudo: required
 gemfile: Gemfile.ci
 script:
   - bundle exec jekyll build

--- a/Rakefile
+++ b/Rakefile
@@ -10,28 +10,20 @@ task :test do
       /expired-isrgrootx1\.letsencrypt\.org/,
       /revoked-isrgrootx1\.letsencrypt\.org/,
       /valid-isrgrootx1\.letsencrypt\.org/,
-      # Do not check the 'certificateautomation.com' website - it has a broken
-      # TLS configuration (missing intermediate)
-      /certificateautomation\.com/,
-      # TLS 1.2 only sites are currently broken
-      # TODO(@cpu): figure out how to upgrade Curl in CI
-      /www\.froxlor\.org/,
-      /kristaps\.bsd\.lv/,
-      # The ALA website seems to time out, skip it
-      # TODO(@cpu): figure out how to tweak typhoeus timeout
-      /www\.ala\.org/,
-      # Crates.io returns errors when curl'd. Maybe UA/Content Type sniffing?
-      # TODO(@cpu): figure out how to curl https://crates.io/ for HTML
+      # Crates.io returns a JSON error when curl'd unless an "Accept:
+      # text/html" header is sent as well. Unfortunately setting that Accept
+      # globally causes two other sites (likely using WAFs?) to forbid the
+      # requests. For now, ignore crates.io.
       /crates\.io/,
-      # Compose.com seems to have load balancing and at least 1 server fails
-      # with a hostname mismatch error
-      /compose\.com/,
-      # Mojzis.com is failing with "SSL connect error", unclear why
-      # TODO(@cpu): diagnose mojzis.com TLS error
-      /mojzis\.com/,
     ],
     :typhoeus => {
       :capath => "/etc/ssl/certs",
+      # Libcurl Connection reuse seems flaky on some versions
+      # Disabling it outright gives better results
+      :forbid_reuse => true,
+      # The default Typhoeus timeout is low enough to cause intermitent failures
+      # (particularly for one or two slower websites).
+      :timeout => 15,
     }
   }).run
 end

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,10 @@ task :test do
       # The default Typhoeus timeout is low enough to cause intermitent failures
       # (particularly for one or two slower websites).
       :timeout => 15,
+      # Without specifying a browser-like Accept header `crates.io` will return
+      # a JSON API error. This Accept header is sourced from Chrome to avoid
+      # server configurations blocking non-standard Accept headers (e.g. WAFs)
+      :headers => { :Accept => "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8" },
     }
   }).run
 end

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task :test do
       :forbid_reuse => true,
       # The default Typhoeus timeout is low enough to cause intermitent failures
       # (particularly for one or two slower websites).
-      :timeout => 15,
+      :timeout => 60,
     }
   }).run
 end

--- a/Rakefile
+++ b/Rakefile
@@ -24,10 +24,6 @@ task :test do
       # The default Typhoeus timeout is low enough to cause intermitent failures
       # (particularly for one or two slower websites).
       :timeout => 15,
-      # Without specifying a browser-like Accept header `crates.io` will return
-      # a JSON API error. This Accept header is sourced from Chrome to avoid
-      # server configurations blocking non-standard Accept headers (e.g. WAFs)
-      :headers => { :Accept => "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8" },
     }
   }).run
 end


### PR DESCRIPTION
This PR removes most of the exceptions from the htmlproofer
Rakefile.

The failures that were fixed are in three categories:

1. Sites that timed-out with the base timeout. This was fixed by
   increasing the Typheous timeout to 15s
2. Sites that had chained up to Identrust's root CA cert
3. Sites that required TLS 1.2+

Items 2 and 3 were fixed by updating the project .travis.yml to add
`sudo: required`. Nothing in our CI pipeline truly requires `sudo` but
this flag is used to gate whether the Ruby build image is Ubuntu 12.04
or 14.04.

One exception remains for `crates.io`. The only workaround I could
identify to fix that false-positive created additional failures with
other sites so I gave up for now.

Resolves https://github.com/letsencrypt/website/issues/134