### PR TITLE
 Sync lastmod with the English version

### DIFF
--- a/content/de/docs/client-options.md
+++ b/content/de/docs/client-options.md
@@ -2,7 +2,7 @@
 title: ACME Client Implementierungen
 slug: client-options
 top_graphic: 1
-lastmod: 2019-05-09
+lastmod: 2019-05-24
 ---
 
 {{< clientslastmod >}}

--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2019-05-09",
+	"lastmod": "2019-05-24",
 	"categories": [
 		"Bash",
 		"C",


### PR DESCRIPTION
To detect not up-to-date translations, translations must have the date set to the English version they correspond to.

(update lastmod on the json file this time only)