### PR TITLE
docs: fix rate-limits lastmod date.

### DIFF
--- a/content/en/docs/rate-limits.md
+++ b/content/en/docs/rate-limits.md
@@ -3,7 +3,7 @@ title: Rate Limits
 slug: rate-limits
 top_graphic: 1
 date: 2018-01-04
-lastmod: 2018-08-01
+lastmod: 2019-03-08
 ---
 
 {{< lastmod >}}


### PR DESCRIPTION
I updated `docs/rate-limits.md` on March 8th to [remove the rate limit ordering gotcha](https://github.com/letsencrypt/website/commit/061a584f108d674eca805f427618adc47b15557e) and forgot to patch the `lastmod` date.