### PR TITLE
Fix typo:  "three 3" -> "3"

### DIFF
--- a/content/en/docs/staging-environment.md
+++ b/content/en/docs/staging-environment.md
@@ -29,7 +29,7 @@ The staging environment uses the same rate limits as [described for the producti
 * The **Certificates per Registered Domain** limit is 30,000 per week.
 * The **Duplicate Certificate** limit is 30,000 per week.
 * The **Failed Validations** limit is 60 per hour.
-* The **Accounts per IP Address** limit is 50 accounts per three 3 hour period per IP.
+* The **Accounts per IP Address** limit is 50 accounts per 3 hour period per IP.
 * For ACME v2, the **New Orders** limit is 1,500 new orders per 3 hour period per account.
 
 # Root Certificate


### PR DESCRIPTION
Request:
can you change the github repo description from "Let's Encrypt Website"
to "Let's Encrypt Website **and documentation**" ?

I was clicking too fast; went to github, but `^f` didn't find any `docs`, 
so I went back to forums to search for documentation .. eventually back to github and found it.