### PR TITLE
Defer loading of Google Analytics and enable IP anonymization

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -63,4 +63,8 @@
   </div>
 
   <script src="{{ "js/main.min.js" | relURL }}"></script>
+  
+  <script defer src="{{ "js/ga.js" | relURL }}"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-56433935-1&aip=1"></script>
+
 </footer>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,4 @@
 <head>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-56433935-1"></script>
-    <script src="{{ "js/ga.js" | relURL }}"></script>
-
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width initial-scale=1" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -15,8 +12,6 @@
     <meta name="twitter:image:src" content="{{ "images/le-logo-twitter.png" | absURL }}">
     <link rel="stylesheet" href="{{ "css/main.min.css" | relURL }}">
     <link rel="canonical" href="{{ .Permalink }}">
-    <link rel="dns-prefetch" href="https://www.google-analytics.com">
-    <link rel="dns-prefetch" href="https://www.googleadservices.com">
     {{ with .Site.Home.OutputFormats.Get "RSS" -}}
     <link rel="{{ .Rel }}" href="{{ .Permalink }}" type="application/rss+xml" title="{{ i18n "blog_feed" }}" />
     {{ end  }}

--- a/static/js/ga.js
+++ b/static/js/ga.js
@@ -4,4 +4,4 @@ window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 /*eslint-enable*/
 gtag("js", new Date());
-gtag("config", "UA-56433935-1");
+gtag("config", "UA-56433935-1", { 'anonymize_ip': true });


### PR DESCRIPTION
There are no reasonable needs to slow the page loading for analytics purpose.
Enabling IP anonymization is better for privacy and have negligible drawbacks.
(If IP anonymization is already enabled in the Google Analytics console, that will just confirm the pledge to respect users privacy)
Cf. #107 and #324
Cf. https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization and https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#aip