### PR TITLE
Remove graphs because the data source is incorrect

### DIFF
--- a/content/de/stats.md
+++ b/content/de/stats.md
@@ -17,13 +17,6 @@ menu:
 </div>
 
 <div class="figure">
-  <h2><a name="percent-pageloads" href="#percent-pageloads"
-    >Percentage of Web Pages Loaded by Firefox Using HTTPS</a></h2>
-  <p>(14-day moving average, source: <a href="https://docs.telemetry.mozilla.org/datasets/other/ssl/reference.html">Firefox Telemetry</a>)</p>
-  <div id="pageloadPercent" title="Percentage of Web Pages Loaded by Firefox Using HTTPS" class="statsgraph"></div>
-</div>
-
-<div class="figure">
   <h2><a name="daily-issuance" href="#daily-issuance"
     >Let's Encrypt Certificates Issued Per Day</a></h2>
   <div id="issuancePerDay" title="Let's Encrypt Certificates Issued Per Day" class="statsgraph"></div>

--- a/content/en/stats.md
+++ b/content/en/stats.md
@@ -17,13 +17,6 @@ menu:
 </div>
 
 <div class="figure">
-  <h2><a name="percent-pageloads" href="#percent-pageloads"
-    >Percentage of Web Pages Loaded by Firefox Using HTTPS</a></h2>
-  <p>(14-day moving average, source: <a href="https://docs.telemetry.mozilla.org/datasets/other/ssl/reference.html">Firefox Telemetry</a>)</p>
-  <div id="pageloadPercent" title="Percentage of Web Pages Loaded by Firefox Using HTTPS" class="statsgraph"></div>
-</div>
-
-<div class="figure">
   <h2><a name="daily-issuance" href="#daily-issuance"
     >Let's Encrypt Certificates Issued Per Day</a></h2>
   <div id="issuancePerDay" title="Let's Encrypt Certificates Issued Per Day" class="statsgraph"></div>

--- a/content/es/stats.md
+++ b/content/es/stats.md
@@ -17,13 +17,6 @@ menu:
 </div>
 
 <div class="figure">
-  <h2><a name="percent-pageloads" href="#percent-pageloads"
-    >Porcentaje de Páginas de Web Cargadas por Firefox Usando HTTPS</a></h2>
-  <p>(media móvil de 14 días, fuente: <a href="https://docs.telemetry.mozilla.org/datasets/other/ssl/reference.html">Firefox Telemetry</a>)</p>
-  <div id="pageloadPercent" title="Porcentaje de Páginas de Web Cargadas por Firefox Usando HTTPS" class="statsgraph"></div>
-</div>
-
-<div class="figure">
   <h2><a name="daily-issuance" href="#daily-issuance"
     >Certificados Let's Encrypt Emitidos por Día</a></h2>
   <div id="issuancePerDay" title="Certificados Let's Encrypt Emitidos por Día" class="statsgraph"></div>

--- a/content/fr/stats.md
+++ b/content/fr/stats.md
@@ -17,13 +17,6 @@ menu:
 </div>
 
 <div class="figure">
-  <h2><a name="percent-pageloads" href="#percent-pageloads"
-    >Pourcentage de pages Web chargées par Firefox utilisant HTTPS</a></h2>
-  <p>(Moyenne mobile sur 14 jours, source: <a href="https://docs.telemetry.mozilla.org/datasets/other/ssl/reference.html">Firefox Telemetry</a>)</p>
-  <div id="pageloadPercent" title="Pourcentage de pages Web chargées par Firefox à l'aide du protocole HTTPS" class="statsgraph"></div>
-</div>
-
-<div class="figure">
   <h2><a name="daily-issuance" href="#daily-issuance"
     >Certificats de Let's Encrypt délivrés par jour</a></h2>
   <div id="issuancePerDay" title="Certificats de Let's Encrypt délivrés par jour" class="statsgraph"></div>

--- a/content/ru/stats.md
+++ b/content/ru/stats.md
@@ -17,13 +17,6 @@ menu:
 </div>
 
 <div class="figure">
-  <h2><a name="percent-pageloads" href="#percent-pageloads"
-    >Доля web-страниц, загруженных браузером Firefox по протоколу HTTPS</a></h2>
-  <p>(14-дневная скользящая средняя, источник: <a href="https://docs.telemetry.mozilla.org/datasets/other/ssl/reference.html">Телеметрия Firefox</a>)</p>
-  <div id="pageloadPercent" title="Доля web-страниц, загруженных браузером Firefox по протоколу HTTPS" class="statsgraph"></div>
-</div>
-
-<div class="figure">
   <h2><a name="daily-issuance" href="#daily-issuance"
     >Число сертификатов Let's Encrypt Certificates, выпускаемых в сутки</a></h2>
   <div id="issuancePerDay" title="Число сертификатов Let's Encrypt Certificates, выпускаемых в сутки" class="statsgraph"></div>


### PR DESCRIPTION
The Mozilla telemetry data is incorrect and producing a graph that stops around 2016. We should not show bad data while we sort it out.