### PR TITLE
Fix #107 Google Analytics: respect Do Not Track

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -51,6 +51,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [acme-dns-tiny](https://acme-dns-tiny.adorsaz.ch) (v2.0 onwards)
 - [unixcharles/acme-client](https://github.com/unixcharles/acme-client)
 - [Greenlock](https://git.coolaj86.com/coolaj86/greenlock-express.js)
+- [Get HTTPS for free](https://gethttpsforfree.com)
 - [eggsampler/acme Go client library](https://github.com/eggsampler/acme)
 
 ## Bash

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,6 +1,5 @@
 <head>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-56433935-1"></script>
-    <script src="{{ "js/ga.js" | relURL }}"></script>
+    <script async defer src="{{ "js/ga.js" | relURL }}"></script>
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width initial-scale=1" />
@@ -17,8 +16,6 @@
     <meta name="twitter:image:src" content="{{ "images/le-logo-twitter.png" | absURL }}">
     <link rel="stylesheet" href="{{ "css/main.css" | relURL }}">
     <link rel="canonical" href="{{ .Permalink }}">
-    <link rel="dns-prefetch" href="https://www.google-analytics.com">
-    <link rel="dns-prefetch" href="https://www.googleadservices.com">
     {{ with .Site.Home.OutputFormats.Get "RSS" -}}
     <link rel="{{ .Rel }}" href="{{ .Permalink }}" type="application/rss+xml" title="Let's Encrypt Blog Feed" />
     {{ end  }}

--- a/static/js/ga.js
+++ b/static/js/ga.js
@@ -19,21 +19,23 @@ gtag('config', 'UA-56433935-1');
 
 // AdWords Conversion Tracking
 gtag('config', 'AW-872454614');
-function gtag_report_conversion(url) {
+function gtag_report_conversion(ev) {
+  if ( ! window.google_tag_manager ) {
+    return;
+  }
+  var href = ev.currentTarget.href;
   var callback = function () {
-    if (typeof(url) != 'undefined') {
-      window.location = url;
-    }
+    window.location = href;
   };
   gtag('event', 'conversion', {
       'send_to': 'AW-872454614/r2JLCP7BiGwQ1rOCoAM',
       'event_callback': callback
   });
-  return false;
+  ev.preventDefault();
 }
 var el = document.getElementById("getting-started-button");
 if (el) {
-  el.addEventListener("click", function(){gtag_report_conversion(el.href)}, false);
+  el.addEventListener("click", gtag_report_conversion);
 }
 
 })();

--- a/static/js/ga.js
+++ b/static/js/ga.js
@@ -1,3 +1,16 @@
+(function(){
+"use strict";
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack
+if ( window.doNotTrack == 1 || navigator.doNotTrack == 1
+|| navigator.doNotTrack === "yes" || navigator.msDoNotTrack == 1 ) {
+ return;
+}
+
+var googletagmanager = document.createElement('script');
+googletagmanager.setAttribute('src','https://www.googletagmanager.com/gtag/js?id=UA-56433935-1');
+document.head.appendChild(googletagmanager);
+
 // Google Analytics
 window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
@@ -20,5 +33,7 @@ function gtag_report_conversion(url) {
 }
 var el = document.getElementById("getting-started-button");
 if (el) {
-  el.addEventListener("click", function(){gtag_report_conversion("https://letsencrypt.org/getting-started/")}, false);
+  el.addEventListener("click", function(){gtag_report_conversion(el.href)}, false);
 }
+
+})();


### PR DESCRIPTION
- Remove the dns-prefetch of www.google-analytics.com and www.googleadservices.com
- Moved the loading of googletagmanager into ga.js
- ga.js is now async and defer.
- ga.js returns (do nothing) if Do Not Track is on.
- ga.js do not pollute the global javascript environment
- gtag_report_conversion uses the href of getting-started-button (because the link may be different with i18n)
- replace "return false" by "ev.preventDefault()" to prevent the navigation and waits for the event_callback to be called.
- Now that the code correctly prevented the navigation, I've added a safeguard in case of GA didn't load.