### PR TITLE
Add pfSense to the list of Projects integrating with Let's Encrypt

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -184,3 +184,4 @@ third party clients.
 - [Virtualmin Web Hosting Control Panel](https://www.virtualmin.com/)
 - [Plesk Web Hosting Control Panel](https://www.plesk.com/)
 - [Zappa](https://github.com/Miserlou/Zappa#lets-encrypt-ssl-domain-certification-and-installation)
+- [pfSense](https://www.pfsense.org/)


### PR DESCRIPTION
The [pfSense](https://www.pfsense.org) OSS firewall project has an [ACME package](https://doc.pfsense.org/index.php/ACME_package) to manage Let's Encrypt certificates for its GUI and other purposes, so it would be helpful to add it to the list of projects integrating with LE.