### PR TITLE
Update title and ACME v2 compat for Certify (The Web)

### DIFF
--- a/content/docs/client-options.md
+++ b/content/docs/client-options.md
@@ -44,6 +44,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [ocelotconsulting/node-acme-lambda](https://github.com/ocelotconsulting/node-acme-lambda)
 - [SSL for free](https://www.sslforfree.com/)
 - [Caddy](https://caddyserver.com) (Caddy >= 0.10.12)
+- [Certify The Web (Windows)](https://certifytheweb.com) (v4 onwards)
 
 ## Bash
 
@@ -156,7 +157,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 
 - [ACMESharp](https://github.com/ebekker/ACMESharp) (.NET, PowerShell)
 - [win-acme](https://github.com/PKISharp/win-acme) (.NET)
-- [Certify](https://github.com/webprofusion/Certify) GUI (.NET, WinForms)
+- [Certify The Web](https://github.com/webprofusion/certify) GUI (.NET, WPF)
 - [oocx/acme.net](https://github.com/oocx/acme.net) (.NET)
 - [kelunik/acme-client](https://github.com/kelunik/acme-client) (PHP)
 - [ZeroSSL Windows](https://github.com/do-know/Crypt-LE/releases)


### PR DESCRIPTION
Certify SSL Manager on Windows now has ACME v2 compat from v4 alpha onwards.