### PR TITLE
client-options: anchors for client/lib categories

### DIFF
--- a/layouts/shortcodes/clients.html
+++ b/layouts/shortcodes/clients.html
@@ -1,5 +1,5 @@
 
-<h2>{{ .Get "acme_v2" }}</h2>
+<h2 id="acme-v2-compatible-clients">{{ .Get "acme_v2" }}</h2>
 
 <ul>
 {{ range $.Site.Data.clients.list }}
@@ -12,7 +12,7 @@
 </ul>
 
 {{ range $.Site.Data.clients.categories }}
-    <h2>{{ . }}</h2>
+    <h2 id="clients-{{ urlize . }}">{{ . }}</h2>
     {{ $category := . }}
     <ul>
     {{ range $.Site.Data.clients.list }}
@@ -35,7 +35,7 @@
 {{ $certbot := .Inner }}
 
 {{ range $.Site.Data.clients.libraries }}
-    <h2>{{ . }}</h2>
+    <h2 id="libraries-{{ urlize . }}">{{ . }}</h2>
     {{ $library := . }}
     <ul>
     {{ if eq . "Python"}}
@@ -56,7 +56,7 @@
     </ul>
 {{ end }}
 
-<h1>{{ .Get "projects" }}</h1>
+<h1 id="projects-integrating-with-let-s-encrypt">{{ .Get "projects" }}</h1>
 
 <ul>
 {{ range $.Site.Data.clients.projects }}


### PR DESCRIPTION
It appears that when the Client Options page was changed to be a shortcode, the automatically generated header anchors were lost.

IMO these were useful to have because the page is very long. For example, when linking somebody to Windows clients.

This commit restores the anchors for client and library categories, although unfortunately they do not exactly match the anchors that were there previously.