### PR TITLE
Remove documentation about the old-style staging URL

### DIFF
--- a/content/de/docs/staging-environment.md
+++ b/content/de/docs/staging-environment.md
@@ -10,12 +10,6 @@ lastmod: 2018-03-12
 
 Wir empfehlen dringend das Testen gegen unsere Staging-Umgebung, bevor die Produktionsumgebung benutzt wird. Das wird Ihnen erlauben, die Dinge richtig zu machen, bevor vertrauenswürdige Zertifikate ausgestellt werden und reduziert das Risiko, gegen Rate Limits zu laufen.
 
-Die ACME URL für unsere Staging-Umgebung lautet:
-
-`https://acme-staging.api.letsencrypt.org/directory`
-
-Wenn Sie Certbot benutzen, können Sie unsere Staging-Umgebung mit dem `--dry-run` Flag benutzen. Für andere ACME Clients lesen Sie bitte die Instruktionen für Informationen zum Testen mit unserer Staging-Umgebung.
-
 Die ACME URL für unsere [ACME v2 Staging-Umgebung](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605) ist:
 
 `https://acme-staging-v02.api.letsencrypt.org/directory`

--- a/content/en/docs/staging-environment.md
+++ b/content/en/docs/staging-environment.md
@@ -10,12 +10,6 @@ lastmod: 2018-03-12
 
 We highly recommend testing against our staging environment before using our production environment. This will allow you to get things right before issuing trusted certificates and reduce the chance of your running up against rate limits.
 
-The ACME URL for our staging environment is:
-
-`https://acme-staging.api.letsencrypt.org/directory`
-
-If you're using Certbot, you can use our staging environment with the `--dry-run` flag. For other ACME clients, please read their instructions for information on testing with our staging environment.
-
 The ACME URL for our [ACME v2 staging environment](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605) is:
 
 `https://acme-staging-v02.api.letsencrypt.org/directory`

--- a/content/es/docs/staging-environment.md
+++ b/content/es/docs/staging-environment.md
@@ -10,12 +10,6 @@ lastmod: 2018-03-12
 
 We highly recommend testing against our staging environment before using our production environment. This will allow you to get things right before issuing trusted certificates and reduce the chance of your running up against rate limits.
 
-The ACME URL for our staging environment is:
-
-`https://acme-staging.api.letsencrypt.org/directory`
-
-If you're using Certbot, you can use our staging environment with the `--dry-run` flag. For other ACME clients, please read their instructions for information on testing with our staging environment.
-
 The ACME URL for our [ACME v2 staging environment](https://community.letsencrypt.org/t/staging-endpoint-for-acme-v2/49605) is:
 
 `https://acme-staging-v02.api.letsencrypt.org/directory`


### PR DESCRIPTION
> If you're using Certbot, you can use our staging environment with the `--dry-run` flag. For other ACME clients, please read their instructions for information on testing with our staging environment.

This sentence was written twice in `staging-environment.md`.