### PR TITLE
upcoming-features : CT log enabled

### DIFF
--- a/content/en/upcoming-features.md
+++ b/content/en/upcoming-features.md
@@ -2,6 +2,7 @@
 title: Upcoming Features
 slug: upcoming-features
 top_graphic: 1
+lastmod: 2019-06-15
 ---
 
 ## Multi-Perspective Validation

--- a/content/en/upcoming-features.md
+++ b/content/en/upcoming-features.md
@@ -4,12 +4,6 @@ slug: upcoming-features
 top_graphic: 1
 ---
 
-## Certificate Transparency Log
-
-* ETA: Q1 2019
-
-We are planning to operate a [certificate transparency log](http://www.certificate-transparency.org/how-ct-works).
-
 ## Multi-Perspective Validation
 
 * ETA: Q2 2019
@@ -23,6 +17,12 @@ Currently Let's Encrypt validates from a single network perspective. We are plan
 Currently Let's Encrypt only signs end-entity certificates with RSA intermediates. Let's Encrypt will generate an ECDSA root and intermediates which can be used to sign end-entity certificates.
 
 # Completed Features
+
+## Certificate Transparency Log
+
+* Enabled: May 15, 2019
+
+We are starting to operate a [Certificate Transparency log](https://letsencrypt.org/docs/ct-logs/).
 
 ## TLS ALPN Challenge Support
 


### PR DESCRIPTION
I wonder where the link should point to:
https://letsencrypt.org/docs/ct-logs/ (currently in this PR)
or https://letsencrypt.org/2019/05/15/introducing-oak-ct-log.html
?