### PR TITLE
Add Traefik to clients

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -64,6 +64,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [Lets-proxy](https://github.com/rekby/lets-proxy) (Reverse proxy to handle https/tls)
 - [autocert](https://godoc.org/golang.org/x/crypto/acme/autocert)
 - [Ponzu CMS](https://ponzu-cms.org)
+- [Traefik](https://traefik.io)
 
 ## HAProxy
 


### PR DESCRIPTION
Hey Let's Encrypt!
I propose to add [Traefik](https://github.com/containous/traefik) to Let's Encrypt's clients in the documentation.
Keep up the good work 👍 