### PR TITLE
add sewer to acme v2 supporting clients

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -33,6 +33,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
 - [LEClient PHP library](https://github.com/yourivw/LEClient)
 - [dehydrated](https://github.com/lukas2511/dehydrated)
+- [sewer](https://github.com/komuw/sewer/tree/acmev2) (`acmev2` branch)
 
 ## Bash
 


### PR DESCRIPTION
# what
- added sewer to list of clients that support acme version 2

# why
- v2 is the future 
- fulfill this call to action; https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605