### PR TITLE
Remove superfluous XML header in RSS feed

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,5 +1,3 @@
-
-<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ .Site.Title }}</title>


### PR DESCRIPTION
Hugo is adding one, which makes two.