### PR TITLE
add Get HTTPS for free for ACME v2  Clients

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -41,6 +41,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [ACME Tiny](https://github.com/diafygi/acme-tiny)
 - [itr-acme-client PHP library](https://github.com/ITronic/itr-acme-client)
 - [acmebot](https://github.com/plinss/acmebot)
+- [Get HTTPS for free](https://gethttpsforfree.com) (wildcard certificate available)
 
 ## Bash
 


### PR DESCRIPTION
add Get HTTPS for free for ACME v2 Compatible Clients
https://gethttpsforfree.com