### PR TITLE
Add win-acme to the client options list.

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -136,6 +136,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 ## Windows / IIS
 
 - [ACMESharp](https://github.com/ebekker/ACMESharp) (.NET, PowerShell)
+- [win-acme](https://github.com/PKISharp/win-acme) (.NET)
 - [Certify](https://github.com/webprofusion/Certify) GUI (.NET, WinForms)
 - [oocx/acme.net](https://github.com/oocx/acme.net) (.NET)
 - [kelunik/acme-client](https://github.com/kelunik/acme-client) (PHP)


### PR DESCRIPTION
This client was previously listed in this position under
"letsencrypt-win-simple" and was removed for infringing the Let's
Encrypt trademark. It has since been renamed :tada: so we can add it
back to the spot it was in before :-)