### PR TITLE
Fixes markdown error for autocert.

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -50,7 +50,7 @@ third party clients.
 - [hlandau/acme](https://github.com/hlandau/acme)
 - [ericchiang/letsencrypt](https://github.com/ericchiang/letsencrypt)
 - [Lets-proxy](https://github.com/rekby/lets-proxy) (Reverse proxy to handle https/tls)
-- [autocert] (https://godoc.org/golang.org/x/crypto/acme/autocert)
+- [autocert](https://godoc.org/golang.org/x/crypto/acme/autocert)
 
 ## HAProxy
 


### PR DESCRIPTION
https://github.com/letsencrypt/website/pull/150 had broken markdown formatting and I failed to notice. This commit fixes the markdown.