### PR TITLE
 Fix i18n <html lang="en"> 

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ with $.Site.LanguageCode }}{{ . }}{{ else }}en-us{{ end }}">
 	{{ partial "head" . }}
 	<body>
 		{{ partial "header" . }}

--- a/layouts/_default/blank.html
+++ b/layouts/_default/blank.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ with $.Site.LanguageCode }}{{ . }}{{ else }}en-us{{ end }}">
 	{{ partial "head" . }}
 	<body>
 		{{ .Content }}

--- a/layouts/post/baseof.html
+++ b/layouts/post/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ with $.Site.LanguageCode }}{{ . }}{{ else }}en-us{{ end }}">
   {{ partial "head" . }}
   <body>
     {{ partial "header" . }}


### PR DESCRIPTION
Set the "lang" attribute to the correct value depending of `languageCode` from https://github.com/letsencrypt/website/blob/master/config.toml

Before: `en`
After: `en-us`, `fr-fr`, `es-us`, ... 