### PR TITLE
Please add 'FreeSSL.tech Auto' PHP client

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -3,7 +3,7 @@ title: ACME Client Implementations
 slug: client-options
 top_graphic: 1
 date: 2018-01-05
-lastmod: 2018-09-20
+lastmod: 2018-10-11
 ---
 
 {{< lastmod >}}
@@ -60,6 +60,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [Nginx ACME V1/V2 client](https://github.com/kshcherban/acme-nginx)
 - [WinCertes Windows ACMEv2 client](https://github.com/aloopkin/WinCertes)
 - [ACME-PS](https://github.com/PKISharp/ACMESharpCore-PowerShell)
+- [FreeSSL.tech Auto](https://freessl.tech) (It works with Live ACME V2 API. Auto-installs SSL cert in shared hosting cPanel. No root access required.)
 
 ## Bash
 
@@ -136,6 +137,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [AcmePHP](https://github.com/acmephp/acmephp)
 - [LE Manager](https://github.com/analogic/lemanager)
 - [Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
+- [FreeSSL.tech Auto](https://freessl.tech) (Auto-installs SSL cert in shared hosting cPanel. No root access required. ACME V1 & V2)
 
 ## Python
 

--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -60,7 +60,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [Nginx ACME V1/V2 client](https://github.com/kshcherban/acme-nginx)
 - [WinCertes Windows ACMEv2 client](https://github.com/aloopkin/WinCertes)
 - [ACME-PS](https://github.com/PKISharp/ACMESharpCore-PowerShell)
-- [FreeSSL.tech Auto](https://freessl.tech) (It works with Live ACME V2 API. Auto-installs SSL cert in shared hosting cPanel. No root access required.)
+- [FreeSSL.tech Auto](https://freessl.tech)
 
 ## Bash
 
@@ -137,7 +137,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [AcmePHP](https://github.com/acmephp/acmephp)
 - [LE Manager](https://github.com/analogic/lemanager)
 - [Hiawatha](https://www.hiawatha-webserver.org/letsencrypt)
-- [FreeSSL.tech Auto](https://freessl.tech) (Auto-installs SSL cert in shared hosting cPanel. No root access required. ACME V1 & V2)
+- [FreeSSL.tech Auto](https://freessl.tech)
 
 ## Python
 


### PR DESCRIPTION
Perhaps it is the first 3rd party client that does complete automation, including SSL certificate installation, in shared hosting cPanel. No root access required.
It works with Live ACME V2 and V1 API. It is possible to install the client and configure with a browser. Developed for less tech-savvy users.