### PR TITLE
added a new python letsencrypt client

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -102,6 +102,7 @@ third party clients.
 - [letsencryptshell](https://mojzis.com/software/letsencryptshell/)
 - [wile](https://github.com/costela/wile)
 - [acmebot](https://github.com/plinss/acmebot)
+- [sewer](https://github.com/komuW/sewer)
 
 ## Ruby
 


### PR DESCRIPTION
## What?
- I added a new listing for a new python based letsencrypt client

##  Why?
- I created the [sewer](https://github.com/komuW/sewer) letsencrypt client since I was unable to find one that is primarily meant to be used as a python libarary (as opposed to a commandline app)