### PR TITLE
Update the lastmod timestamp for client-options.md

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -2,7 +2,7 @@
 title: ACME Client Implementations
 slug: client-options
 top_graphic: 1
-lastmod: 2019-05-09
+lastmod: 2019-05-24
 ---
 
 {{< clientslastmod >}}


### PR DESCRIPTION
Even though PR https://github.com/letsencrypt/website/pull/519 has been merged, the new client, certman-operator added in PR is not showing up on the website yet and could be because the lastmod was not updated in that PR. So I am submitting this new PR to update the lastmod for the client-options.md page.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>