### PR TITLE
Add Rust acme-client library

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -133,6 +133,10 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [Acmesmith, An effective ACME client: Manage keys on the cloud (AWS and more)](https://github.com/sorah/acmesmith)
 - [schubergphilis/chef-acme](https://github.com/schubergphilis/chef-acme)
 
+## Rust
+
+- [acme-client](https://github.com/onur/acme-client)
+
 ## Windows / IIS
 
 - [ACMESharp](https://github.com/ebekker/ACMESharp) (.NET, PowerShell)


### PR DESCRIPTION
letsencrypt-rs removed from client-options in f565f26de2b61a0cf4660c716a89cb2dfdef8722 due to ISRG trademark violation. This issue is [fixed](https://github.com/onur/acme-client/issues/25) and letsencrypt-rs is renamed to acme-client now.

This patch adds acme-client to client-options.