### PR TITLE
Add eggsampler/acme to v2 and Go client options

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -3,7 +3,7 @@ title: ACME Client Implementations
 slug: client-options
 top_graphic: 1
 date: 2018-01-05
-lastmod: 2018-05-03
+lastmod: 2018-05-23
 ---
 
 {{< lastmod >}}
@@ -51,6 +51,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [acme-dns-tiny](https://acme-dns-tiny.adorsaz.ch) (v2.0 onwards)
 - [unixcharles/acme-client](https://github.com/unixcharles/acme-client)
 - [Greenlock](https://git.coolaj86.com/coolaj86/greenlock-express.js)
+- [eggsampler/acme Go client library](https://github.com/eggsampler/acme)
 
 ## Bash
 
@@ -89,6 +90,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [autocert](https://godoc.org/golang.org/x/crypto/acme/autocert)
 - [Ponzu CMS](https://ponzu-cms.org)
 - [Traefik](https://traefik.io)
+- [eggsampler/acme](https://github.com/eggsampler/acme)
 
 ## HAProxy
 


### PR DESCRIPTION
Adding eggsampler/acme to clientoptions.md under v2 and Go headings.