### PR TITLE
Update the links to Mozilla's Telemetry, and also fix the /stats/ markdown list

### DIFF
--- a/content/stats.md
+++ b/content/stats.md
@@ -21,7 +21,7 @@ These statistics are updated daily.
 <div class="figure">
   <h2><a name="percent-pageloads" href="#percent-pageloads"
     >Percentage of Web Pages Loaded by Firefox Using HTTPS</a></h2>
-  <p>(14-day moving average, source: <a href="https://wiki.mozilla.org/Telemetry/FAQ#Telemetry_and_User_Control:_FAQ">Firefox Telemetry</a>)</p>
+  <p>(14-day moving average, source: <a href="https://docs.telemetry.mozilla.org/datasets/other/ssl/reference.html">Firefox Telemetry</a>)</p>
   <div id="pageloadPercent" title="Percentage of Web Pages Loaded by Firefox Using HTTPS" class="statsgraph"></div>
 </div>
 
@@ -33,9 +33,12 @@ These statistics are updated daily.
 
 ## Code
 Since the [2017-07-03 methodology change](https://community.letsencrypt.org/t/adjustments-to-the-lets-encrypt-statistics-methodology/):
-- [ct-mapreduce](https://github.com/jcjones/ct-mapreduce) ingests data from CT logs and Firefox Telemetry, and produces statistics about Let's Encrypt.
+
+- [ct-mapreduce](https://github.com/jcjones/ct-mapreduce) ingests data from CT logs and produces statistics about Let's Encrypt.
+- HTTPS adoption comes from [Mozilla's Telemetry SSL Ratios dataset](https://docs.telemetry.mozilla.org/datasets/other/ssl/reference.html).
 
 Before 2017-07-03:
+
 - [ct-sql](https://github.com/jcjones/ct-sql) ingests data from Censys.io, CT logs, and Firefox Telemetry.
 - [ct-sql-queries](https://github.com/jcjones/ct-sql-queries) contains the SQL queries run periodically to construct the data.
 


### PR DESCRIPTION
Now updated, the `/stats` page indicates the standard Mozilla Telemetry documentation as the source of our HTTPS Ratio statistics; that is misleading. Since Firefox 58's telemetry changeover, that source is [now a separate dataset](https://github.com/mozilla/firefox-data-docs/pull/80).

This change updates the documentation to refer to the new data set descriptor. It also fixes a markdown list bug that appears to have come through from the switch to hugo, where the list at the bottom of `/stats` wasn't showing as a list any more.

**NOTE:** This change should not be merged until the link https://docs.telemetry.mozilla.org/datasets/other/ssl/reference.html is live.