### PR TITLE
Removes `Daplie` from "Projects Integrating with LE" list.

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -179,7 +179,6 @@ third party clients.
 - [Caddy](https://caddyserver.com/)
 - [cPanel](https://cpanel.com/)
 - [Own-Mailbox](https://www.own-mailbox.com/)
-- [Daplie](https://daplie.com/walnut)
 - [Cloudfleet](https://cloudfleet.io/)
 - [Aerys](https://github.com/kelunik/aerys-acme)
 - [CentminMod LEMP Stack](https://centminmod.com/acmetool)


### PR DESCRIPTION
The link to the "Daplie" project linked under "Projects Integrating with
LE" now 404s. Looking at the daplie.com website it's not clear what
happened to the "Walnut" or whether they still integrate with LE. I'm
going to remove the link for now and if someone can provide the correct
link and assurance the project still integrates with LE it can be
readded.

Fixes CI.