### PR TITLE
https instead http for sponsors url

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ layout: no-wrapper
               <a href="https://www.google.com/chrome/" rel="nofollow"><img src="/images/sponsors/small/chrome-logo.png" alt="Google Chrome" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.identrustssl.com/"><img src="/images/sponsors/small/identrust-logo.png" alt="IdenTrust" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.fordfound.org/"><img src="/images/sponsors/small/ford-foundation-logo.png" alt="Ford Foundation" width="80" height="48" style="padding: 10px;"></a>
-              <a href="http://www.internetsociety.org/"><img src="/images/sponsors/small/isoc-logo.png" alt="Internet Society" width="80" height="48" style="padding: 10px;"></a>
+              <a href="https://www.internetsociety.org/"><img src="/images/sponsors/small/isoc-logo.png" alt="Internet Society" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.facebook.com/"><img src="/images/sponsors/small/facebook-logo.png" alt="Facebook" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://automattic.com/"><img src="/images/sponsors/small/automattic-logo.png" alt="Automattic" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.shopify.com/"><img src="/images/sponsors/small/shopify-logo.png" alt="Shopify" width="80" height="48" style="padding: 10px;"></a>
@@ -70,7 +70,7 @@ layout: no-wrapper
               <a href="https://www.yunpian.com/"><img src="/images/sponsors/small/yunpian-logo.png" alt="YunPian" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.fastly.com/"><img src="/images/sponsors/small/fastly-logo.png" alt="Fastly" width="80" height="48" style="padding: 10px;"></a>
               <a href="http://www.casino2k.com/"><img src="/images/sponsors/small/casino2k-logo.png" alt="Casino2k" width="80" height="48" style="padding: 10px;"></a>
-              <a href="http://www.3cx.com/"><img src="/images/sponsors/small/3cx-logo.png" alt="3CX" width="80" height="48" style="padding: 10px;"></a>
+              <a href="https://www.3cx.com/"><img src="/images/sponsors/small/3cx-logo.png" alt="3CX" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.sumologic.com/"><img src="/images/sponsors/small/sumo-logic-logo.png" alt="Sumo Logic" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.tintri.com/"><img src="/images/sponsors/small/tintri-logo.png" alt="Tintri" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.squarespace.com/"><img src="/images/sponsors/small/squarespace-logo.png" alt="Squarespace" width="80" height="48" style="padding: 10px;"></a>
@@ -79,7 +79,7 @@ layout: no-wrapper
               <a href="https://thebestvpn.com/"><img src="/images/sponsors/small/bestvpn-logo.png" alt="The Best VPN" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://ipinfo.io/"><img src="/images/sponsors/small/ipinfo-logo.png" alt="ipinfo.io" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.jimdo.com/"><img src="/images/sponsors/small/jimdo-logo.png" alt="Jimdo" width="80" height="48" style="padding: 10px;"></a>
-              <a href="http://www.vtex.com/"><img src="/images/sponsors/small/vtex-logo.png" alt="VTEX" width="80" height="48" style="padding: 10px;"></a>
+              <a href="https://www.vtex.com/"><img src="/images/sponsors/small/vtex-logo.png" alt="VTEX" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://uptimerobot.com/"><img src="/images/sponsors/small/uptime-robot-logo.png" alt="Uptime Robot" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.digitalocean.com/"><img src="/images/sponsors/small/digital-ocean-logo.png" alt="Digital Ocean" width="80" height="48" style="padding: 10px;"></a>
               <a href="https://www.zendesk.com/"><img src="/images/sponsors/small/zendesk-logo.png" alt="Zendesk" width="80" height="48" style="padding: 10px;"></a>

--- a/sponsors.html
+++ b/sponsors.html
@@ -24,8 +24,8 @@ top_graphic: 1
     <h2>Gold</h2>
     <div align="center">
       <a href="https://www.identrustssl.com/"><img src="/images/sponsors/identrust-logo.png" alt="IdenTrust" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="http://www.fordfound.org/"><img src="/images/sponsors/ford-foundation-logo.png" alt="Ford Foundation" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="http://www.internetsociety.org/"><img src="/images/sponsors/isoc-logo.png" alt="Internet Society" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="https://www.fordfound.org/"><img src="/images/sponsors/ford-foundation-logo.png" alt="Ford Foundation" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="https://www.internetsociety.org/"><img src="/images/sponsors/isoc-logo.png" alt="Internet Society" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
     </div>
   </div>
 
@@ -47,7 +47,7 @@ top_graphic: 1
       <a href="https://www.yunpian.com/"><img src="/images/sponsors/yunpian-logo.png" alt="YunPian" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.fastly.com/"><img src="/images/sponsors/fastly-logo.png" alt="Fastly" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="http://www.casino2k.com/"><img src="/images/sponsors/casino2k-logo.png" alt="Casino2k" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="http://www.3cx.com/"><img src="/images/sponsors/3cx-logo.png" alt="3CX" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="https://www.3cx.com/"><img src="/images/sponsors/3cx-logo.png" alt="3CX" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.sumologic.com/"><img src="/images/sponsors/sumo-logic-logo.png" alt="Sumo Logic" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.tintri.com/"><img src="/images/sponsors/tintri-logo.png" alt="Tintri" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.squarespace.com/"><img src="/images/sponsors/squarespace-logo.png" alt="Squarespace" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
@@ -56,7 +56,7 @@ top_graphic: 1
       <a href="https://thebestvpn.com/"><img src="/images/sponsors/bestvpn-logo.png" alt="The Best VPN" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://ipinfo.io/"><img src="/images/sponsors/ipinfo-logo.png" alt="ipinfo.io" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.jimdo.com/"><img src="/images/sponsors/jimdo-logo.png" alt="Jimdo" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
-      <a href="http://www.vtex.com/"><img src="/images/sponsors/vtex-logo.png" alt="VTEX" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
+      <a href="https://www.vtex.com/"><img src="/images/sponsors/vtex-logo.png" alt="VTEX" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://uptimerobot.com/"><img src="/images/sponsors/uptime-robot-logo.png" alt="Uptime Robot" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.digitalocean.com/"><img src="/images/sponsors/digital-ocean-logo.png" alt="Digital Ocean" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>
       <a href="https://www.zendesk.com/"><img src="/images/sponsors/zendesk-logo.png" alt="Zendesk" width="180" height="108" style="padding-left: 20px; padding-right: 20px; padding-top: 8px; padding-bottom: 8px;"></a>


### PR DESCRIPTION
Some sponsors has a valid https configuration but linked with no-https.

updated:

- `https://www.internetsociety.org/`
- `https://www.3cx.com/`
- `https://www.vtex.com/`
- `https://www.fordfound.org/`