### PR TITLE
Embed SCT receipts in certificates: October, 2017

### DIFF
--- a/upcoming-features.md
+++ b/upcoming-features.md
@@ -9,6 +9,10 @@ top_graphic: 1
 
 * ETA: January, 2018
 
+## Embed SCT receipts in certificates
+
+* ETA: October, 2017
+
 ## ECDSA Root and Intermediates
 
 * ETA: Before September 1, 2017

--- a/upcoming-features.md
+++ b/upcoming-features.md
@@ -11,7 +11,7 @@ top_graphic: 1
 
 ## Embed SCT receipts in certificates
 
-* ETA: October, 2017
+* ETA: December, 2017
 
 ## ECDSA Root and Intermediates
 


### PR DESCRIPTION
https://github.com/letsencrypt/boulder/issues/2244#issuecomment-260044452
> That said, we are starting to design the process to submit precertificates so we can embed SCTs in certificates, and plan to implement before next October.

https://community.letsencrypt.org/t/le-embed-sct-support-policy/36471/2
> Our plan has not changed as far as I'm aware. Thanks!