### PR TITLE
Fix missing negation in german translation

### DIFF
--- a/content/de/docs/client-options.md
+++ b/content/de/docs/client-options.md
@@ -263,6 +263,6 @@ Wenn Sie wissen, dass ein ACME-Client oder ein Projekt in Let's Encrypt integrie
 Bevor Sie Pull-Request absenden, bitte stellen Sie sicher:
 
 1. Ihr Client respektiert die [Let's Encrypt Markenrichtlinien](https://letsencrypt.org/trademarks/).
-2. Ihr Client ist Browser-basiert und unterstützt automatische Erneuerung.
+2. Ihr Client ist nicht Browser-basiert und unterstützt automatische Erneuerung.
 3. Ihr Commit fügt Ihren Client ans **Ende** der relevanten Sektion (Vergessen Sie nicht die "ACME v2 Kompatible Clients" Sektion , wenn es angemessen ist!).
 4. Ihr Commit aktualisiert den `lastmod` Zeitstempel in `client-options.md` oben.


### PR DESCRIPTION
A sentence at the bottom of the clients-option page reads in english:

> Your client is not browser-based and supports automatic renewals.

The german translation misses the negation:

> Ihr Client ist Browser-basiert und unterstützt automatische Erneuerung.

This should be changed to *Ihr Client ist **nicht** Browser-basiert...*