### PR TITLE
Certificates: correct Certbot ref

### DIFF
--- a/content/en/certificates.md
+++ b/content/en/certificates.md
@@ -62,8 +62,8 @@ end-entity certificate, but also a list of intermediates to help browsers verify
 that the end-entity certificate has a trust chain leading to a trusted root
 certificate. Almost all server operators will choose to serve a chain including
 the intermediate certificate with Subject “Let’s Encrypt Authority X3” and
-Issuer “DST Root CA X3.” The official Let's Encrypt software will make this
-configuration seamlessly.
+Issuer “DST Root CA X3.” The recommended Let's Encrypt software,
+[https://certbot.org](Certbot), will make this configuration seamlessly.
 
 The following picture explains the relationships between our certificates
 visually:


### PR DESCRIPTION
Thanks to @tdelmas for flagging this outdated reference to the "official Let's Encrypt software".

Resolves https://github.com/letsencrypt/website/issues/372