### PR TITLE
Added Crypt::LE to ACME v2 list.

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -37,6 +37,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [le-acme2-php library](https://github.com/fbett/le-acme2-php)
 - [sewer](https://github.com/komuw/sewer)
 - [stonemax/acme2 PHP client](https://github.com/stonemax/acme2)
+- [Crypt::LE](https://github.com/do-know/Crypt-LE)
 
 ## Bash
 


### PR DESCRIPTION
Adding Crypt::LE to the list of ACME v2 compatible clients (perhaps the list should be sorted alphabetically as well, to look a bit less "chaotic" and easier to browse).