### PR TITLE
Greenlock seems to have moved

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -97,8 +97,8 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 
 ## Node.js
 
-- [Daplie/greenlock-cli](https://git.daplie.com/Daplie/greenlock-cli)
-- [Daplie/greenlock-express](https://git.daplie.com/Daplie/greenlock-express)
+- [Daplie/greenlock-cli](https://git.coolaj86.com/coolaj86/greenlock-cli.js)
+- [Daplie/greenlock-express](https://git.coolaj86.com/coolaj86/greenlock-express.js)
 - [Cloudron/acme](https://git.cloudron.io/cloudron/box/blob/master/src/cert/acme.js)
 
 ## OpenShift
@@ -168,7 +168,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 
 ## Node.js
 
-- [Daplie/node-greenlock](https://git.daplie.com/Daplie/node-greenlock)
+- [Daplie/node-greenlock](https://git.coolaj86.com/coolaj86/greenlock.js)
 
 ## Perl
 


### PR DESCRIPTION
The node.js library 'greenlock' and related clients seem to have moved to a different git server.