### PR TITLE
Added Hiawatha's Let's Encrypt script to 'ACME v2 Compatible Clients'

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -30,6 +30,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [acme.sh](https://github.com/Neilpang/acme.sh/tree/2) (`2` branch)
 - [Net::ACME2](https://metacpan.org/pod/Net::ACME2)
 - [EasyHTTPs](https://easy.zhetao.com) * (Automatically select v2 or v1)
+- [Let's Encrypt for Hiawatha](https://www.hiawatha-webserver.org/files/letsencrypt.tar.gz)
 
 ## Bash
 

--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -30,7 +30,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [acme.sh](https://github.com/Neilpang/acme.sh/tree/2) (`2` branch)
 - [Net::ACME2](https://metacpan.org/pod/Net::ACME2)
 - [EasyHTTPs](https://easy.zhetao.com) * (Automatically select v2 or v1)
-- [Let's Encrypt for Hiawatha](https://www.hiawatha-webserver.org/files/letsencrypt.tar.gz)
+- [Let's Encrypt for Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
 
 ## Bash
 


### PR DESCRIPTION
Because ACME v2 is not yet in production, I've added a link to the test-version of the script.