### PR TITLE
Update header name on Account ID page

### DIFF
--- a/docs/account-id.md
+++ b/docs/account-id.md
@@ -26,5 +26,5 @@ Check your logs for URLs of the form described above. If your ACME client does
 not record the account ID, you can retrieve it by submitting a new registration
 request with the same key. See the [ACME spec for more
 details](https://github.com/ietf-wg-acme/acme/blob/master/draft-ietf-acme-acme.md#registration).
-You can also find the numeric form of your ID in the Boulder-ID header in the
-response to each POST your ACME client makes.
+You can also find the numeric form of your ID in the Boulder-Requester header in
+the response to each POST your ACME client makes.


### PR DESCRIPTION
The account ID is being sent in the "Boulder-Requester" header, as added in https://github.com/letsencrypt/boulder/pull/1886.