### PR TITLE
Add Aegir to the list of project integrations

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -197,3 +197,4 @@ third party clients.
 - [Zappa](https://github.com/Miserlou/Zappa#lets-encrypt-ssl-domain-certification-and-installation)
 - [pfSense](https://www.pfsense.org/)
 - [Cloudron](https://cloudron.io)
+- [Aegir](https://gitlab.com/aegir/hosting_https)


### PR DESCRIPTION
It appears as though [Aegir](http://www.aegirproject.org/) is missing from the list of projects that integrate with Let's Encrypt.  Here's the list item to add it.