### PR TITLE
client-options: eggsampler/acme is lib, not client

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -239,12 +239,6 @@
 			"category": "Go"
 		},
 		{
-			"name": "eggsampler/acme Go client library",
-			"url": "https://github.com/eggsampler/acme",
-			"acme_v2": "true",
-			"category": "Go"
-		},
-		{
 			"name": "HAProxy ACME validation plugin",
 			"url": "https://github.com/janeczku/haproxy-acme-validation-plugin",
 			"category": "HAProxy"
@@ -566,6 +560,11 @@
 			"url": "https://github.com/tothpaul/DelphiACME",
 			"library": "Delphi",
 			"comments": "(Embarcadero Delphi)"
+		},
+		{
+			"name": "eggsampler/acme",
+			"url": "https://github.com/eggsampler/acme",
+			"library": "Go"
 		},
 		{
 			"name": "zero11it/acme-client",


### PR DESCRIPTION
Additionally remove `acme_v2`, which I assume is reserved for actual clients and not libraries. 

Though I notice that quite a few of the `acme_v2` projects are not actually clients. Maybe there could be a separate PR to clean those up at some point. Otherwise visitors might suffer frustration.

cc @eggsampler to approve