### PR TITLE
client-options: Add WildFly Application Server to the projects integrating with Let's Encrypt

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -3,7 +3,7 @@ title: ACME Client Implementations
 slug: client-options
 top_graphic: 1
 date: 2018-01-05
-lastmod: 2019-01-14
+lastmod: 2019-03-01
 ---
 
 {{< lastmod >}}
@@ -262,6 +262,7 @@ These clients are compatible with our [staging endpoint for ACME v2](https://com
 - [ruxy](https://ruxyserver.com)
 - [ISPConfig](https://www.ispconfig.org/)
 - [LiveConfig Hosting Control Panel](https://www.liveconfig.com/)
+- [WildFly Application Server](https://developer.jboss.org/people/fjuma/blog/2018/08/31/obtaining-certificates-from-lets-encrypt-using-the-wildfly-cli)
 
 # Adding your client/project
 


### PR DESCRIPTION
Since WildFly 14, it is possible to obtain and manage certificates from Let's Encrypt using the WildFly CLI.