### PR TITLE
Remove froxlor from urlcheck ignore, add ICANN.org

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,11 +15,9 @@ task :test do
       # globally causes two other sites (likely using WAFs?) to forbid the
       # requests. For now, ignore crates.io.
       /crates\.io/,
-      # Presently the client-options page links to "https://www.froxlor.org",
-      # which has a certificate hostname mismatch. "http://froxlor.org"
-      # indicates they're having a major outage so for now their URL is added to
-      # the :url_ignore list.
-      /www\.froxlor\.org/,
+      # The ICANN.org website seems to tiemout in the majority of builds.
+      # Unclear why, ignoring for now!
+      /www\.ICANN\.org/,
     ],
     :typhoeus => {
       :capath => "/etc/ssl/certs",

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,9 @@ task :test do
       # The ICANN.org website seems to tiemout in the majority of builds.
       # Unclear why, ignoring for now!
       /www\.ICANN\.org/,
+      # www.vtex.com is failing with "Couldn't resolve host name" from CI, but
+      # appears to work fine with manual test.
+      /www\.vtex\.com/,
     ],
     :typhoeus => {
       :capath => "/etc/ssl/certs",


### PR DESCRIPTION
This commit removes `www.froxlor.org` from the ignore list for the
website linting. Previously there was a hostname mismatch error that
has since been resolved.

This commit also adds `www.ICANN.org` to the ignore list. It's always
timing out in CI and I'm not sure why, seems to work fine when I test
manually. Similarly `www.vtex.com` is suffering a DNS failure but only
in CI so I'm adding it to the ignore list.