### PR TITLE
Don't tell people to use --staging.

### DIFF
--- a/content/en/docs/staging-environment.md
+++ b/content/en/docs/staging-environment.md
@@ -14,13 +14,13 @@ The ACME URL for our staging environment is:
 
 `https://acme-staging.api.letsencrypt.org/directory`
 
-If you're using Certbot, you can use our staging environment with the `--staging` flag. For other ACME clients, please read their instructions for information on testing with our staging environment.
+If you're using Certbot, you can use our staging environment with the `--dry-run` flag. For other ACME clients, please read their instructions for information on testing with our staging environment.
 
 The ACME URL for our [ACME v2 staging environment](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605) is:
 
 `https://acme-staging-v02.api.letsencrypt.org/directory`
 
-If you're using Certbot, you can use our staging environment with the `--staging` flag. For other ACME clients, please read their instructions for information on testing with our staging environment. Please note the v2 staging environment requires a v2 compatible ACME client.
+If you're using Certbot, you can use our staging environment with the `--dry-run` flag. For other ACME clients, please read their instructions for information on testing with our staging environment. Please note the v2 staging environment requires a v2 compatible ACME client.
 
 # Rate Limits
 


### PR DESCRIPTION
When you use `--staging`, Certbot basically works the same way as it does when using the production server. There are a couple very basic sanity checks around things like changing a certificate lineage from production to staging certs, but for the most part, Certbot treats this server like any other ACME server. This can result in things like staging certificates installed into someone's Apache or Nginx config.

I think a better option for people to use here is `--dry-run` which doesn't allow users to test certificate installation (which isn't affected by the choice of ACME server anyway), but works for the `certonly` and `renew` subcommands and doesn't save the resulting untrusted certificates to disk.

On the Certbot side, we never tell anyone to use `--staging` and always recommend they test with `--dry-run`.