### PR TITLE
Add Caddy to list of ACMEv2-compatible clients

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -26,7 +26,6 @@ third party clients and cannot make any guarantees about their safety or reliabi
 These clients are compatible with our [staging endpoint for ACME v2](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605).
 
 - [Certbot](https://certbot.eff.org/) (Certbot >= 0.22.0)
-- [Caddy](https://caddyserver.com) (Caddy >= 0.10.12)
 - [ACME4J](https://github.com/shred/acme4j) (acme4j >= 2.0)
 - [GetSSL](https://github.com/srvrco/getssl/tree/APIv2) (`APIv2` branch)
 - [acme.sh](https://github.com/Neilpang/acme.sh)
@@ -44,6 +43,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [acmebot](https://github.com/plinss/acmebot)
 - [node-acme-lambda](https://github.com/ocelotconsulting/node-acme-lambda)
 - [SSL for free](https://www.sslforfree.com/)
+- [Caddy](https://caddyserver.com) (Caddy >= 0.10.12)
 
 ## Bash
 

--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -26,6 +26,7 @@ third party clients and cannot make any guarantees about their safety or reliabi
 These clients are compatible with our [staging endpoint for ACME v2](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605).
 
 - [Certbot](https://certbot.eff.org/) (Certbot >= 0.22.0)
+- [Caddy](https://caddyserver.com) (Caddy >= 0.10.12)
 - [ACME4J](https://github.com/shred/acme4j) (acme4j >= 2.0)
 - [GetSSL](https://github.com/srvrco/getssl/tree/APIv2) (`APIv2` branch)
 - [acme.sh](https://github.com/Neilpang/acme.sh)


### PR DESCRIPTION
Should I alphabetize this list while I'm at it?