### PR TITLE
docs/client-options: Add CertMagic

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -3,7 +3,7 @@ title: ACME Client Implementations
 slug: client-options
 top_graphic: 1
 date: 2018-01-05
-lastmod: 2019-01-14
+lastmod: 2019-03-01
 ---
 
 {{< lastmod >}}
@@ -195,6 +195,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 
 - [Lego](https://github.com/xenolf/lego)
 - [hlandau/acme](https://github.com/hlandau/acme/tree/master/acmeapi)
+- [CertMagic](https://github.com/mholt/certmagic)
 
 ## Java
 


### PR DESCRIPTION
CertMagic uses lego under the hood, but serves TLS and HTTPS applications with automatic renewals. It is not a CLI tool (CertMagic's CLI version is basically what Caddy is), but is higher-level than lego in that it only requires one or two lines of code to get and manage certificates:

```go
// serves a site on HTTPS, with HTTP->HTTPS redirects, automatic cert renewals,
// OCSP stapling, and the ability to coordinate behind load balancers
err := certmagic.HTTPS([]string{"example.com", "www.example.com"}, myHandler)
```

Even though it doesn't directly implement the ACME itself, it abstracts it away to the level that is useful for application developers, so I figured I'd check to see if it fits in this list anyway; CertMagic nicely fills that gap between "doing all the plumbing" and "full-blown CLI client application".