### PR TITLE
Doubles allowed htmlproofer timeout

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task :test do
       :forbid_reuse => true,
       # The default Typhoeus timeout is low enough to cause intermitent failures
       # (particularly for one or two slower websites).
-      :timeout => 60,
+      :timeout => 120,
     }
   }).run
 end


### PR DESCRIPTION
Builds [look to be failing](https://travis-ci.org/letsencrypt/website/builds/205954686) occasionally on an HTTP timeout. This doubles the allowed timeout to let the one/two stragglers on slow servers respond before we deem the link broken.