### PR TITLE
Add redirect for ct-logs

### DIFF
--- a/content/en/docs/ct-logs.html
+++ b/content/en/docs/ct-logs.html
@@ -3,6 +3,8 @@ title: Certificate Transparency (CT) Logs
 slug: ct-logs
 top_graphic: 4
 lastmod: 2019-05-15
+aliases:
+    - /ct-logs
 ---
 
 {{< lastmod >}}


### PR DESCRIPTION
A press release used an incorrect link to our site.
This will enable that to work too.