### PR TITLE
Add python ACME client integrated with opensrs DNS

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -3,7 +3,7 @@ title: ACME Client Implementations
 slug: client-options
 top_graphic: 1
 date: 2018-01-05
-lastmod: 2019-01-14
+lastmod: 2019-01-17
 ---
 
 {{< lastmod >}}
@@ -160,6 +160,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [ACMEproxy](https://github.com/catalyst/acmeproxy)
 - [acme-dns-tiny](https://acme-dns-tiny.adorsaz.ch) (Python 3)
 - [acme-nosudo](https://github.com/diafygi/acme-nosudo)
+- [le-opensrs](https://github.com/mhmd3bdo/le-opensrs) (Python 3)
 
 ## Ruby
 


### PR DESCRIPTION
client to automate issuing and reissuing wildcard [Let's Encrypt] (https://letsencrypt.org/) certificates with OpenSRS API DNS, this script will retrieve challenge from Let's Encrypt and will update it, in OpenSRS DNS, and the will ask Let's Encrypt to verify the challenge.