### PR TITLE
stonemax/acme2(PHP client for acme2)

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -34,6 +34,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [LEClient PHP library](https://github.com/yourivw/LEClient)
 - [dehydrated](https://github.com/lukas2511/dehydrated)
 - [sewer](https://github.com/komuw/sewer/tree/acmev2) (`acmev2` branch)
+- [stonemax/acme2 PHP client](https://github.com/stonemax/acme2)
 
 ## Bash
 


### PR DESCRIPTION
# what
added stonemax/acme2 (PHP Client) to list of clients that support acme version 2

# why
* v2 is the future
* fulfill this call to action; https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605