### PR TITLE
Only give site description on homepage.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+    {% if page.url == "/" %}
     <meta name="description" content="{{ site.description }}">
+    {% endif %}
 
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@letsencrypt">
@@ -18,8 +20,6 @@
     {% endif %}
     {% if page.excerpt %}
     <meta name="twitter:description" content="{{ page.excerpt }}">
-    {% else %}
-    <meta name="twitter:description" content="{{ site.description }}">
     {% endif %}
     <meta name="twitter:image:src" content="{{ site.url }}images/le-logo-twitter.png">
 


### PR DESCRIPTION
Previously we were setting a meta description tag for all pages that contained
the generic description "Let's Encrypt is a free, automated, and open certificate
authority brought to you by the non-profit Internet Security Research Group
(ISRG)." This gets inserted, e.g. into summaries of links pasted in
Discourse, which is confusing, because it makes it look as if the link goes to
the homepage.

In this change, only provide the default description for the homepage.