### PR TITLE
client-options.md: Fix acme.sh ACME v2 link

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -27,11 +27,11 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 
 - [ACME4J](https://github.com/shred/acme4j) (acme4j >= 2.0)
 - [GetSSL](https://github.com/srvrco/getssl/tree/APIv2) (`APIv2` branch)
-- [acme.sh](https://github.com/Neilpang/acme.sh/tree/2) (`2` branch)
+- [acme.sh](https://github.com/Neilpang/acme.sh)
 - [Net::ACME2](https://metacpan.org/pod/Net::ACME2)
 - [EasyHTTPs](https://easy.zhetao.com) * (Automatically select v2 or v1)
 - [Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
-- [LEClient PHP library](https://github.com/yourivw/LEClient/)
+- [LEClient PHP library](https://github.com/yourivw/LEClient)
 - [dehydrated](https://github.com/lukas2511/dehydrated)
 
 ## Bash


### PR DESCRIPTION
The ACME v2 link to ame.sh is broken. It was a link to the client's v2 branch; now the branch has been merged into master and deleted, so the link no longer works. Change it link to master.

Reported by rleeden on the [forum](https://community.letsencrypt.org/t/acme-client-implementations-404-on-acme-sh-link/53596).

Unrelated: Remove an extra "/" from a different URL.