### PR TITLE
Hiawatha's Let's Encrypt script

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -26,11 +26,11 @@ third party clients.
 These clients are compatible with our [staging endpoint for ACME v2](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605).
 
 - [ACME4J](https://github.com/shred/acme4j) (acme4j >= 2.0)
-- [acme.sh](https://github.com/Neilpang/acme.sh/tree/2) (`2` branch)
-- [EasyHTTPs](https://easy.zhetao.com) * (Automatically select v2 or v1)
 - [GetSSL](https://github.com/srvrco/getssl/tree/APIv2) (`APIv2` branch)
-- [Let's Encrypt for Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
+- [acme.sh](https://github.com/Neilpang/acme.sh/tree/2) (`2` branch)
 - [Net::ACME2](https://metacpan.org/pod/Net::ACME2)
+- [EasyHTTPs](https://easy.zhetao.com) * (Automatically select v2 or v1)
+- [Let's Encrypt for Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
 
 ## Bash
 

--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -26,10 +26,11 @@ third party clients.
 These clients are compatible with our [staging endpoint for ACME v2](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605).
 
 - [ACME4J](https://github.com/shred/acme4j) (acme4j >= 2.0)
-- [GetSSL](https://github.com/srvrco/getssl/tree/APIv2) (`APIv2` branch)
 - [acme.sh](https://github.com/Neilpang/acme.sh/tree/2) (`2` branch)
-- [Net::ACME2](https://metacpan.org/pod/Net::ACME2)
 - [EasyHTTPs](https://easy.zhetao.com) * (Automatically select v2 or v1)
+- [GetSSL](https://github.com/srvrco/getssl/tree/APIv2) (`APIv2` branch)
+- [Let's Encrypt for Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
+- [Net::ACME2](https://metacpan.org/pod/Net::ACME2)
 
 ## Bash
 
@@ -110,7 +111,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [AcmePHP](https://github.com/acmephp/acmephp)
 - [LE Manager](https://github.com/analogic/lemanager)
 - [WordPress Plugin](https://github.com/tollmanz/lets-encrypt-wp)
-- [Let's Encrypt for Hiawatha](https://github.com/hsleisink/hiawatha/tree/master/extra/letsencrypt)
+- [Let's Encrypt for Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
 
 ## Python
 


### PR DESCRIPTION
Added Hiawatha's Let's Encrypt script to the ACME v2 Compatible Clients section.
Updated link of Hiawatha's Let's Encrypt script in PHP section.