### PR TITLE
Add Posh-ACME to v2 and Windows client lists

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -47,6 +47,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [ZeroSSL](https://ZeroSSL.com/)
 - [Certify The Web (Windows)](https://certifytheweb.com) (v4 onwards)
 - [publishlab/node-acme-client](https://github.com/publishlab/node-acme-client)
+- [Posh-ACME](https://github.com/rmbolger/Posh-ACME)
 
 ## Bash
 
@@ -164,6 +165,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [kelunik/acme-client](https://github.com/kelunik/acme-client) (PHP)
 - [ZeroSSL Windows](https://github.com/do-know/Crypt-LE/releases)
 - [AutoACME](https://www.autoacme.net/) (.NET)
+- [Posh-ACME](https://github.com/rmbolger/Posh-ACME) (PowerShell)
 
 # Libraries
 


### PR DESCRIPTION
This is a v2 based PowerShell client installable from the [PowerShell Gallery](https://www.powershellgallery.com/packages/Posh-ACME/1.1).