### PR TITLE
add acme-dns-tiny to client options

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -3,7 +3,7 @@ title: ACME Client Implementations
 slug: client-options
 top_graphic: 1
 date: 2018-01-05
-lastmod: 2018-03-27
+lastmod: 2018-05-03
 ---
 
 {{< lastmod >}}
@@ -47,6 +47,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [ZeroSSL](https://ZeroSSL.com/)
 - [Certify The Web (Windows)](https://certifytheweb.com) (v4 onwards)
 - [publishlab/node-acme-client](https://github.com/publishlab/node-acme-client)
+- [acme-dns-tiny](https://acme-dns-tiny.adorsaz.ch) (v2.0 onwards)
 
 ## Bash
 
@@ -143,6 +144,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [sewer](https://github.com/komuW/sewer)
 - [acme-powerdns](https://github.com/adfinis-sygroup/acme-powerdns)
 - [ACMEproxy](https://github.com/catalyst/acmeproxy)
+- [acme-dns-tiny](https://acme-dns-tiny.adorsaz.ch) (Python 3)
 
 ## Ruby
 


### PR DESCRIPTION
acme-dns-tiny is a fork of acme-tiny project to provide a Python 3 script able to respond to `dns-01` challenges with automatic DNS updates (by use of a TSIG key).

This week the project has released it's `v2.0` version which is compatible with ACME draft-09 (Let's Encrypt API v2).