### PR TITLE
Simplify Hiwatha listing

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -30,7 +30,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [acme.sh](https://github.com/Neilpang/acme.sh/tree/2) (`2` branch)
 - [Net::ACME2](https://metacpan.org/pod/Net::ACME2)
 - [EasyHTTPs](https://easy.zhetao.com) * (Automatically select v2 or v1)
-- [Let's Encrypt for Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
+- [Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
 - [LEClient PHP library](https://github.com/yourivw/LEClient/)
 - [dehydrated](https://github.com/lukas2511/dehydrated)
 
@@ -111,7 +111,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [AcmePHP](https://github.com/acmephp/acmephp)
 - [LE Manager](https://github.com/analogic/lemanager)
 - [WordPress Plugin](https://github.com/tollmanz/lets-encrypt-wp)
-- [Let's Encrypt for Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
+- [Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
 
 ## Python
 


### PR DESCRIPTION
There's no need to say "Let's Encrypt for" in this entry and it makes our policy on trademarks clearer (even if in this case the client in question is not in violation).