### PR TITLE
Ansible's acme_certificate client

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -54,6 +54,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [Get HTTPS for free](https://gethttpsforfree.com)
 - [eggsampler/acme Go client library](https://github.com/eggsampler/acme)
 - [Certes](https://github.com/fszlin/certes)
+- [Ansible acme_certificate module](https://docs.ansible.com/ansible/latest/modules/acme_certificate_module.html) (ansible >= 2.6)
 
 ## Bash
 


### PR DESCRIPTION
The client has ACME v2 support since Ansible 2.5.1. It works fine both with the staging server as well as with the production endpoint.

I've added a link to the documentation on the `letsencrypt` module for Ansible.