### PR TITLE
docs: update rate limits page RE: renewal ordering.

### DIFF
--- a/content/en/docs/rate-limits.md
+++ b/content/en/docs/rate-limits.md
@@ -49,10 +49,7 @@ you've hit the limit for the week, you can still issue new certificates that
 count as renewals. An issuance request counts as a renewal if it contains the
 exact same set of hostnames as a previously issued certificate. This is the same
 definition used for the Duplicate Certificate limit described above. Renewals
-*are* still subject to the Duplicate Certificate limit. Also note: the order of
-renewals and new issuances matters. To get the maximum possible number of
-certificates, you must perform all new issuances before renewals during a given
-time window.
+*are* still subject to the Duplicate Certificate limit.
 
 The Duplicate Certificate limit and the Renewal Exemption ignore the public key
 and extensions requested. A certificate issuance can be considered a renewal even if


### PR DESCRIPTION
See
https://community.letsencrypt.org/t/rate-limits-fixing-certs-per-name-rate-limit-order-of-operations-gotcha/88189

I think there's room for changing the way we describe the renewal rate limit exception but I wanted to remove the inaccurate note before diving into a larger update later on.