### PR TITLE
Fix link to GetSSL - Azure Automation

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -105,7 +105,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 
 ## Microsoft Azure
 
-- [GetSSL - Azure Automation](https://www.powershellgallery.com/packages/GetSSL-LetsEncrypt/1.4.3/DisplayScript) (Compatible with any App Service)
+- [GetSSL - Azure Automation](https://www.powershellgallery.com/packages/GetSSL-LetsEncrypt/) (Compatible with any App Service)
 
 ## nginx
 


### PR DESCRIPTION
And make it reliable for future versions:
https://www.powershellgallery.com/packages/GetSSL-LetsEncrypt/1.4.3/DisplayScript -> https://www.powershellgallery.com/packages/GetSSL-LetsEncrypt/

(that currently redirects to https://www.powershellgallery.com/packages/GetSSL-LetsEncrypt/1.4.7 )

Ping the original commiter @bdaehlie https://github.com/letsencrypt/website/commit/f9bd51dfa41d6bad97db41f7b554af41efbe3988