### PR TITLE
Add Synchronet SBBS, which now has an ACMEv2 client included.

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -213,6 +213,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [pfSense](https://www.pfsense.org/)
 - [Cloudron](https://cloudron.io)
 - [Aegir](https://gitlab.com/aegir/hosting_https)
+- [Synchronet BBS System](http://www.synchro.net) (ACMEv2 only)
 
 
 Note: * = Service may require payment.


### PR DESCRIPTION
Synchronet just got an ACMEv2 client (LetSyncrypt)... code here: http://cvs.synchro.net/cgi-bin/viewcvs.cgi/exec/letsyncrypt.js and here: http://cvs.synchro.net/cgi-bin/viewcvs.cgi/exec/load/acmev2.js