### PR TITLE
Let's Encrypt uses OCSP only, not CRLs

### DIFF
--- a/content/en/technicaloverview.md
+++ b/content/en/technicaloverview.md
@@ -51,7 +51,7 @@ When the Let's&nbsp;Encrypt CA receives the request, it verifies both signatures
      src="/images/howitworks_certificate.png"/>
 </div>
 
-Revocation works in a similar manner.  The agent signs a revocation request with the key pair authorized for `example.com`, and the Let's&nbsp;Encrypt CA verifies that the request is authorized.  If so, it publishes revocation information into the normal revocation channels (i.e., CRLs, OCSP), so that relying parties such as browsers can know that they shouldn't accept the revoked certificate.
+Revocation works in a similar manner.  The agent signs a revocation request with the key pair authorized for `example.com`, and the Let's&nbsp;Encrypt CA verifies that the request is authorized.  If so, it publishes revocation information into the normal revocation channels (i.e. OCSP), so that relying parties such as browsers can know that they shouldn't accept the revoked certificate.
 
 <div class="howitworks-figure">
 <img alt="Requesting revocation of a certificate for example.com"


### PR DESCRIPTION
in the sentence:

> If so, it publishes revocation information into the normal revocation channels

`It` refers to Let's Encrypt, and not any ACME CA, and as Let's Encrypt only uses OCSP, and not CRLs, I think it should at least not be mentioned.

(the image howitworks_revocation.png should probably be updated too, or the text should mentioned that Let's Encrypt doesn't uses CRLs)