### PR TITLE
v2 compat: Add acme.sh, update ACME4J

### DIFF
--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -3,7 +3,7 @@ layout: page
 title: ACME Client Implementations
 permalink: /docs/client-options/
 top_graphic: 1
-date: 2016-07-02T00:00
+date: 2018-01-05T00:00
 ---
 
 Last updated: {{ page.date | date: "%B %d, %Y" }} \| [See all Documentation](/docs/)
@@ -20,6 +20,13 @@ If certbot does not meet your needs, or you’d simply like to try something els
 
 The ACME clients below are offered by third parties. Let's Encrypt doesn't review
 third party clients.
+
+## ACME v2 Compatible Clients
+
+These clients are compatible with our [staging endpoint for ACME v2](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605).
+
+- [ACME4J](https://github.com/shred/acme4j#future-compatibility) (`draft` branch)
+- [GetSSL](https://github.com/srvrco/getssl/tree/APIv2) (`APIv2` branch)
 
 ## Bash
 

--- a/docs/client-options.md
+++ b/docs/client-options.md
@@ -25,8 +25,9 @@ third party clients.
 
 These clients are compatible with our [staging endpoint for ACME v2](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605).
 
-- [ACME4J](https://github.com/shred/acme4j#future-compatibility) (`draft` branch)
+- [ACME4J](https://github.com/shred/acme4j) (acme4j >= 2.0)
 - [GetSSL](https://github.com/srvrco/getssl/tree/APIv2) (`APIv2` branch)
+- [acme.sh](https://github.com/Neilpang/acme.sh/tree/2) (`2` branch)
 
 ## Bash
 


### PR DESCRIPTION
[acme.sh added support in the "2" branch](https://community.letsencrypt.org/t/acme-sh-supports-acme-v2-wildcard-now/49685). ACME4J [merged support to master](https://twitter.com/shred_/status/950040298176110592) and cut a new release.