### PR TITLE
i18n:  Missing entries in docs index 

### DIFF
--- a/content/de/docs/_index.md
+++ b/content/de/docs/_index.md
@@ -29,6 +29,9 @@ menu:
 * [Zertifikate sperren](/de/docs/revoking/)
 * [Zertifizierungsstellenberechtigung](/de/docs/caa/)
 * [Zertifikate für localhost](/de/docs/certificates-for-localhost/)
+* [Best Practice - Keep Port 80 Open](/docs/allow-port-80/)
+* [Challenge Types](/docs/challenge-types/)
+* [Certificate Transparency (CT) Logs](/docs/ct-logs/)
 
 # Informationen für Client Entwickler
 

--- a/content/es/docs/_index.md
+++ b/content/es/docs/_index.md
@@ -29,6 +29,9 @@ menu:
 * [Revoking Certificates](/docs/revoking/)
 * [Autorizaci&oacute;n de la Autoridad de Certificaci&oacute;n (CAA)](/es/docs/caa/)
 * [Certificados para localhost](/es/docs/certificates-for-localhost/)
+* [Best Practice - Keep Port 80 Open](/docs/allow-port-80/)
+* [Challenge Types](/docs/challenge-types/)
+* [Certificate Transparency (CT) Logs](/docs/ct-logs/)
 
 # Informaci&oacute;n para Desarrolladores de Clientes
 

--- a/content/fr/docs/_index.md
+++ b/content/fr/docs/_index.md
@@ -29,6 +29,9 @@ menu:
 * [Revoking Certificates](/docs/revoking/)
 * [Certificate Authority Authorization](/docs/caa/)
 * [Certificates for localhost](/docs/certificates-for-localhost/)
+* [Best Practice - Keep Port 80 Open](/docs/allow-port-80/)
+* [Challenge Types](/docs/challenge-types/)
+* [Certificate Transparency (CT) Logs](/docs/ct-logs/)
 
 # Client Developer Information
 

--- a/content/pt-br/docs/_index.md
+++ b/content/pt-br/docs/_index.md
@@ -31,6 +31,7 @@ menu:
 * [Certificates for localhost](/docs/certificates-for-localhost/)
 * [Best Practice - Keep Port 80 Open](/docs/allow-port-80/)
 * [Challenge Types](/docs/challenge-types/)
+* [Certificate Transparency (CT) Logs](/docs/ct-logs/)
 
 # Informações Para Desenvolvedores de Clientes
 

--- a/content/ru/docs/_index.md
+++ b/content/ru/docs/_index.md
@@ -31,6 +31,7 @@ menu:
 * [Certificates for localhost](/docs/certificates-for-localhost/)
 * [Best Practice - Keep Port 80 Open](/docs/allow-port-80/)
 * [Challenge Types](/docs/challenge-types/)
+* [Certificate Transparency (CT) Logs](/docs/ct-logs/)
 
 # Информация для разработчиков
 


### PR DESCRIPTION
* [Best Practice - Keep Port 80 Open](/docs/allow-port-80/)
* [Challenge Types](/docs/challenge-types/)
* [Certificate Transparency (CT) Logs](/docs/ct-logs/)