### PR TITLE
Added FreeSSL.org to ACME v2 list.

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -41,6 +41,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [ACME Tiny](https://github.com/diafygi/acme-tiny)
 - [itr-acme-client PHP library](https://github.com/ITronic/itr-acme-client)
 - [acmebot](https://github.com/plinss/acmebot)
+- [FreeSSL.org](https://freessl.org)
 
 ## Bash
 


### PR DESCRIPTION
Adding FreeSSL.org to the list of ACME v2 compatible clients.