### PR TITLE
Fix broken link to https://letsencrypt.org/repository/

### DIFF
--- a/content/en/documents/ISRG-CPS-v2.4.html
+++ b/content/en/documents/ISRG-CPS-v2.4.html
@@ -1641,7 +1641,7 @@ The sample is randomly selected. Results are saved and provided to auditors upon
 <h3 id="9-4-6-disclosure-pursuant-to-judicial-or-administrative-process">9.4.6 Disclosure pursuant to judicial or administrative process</h3>
 <p>ISRG may disclose personal information if compelled to do so by court order or other compulsory legal process, provided that ISRG will oppose such disclosure with all legal and technical tools reasonably available to ISRG.</p>
 <h3 id="9-4-7-other-information-disclosure-circumstances">9.4.7 Other information disclosure circumstances</h3>
-<p>ISRG may disclose personal information under other circumstances that are described in the privacy policy posted on its website (<a href="https://letsencrypt.org/repository/)">https://letsencrypt.org/repository/)</a>.</p>
+<p>ISRG may disclose personal information under other circumstances that are described in the privacy policy posted on its website (<a href="https://letsencrypt.org/repository/">https://letsencrypt.org/repository/</a>).</p>
 <h2 id="9-5-intellectual-property-rights">9.5 Intellectual property rights</h2>
 <p>ISRG and/or its business partners own the intellectual property rights in ISRG’s services, including the certificates, trademarks used in providing the services, and this CPS. Certificate and revocation information are the property of ISRG. ISRG grants permission to reproduce and distribute certificates on a non-exclusive and royalty-free basis, provided that they are reproduced and distributed in full. Private Keys and Public Keys remain the property of the Subscribers who rightfully hold them.</p>
 <p>Notwithstanding the foregoing, third party software (including open source software) used by ISRG to provide its services is licensed, not owned, by ISRG.</p>


### PR DESCRIPTION
(The parenthesis was inside the href)