### PR TITLE
Fix dropdown navigation on small screens

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
       <a href="https://collabprojects.linuxfoundation.org/" target="_blank"><img src="/images/linux-foundation.png" alt="Linux Foundation Collaborative Projects" /></a>
     </div>
     <a class="site-title" href="{{ .Site.Home.RelPermalink }}"><img src="/images/letsencrypt-logo-horizontal.svg" alt="Let's Encrypt"></a>
-    
+
     <span id="menuIcon">
       <svg viewBox="0 0 18 15">
         <path fill="#424242" d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.031C17.335,0,18,0.665,18,1.484L18,1.484z"/>
@@ -18,7 +18,7 @@
         <ul class="pure-menu-list">
           {{ range .Site.Menus.main }}
           <li class="pure-menu-item{{ if .HasChildren }}  pure-menu-has-children pure-menu-allow-hover{{ end }}">
-            <a href="{{ .URL }}" class="pure-menu-link">{{ .Name }}</a>
+            <a href="{{ .URL }}" class="pure-menu-link" tabindex="0">{{ .Name }}</a>
             {{ if .HasChildren }}
             <ul class="pure-menu-children">
               {{ range .Children }}

--- a/src/css/_nav.scss
+++ b/src/css/_nav.scss
@@ -19,7 +19,7 @@
             margin-left: 20px;
         }
     }
-    
+
     .pure-menu-horizontal > .pure-menu-list > .pure-menu-item:last-child > a.pure-menu-link {
         padding-right: 0;
     }
@@ -55,10 +55,11 @@ a.pure-menu-link:hover {
     top: 56px;
     left: auto;
     right:0;
-    text-align: right;
+    text-align: left;
     min-width: 146px;
     background-color: #FDFDFD;
 }
+
 .pure-menu-link {
     color: darken($brand-color, 20%);
     &:visited {
@@ -110,7 +111,12 @@ a.pure-menu-link:hover {
         padding-bottom:20px;
     }
 
-    .pure-menu-has-children.isOpen > .pure-menu-link:after {
+    .pure-menu-allow-hover:hover > .pure-menu-children,
+    .pure-menu-active > .pure-menu-children {
+      position: unset;
+    }
+
+    .pure-menu-has-children.pure-menu-active > .pure-menu-link:after {
         content: "\25BE";
     }
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -174,7 +174,7 @@ td, th { padding: 0; }
 
 .pure-button::-moz-focus-inner { padding: 0; border: 0; }
 
-.pure-button { font-family: inherit; font-size: 100%; padding: .5em 1em; color: #444; color: rgba(0, 0, 0, 0.8); border: 1px solid #999; border: 0 transparent; background-color: #E6E6E6; text-decoration: none; border-radius: 2px; }
+.pure-button { font-family: inherit; font-size: 100%; padding: .5em 1em; color: #444; color: rgba(0, 0, 0, 0.8); border: 1px solid #999; border: 0 rgba(0, 0, 0, 0); background-color: #E6E6E6; text-decoration: none; border-radius: 2px; }
 
 .pure-button-hover, .pure-button:hover, .pure-button:focus { filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#1a000000', GradientType=0); background-image: -webkit-gradient(linear, 0 0, 0 100%, from(transparent), color-stop(40%, rgba(0, 0, 0, 0.05)), to(rgba(0, 0, 0, 0.1))); background-image: -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05) 40%, rgba(0, 0, 0, 0.1)); background-image: -moz-linear-gradient(top, rgba(0, 0, 0, 0.05) 0, rgba(0, 0, 0, 0.1)); background-image: -o-linear-gradient(transparent, rgba(0, 0, 0, 0.05) 40%, rgba(0, 0, 0, 0.1)); background-image: linear-gradient(transparent, rgba(0, 0, 0, 0.05) 40%, rgba(0, 0, 0, 0.1)); }
 
@@ -774,7 +774,7 @@ pre > code { border: 0; padding-right: 0; padding-left: 0; }
 
 a.pure-menu-link:hover { text-decoration: none; }
 
-.pure-menu-allow-hover:hover > .pure-menu-children, .pure-menu-active > .pure-menu-children { top: 56px; left: auto; right: 0; text-align: right; min-width: 146px; background-color: #FDFDFD; }
+.pure-menu-allow-hover:hover > .pure-menu-children, .pure-menu-active > .pure-menu-children { top: 56px; left: auto; right: 0; text-align: left; min-width: 146px; background-color: #FDFDFD; }
 
 .pure-menu-link { color: #144b92; }
 
@@ -787,7 +787,8 @@ a.pure-menu-link:hover { text-decoration: none; }
   #menuIcon > svg path { fill: #424242; }
   .site-nav { text-align: left; margin-top: 20px; right: 18px; position: relative; margin-bottom: 10px; right: 0; width: 100%; margin-top: 0; top: 0px; }
   .pure-menu { clear: both; display: none; position: relative; padding-bottom: 20px; }
-  .pure-menu-has-children.isOpen > .pure-menu-link:after { content: "\25BE"; }
+  .pure-menu-allow-hover:hover > .pure-menu-children, .pure-menu-active > .pure-menu-children { position: unset; }
+  .pure-menu-has-children.pure-menu-active > .pure-menu-link:after { content: "\25BE"; }
   .pure-menu-children { display: none; left: 0; position: relative; margin-left: 20px; }
   .pure-menu-children.show-children { display: block; }
   .page-link { display: block; padding: 5px 10px; } }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -3,12 +3,38 @@
 //==============
 
 (function (window, document) {
-var menu = document.getElementById('menu'),
-    WINDOW_CHANGE_EVENT = ('onorientationchange' in window) ? 'orientationchange':'resize';
+
+const MENU_ID = 'menu';
+const MENU_SELECTOR = `#${MENU_ID}`;
+
+const MENU_OPEN_CLASS = 'open';
+
+// Applied to NAV_MENU_PARENTs when they're active/open.
+// Note that this doesn't not get applied with NAV_MENU_HOVERABLE.
+const NAV_MENU_ACTIVE_CLASS = 'pure-menu-active';
+const NAV_MENU_ACTIVE_SELECTOR = `.${NAV_MENU_ACTIVE_CLASS}`;
+
+// When applied to a NAV_MENU_PARENT_ item, the menu will toggle on hover
+// (See https://purecss.io/menus/#dropdowns)
+const NAV_MENU_HOVERABLE_CLASS = 'pure-menu-allow-hover';
+
+// Applied to nav menu items that are parents of a sub-menu
+const NAV_MENU_PARENT_CLASS = 'pure-menu-has-children';
+const NAV_MENU_PARENT_SELECTOR = `.${NAV_MENU_PARENT_CLASS}`;
+
+// The containing <ul> of a sub-menu's items
+const NAV_MENU_CHILD_CLASS = 'pure-menu-children';
+const NAV_MENU_CHILD_SELECTOR = `.${NAV_MENU_CHILD_CLASS}`;
+
+const NAV_LINK_CLASS = 'pure-menu-link';
+const NAV_LINK_SELECTOR = `.${NAV_LINK_CLASS}`;
+
+const menu = document.getElementById(MENU_ID);
+const WINDOW_CHANGE_EVENT = ('onorientationchange' in window) ? 'orientationchange':'resize';
 
 function toggleHorizontal() {
     [].forEach.call(
-        document.getElementById('menu').querySelectorAll('.custom-can-transform'),
+        document.getElementById(MENU_ID).querySelectorAll('.custom-can-transform'),
         function(el){
             el.classList.toggle('pure-menu-horizontal');
         }
@@ -26,116 +52,106 @@ function toggleMenu() {
         toggleHorizontal();
         disableDropdowns();
     }
-    menu.classList.toggle('open');
+    menu.classList.toggle(MENU_OPEN_CLASS);
     // document.getElementById('menuIcon').classList.toggle('x');
 }
 
-function closeMenu() {
-    if (menu.classList.contains('open')) {
-        toggleMenu();
-    }
+function openNavMenu(el) {
+  closeAllNavMenus(el);
+  el.classList.add(NAV_MENU_ACTIVE_CLASS);
+  el.querySelector(`${NAV_MENU_PARENT_SELECTOR} > ${NAV_LINK_SELECTOR}`)
+    .setAttribute('aria-expanded', true);
 }
 
-var dropdownListener = function(el) {
-  el.addEventListener('click', function (e) {
-    el.classList.toggle('isOpen');
-    el.querySelector('.pure-menu-children').classList.toggle('show-children');
-  });
-};
+function closeNavMenu(el) {
+  el.classList.remove(NAV_MENU_ACTIVE_CLASS);
+  el.querySelector(`${NAV_MENU_PARENT_SELECTOR} > ${NAV_LINK_SELECTOR}`)
+    .setAttribute('aria-expanded', false);
+}
+
+function closeAllNavMenus(exclude) {
+  [].forEach.call(
+    menu.querySelectorAll(NAV_MENU_ACTIVE_SELECTOR), function(el) {
+      if (el !== exclude) {
+        closeNavMenu(el);
+      }
+    }
+  );
+}
 
 function enableDropdowns() {
   [].forEach.call(
-      document.getElementById('menu').querySelectorAll('.pure-menu-has-children'),
+      document.getElementById(MENU_ID).querySelectorAll(NAV_MENU_PARENT_SELECTOR),
       function(el){
-          dropdownListener(el);
-          el.classList.toggle('pure-menu-allow-hover');
+        el.classList.add(NAV_MENU_HOVERABLE_CLASS);
+        el.addEventListener('focusin', function(e) {
+          openNavMenu(el);
+        })
       }
   );
 }
 
 function disableDropdowns() {
   [].forEach.call(
-      document.getElementById('menu').querySelectorAll('.pure-menu-has-children'),
+      document.getElementById(MENU_ID).querySelectorAll(NAV_MENU_PARENT_SELECTOR),
       function(el){
-          el.removeEventListener('click', dropdownListener(el));
-          el.classList.toggle('pure-menu-allow-hover');
+        el.classList.remove(NAV_MENU_HOVERABLE_CLASS);
       }
   );
 }
 
-document.getElementById('menuIcon').addEventListener('click', function (e) {
+function closeMenu() {
+  if (menu.classList.contains(MENU_OPEN_CLASS)) {
+    closeAllNavMenus();
     toggleMenu();
+  }
+}
+
+document.getElementById('menuIcon').addEventListener('click', function (e) {
+  // Don't propagate to the document-level click listener, since that closes the menu
+  e.stopPropagation();
+  toggleMenu();
 });
 
 [].forEach.call(
-  document.getElementById('menu').querySelectorAll('.pure-menu-has-children'), function(el) {
+  document.getElementById(MENU_ID).querySelectorAll(NAV_MENU_PARENT_SELECTOR), function(el) {
     el.firstElementChild.addEventListener('click', function (e) {e.preventDefault();});
   }
 );
 
 window.addEventListener(WINDOW_CHANGE_EVENT, closeMenu);
 
-
-function closeNavMenus(exclude) {
-  [].forEach.call(
-    menu.querySelectorAll('.pure-menu-active'), function(el) {
-      if (el !== exclude) {
-        el.classList.remove('pure-menu-active');
-        el.querySelector('.pure-menu-has-children > .pure-menu-link').setAttribute('aria-expanded', false);
-      }
-    }
-  );
-}
-
 // Initialize nav menu aria roles/state
 menu.querySelector('.pure-menu-list').setAttribute('role', 'menubar');
 
 [].forEach.call(
-  menu.querySelectorAll('.pure-menu-link'), function(el) {
+  menu.querySelectorAll(NAV_LINK_SELECTOR), function(el) {
     el.setAttribute('role', 'menuitem');
     el.parentNode.setAttribute('role', 'none');
 
-    if (el.parentNode.classList.contains('pure-menu-has-children')) {
+    if (el.parentNode.classList.contains(NAV_MENU_PARENT_CLASS)) {
       el.setAttribute('aria-haspopup', true);
       el.setAttribute('aria-expanded', false);
 
-      var childMenu = el.parentNode.querySelector('.pure-menu-children');
+      var childMenu = el.parentNode.querySelector(NAV_MENU_CHILD_SELECTOR);
       childMenu.setAttribute('role', 'menu');
       childMenu.setAttribute('aria-label', el.text);
     }
   }
 );
 
-menu.addEventListener('focusin', function(e) {
-  if (e.target.classList.contains('pure-menu-link')) {
-    var anchor = e.target;
+enableDropdowns();
 
-    var listItem = anchor.parentNode;
-    if (listItem.parentNode.classList.contains('pure-menu-children'))
-      listItem = listItem.parentNode.parentNode;
-
-    var listItemAnchor = listItem.querySelector('.pure-menu-link');
-
-    closeNavMenus(listItem);
-
-    if (listItem.classList.contains('pure-menu-has-children')) {
-      listItem.classList.add('pure-menu-active');
-      listItemAnchor.setAttribute('aria-expanded', true);
-    }
+document.addEventListener('click', function(e) {
+  if (!e.target.closest(MENU_SELECTOR)) {
+    closeMenu();
   }
-});
-
-
-document.addEventListener('click', closeNavMenus);
-
-document.addEventListener('focusin', function(e) {
-  if (!e.target.classList.contains('pure-menu-link'))
-    closeNavMenus();
-});
+})
 
 document.addEventListener('keyup', function(e) {
-  if (e.keyCode == 27 && e.target.classList.contains('pure-menu-link'))
-    closeNavMenus();
-});
+  if (e.keyCode === 27) {
+    closeMenu();
+  }
+})
 
 })(this, this.document);


### PR DESCRIPTION
Closes #379

### Changes

- Removes use of the `.isOpen` selector in favour of using `.pure-menu-active` only
- Left-aligns nav menu text for better readability and consistency across small & large screens
- Simplifies small-screen menu to use default positioning, instead of absolute.
- Adds a bunch of variables for CSS class names & selectors
- Change handling of the ESC key & clicking out-of-bounds to close the entire navigation menu rather than closing only the current sub-menu. 

Tested on:
- Chrome Version 69.0.3497.100 (Mac OSX and Android)
- Safari Version 12.0
- Firefox Quantum 61.0

### Screenshots

Small-screen mouse navigation:

![le-nav-sm-mouse](https://user-images.githubusercontent.com/855595/47046358-e98afb80-d162-11e8-8c43-7dc60d54355a.gif)

Small-screen keyboard navigation:

![le-nav-sm-keyboard](https://user-images.githubusercontent.com/855595/47046365-ed1e8280-d162-11e8-8038-b04d70b2944e.gif)

Large-screen mouse navigation:

![le-nav-lg-mouse](https://user-images.githubusercontent.com/855595/47046371-f0197300-d162-11e8-82c5-b01f1039d497.gif)

Large-screen keyboard navigation:

![le-nav-lg-keyboard](https://user-images.githubusercontent.com/855595/47046377-f4459080-d162-11e8-81b2-88d2a3578cd2.gif)

### Notes

Note that there's a small edge-case bug with the current implementation that has not been fixed by this PR, although it does surface in a slightly different way. 

To reproduce on the production site:

1. Use keyboard navigation to focus the "Donate" dropdown
2. Use a mouse to hover over the "About Us" dropdown
3. Both menus will be shown at the same time. 

![le-nav-bug-old](https://user-images.githubusercontent.com/855595/47046336-e09a2a00-d162-11e8-8dfc-4de79b8f3b3c.gif)

To reproduce in this PR:

1. Click the "Donate" dropdown 
2. Hover over the "About Us" dropdown
3. Both menus will be shown at the same time

![le-nav-bug-new](https://user-images.githubusercontent.com/855595/47046345-e55ede00-d162-11e8-8992-201a0aa194a0.gif)

The root cause is general weirdness around using hover & focus events for hiding/showing dropdowns. I find it a bit easier (and more accessible) to use a click/keydown event to trigger a dropdown, with the dropdown persisting until it's closed with the ESC key or an out-of-bounds click. Click events also avoid the problem of immediately displaying a sub-menu when navigating with a keyboard; per the [W3 documentation](https://www.w3.org/WAI/tutorials/menus/flyout/#keyboard-users): 

> Submenus should not open when using the tab key to navigate through the menu, as keyboard users would then have to step through all submenu items to get to the next top-level item.

I didn't want to shave too many a11y yaks in this PR, but I'm happy to ticket this behaviour separately if you're interested. 

