### PR TITLE
Show English blog posts on translated versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: generic
 
 before_install:
-  - wget https://github.com/gohugoio/hugo/releases/download/v0.33/hugo_0.33_Linux-64bit.deb
-  - echo "6426dad5c5489b642ee9a635ef2c7239cad242fd1d65cc712a8fb815565362cd hugo_0.33_Linux-64bit.deb" | sha256sum -c - || exit 1;
-  - sudo dpkg -i hugo_0.33_Linux-64bit.deb
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.50/hugo_0.50_Linux-64bit.deb
+  - echo "b7d2f9c2b85f29933335b8df93a07b4d4a8ddb74cfbb7eaedcef93dc0be49c6e hugo_0.50_Linux-64bit.deb" | sha256sum -c - || exit 1;
+  - sudo dpkg -i hugo_0.50_Linux-64bit.deb
 
 install:
   - hugo env

--- a/config.toml
+++ b/config.toml
@@ -36,7 +36,7 @@ contentDir = "content/en"
 languageName ="English"
 languageCode= "en-us"
 # Weight used for sorting.
-weight = 1
+weight = 10
 description = """
   Let&rsquo;s&nbsp;Encrypt is a free, automated, and open certificate
   authority brought to you by the non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
@@ -80,7 +80,7 @@ languageName = "Français"
 contentDir = "content/fr"
 languageCode= "fr-fr"
 # Weight used for sorting.
-weight = 1
+weight = 20
 description = """
   Let&rsquo;s&nbsp;Encrypt est une autorité de certification gratuite, automatisée et ouverte
   apporté par l'<a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>, organisme à but non lucratif.
@@ -112,7 +112,7 @@ contentDir = "content/es"
 languageName ="Español"
 languageCode= "es-us"
 # Weight used for sorting.
-weight = 1
+weight = 30
 description = """
   Let&rsquo;s&nbsp;Encrypt es una autoridad de certificaci&oacute;n gratuita, automatizada, y abierta traida a ustedes por la organizaci&oacute;n sin &aacute;nimos de lucro <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,7 +20,8 @@
           <div class="grid-container">
             <h2 class="through-line"><a href="/blog/">{{ i18n "home_from_our_blog" }}</a></h2>
               <ul class="post-list">
-                {{ $posts := where .Site.RegularPages "Type" "in" (slice "post") | first 3 }}
+                {{ $enPosts := where .Sites.First.RegularPages "Type" "in" (slice "post") | first 3 }}
+                {{ $posts := where .Site.RegularPages "Type" "in" (slice "post") | first 3 | lang.Merge $enPosts }}
                 {{ range $posts }}
                   <li>
                     <span class="post-meta">{{ .Date.Format $.Site.Params.time_format_default }}</span>


### PR DESCRIPTION
This commit merges in missing blog post translations on the home page from the first site, i.e. English.

To get "first" to mean English, this commit also sets a distinct weight for each language to get the expected sort order (1. English 2. French 3. Spanish).

Note that the links to the blog articles in another language will go to the English version of the site, so you may want to make them open in another window to make that explicit.

Fixes #402