### PR TITLE
Correct error in unique subdomains per week

### DIFF
--- a/content/en/docs/rate-limits.md
+++ b/content/en/docs/rate-limits.md
@@ -96,7 +96,7 @@ name="new-orders"></a>**New Orders** per account per 3 hours.
 
 If you've hit a rate limit, we don't have a way to temporarily reset it. You'll
 need to wait until the rate limit expires after a week. We use a sliding window,
-so if you issued 10 certificates on Monday and 10 more certificates on Friday,
+so if you issued 25 certificates on Monday and 25 more certificates on Friday,
 you'll be able to issue again starting Monday. You can get a list of certificates
 issued for your registered domain by [searching on crt.sh](https://crt.sh), which
 uses the public [Certificate Transparency](https://www.certificate-transparency.org)

--- a/content/en/docs/rate-limits.md
+++ b/content/en/docs/rate-limits.md
@@ -30,7 +30,7 @@ domain.
 
 If you have a lot of subdomains, you may want to combine them into a single
 certificate, up to a limit of 100 <a name="names-per-certificate"></a>**Names per Certificate**. Combined with the
-above limit, that means you can issue certificates containing up to 2,000 unique
+above limit, that means you can issue certificates containing up to 5,000 unique
 subdomains per week. A certificate with multiple names is often called a SAN
 certificate, or sometimes a UCC certificate.
 


### PR DESCRIPTION
This calculation is out of date; it presume the certs per registered domain per week limit is the old value of 20; the commit 7ea2fa0f1c3db2679d52be3c5f109961ffdeb25b

> commit 7ea2fa0f1c3db2679d52be3c5f109961ffdeb25b
> Author: Josh Aas <jaas@kflag.net>
> Date:   Wed Aug 1 15:40:37 2018 -0500
>
> Certs per domain per week rate limit has been raised to 50.

updated the certs per registered domain per week limit, but forgot to update this dependent calculation.

Closes #360.