### PR TITLE
updated list

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -32,7 +32,6 @@ third party clients.
 
 - [Get HTTPS for free](https://gethttpsforfree.com)
 - [ZeroSSL](https://ZeroSSL.com) (Fully in-browser process, inc. CSR generation)
-- [Certificate Automation](https://www.certificateautomation.com/)
 - [SSL for free](https://www.sslforfree.com/) (Fully in-browser process, inc. CSR generation)
 
 ## C


### PR DESCRIPTION
https://www.certificateautomation.com/ is not a let's encrypt certificate provider.