### PR TITLE
\docs\ can be translated

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -17,6 +17,6 @@
 * Paths should stay in English: `/en/about` becomes `/XX/about` in every languages.
 * When a file is not translated, it will not appear in the menu.
 * client-options.md and cert-compat.md are not ready to be translated
-* Blog posts (`content\XX\post\`) and docs (`content\XX\docs\`) are not ready to be translated
+* Blog posts (`content\XX\post\`) are not ready to be translated
 * Images are not ready to be translated ([#314](https://github.com/letsencrypt/website/issues/314))
 * Graphs content are not ready to be translated ([#344](https://github.com/letsencrypt/website/issues/344))

--- a/layouts/shortcodes/lastmod.html
+++ b/layouts/shortcodes/lastmod.html
@@ -1,1 +1,1 @@
-<p>{{ i18n "last_updated" }} {{ .Page.Lastmod.Format "January 2, 2006" }}{{ if eq .Page.Section "docs" }} | <a href="{{ "docs" | relURL }}">{{ i18n "see_all_doc" }}</a>{{ end }}</p>
+<p>{{ i18n "last_updated" }} {{ .Page.Lastmod.Format "January 2, 2006" }}{{ if eq .Page.Section "docs" }} | <a href="{{ "docs" | relLangURL }}">{{ i18n "see_all_doc" }}</a>{{ end }}</p>


### PR DESCRIPTION
I think I forgot to remove that part when I added the one about `docs/_index.md`, sorry. I see no reason anymore not to translate the documentation.