### PR TITLE
docs: update account-id page, remove shorthand.

### DIFF
--- a/content/en/docs/account-id.md
+++ b/content/en/docs/account-id.md
@@ -3,7 +3,7 @@ title: Finding Account IDs
 slug: account-id
 top_graphic: 1
 date: 2016-08-10
-lastmod: 2016-08-10
+lastmod: 2019-07-30
 ---
 
 {{< lastmod >}}
@@ -14,8 +14,8 @@ the ACME client software you use to talk to Let's Encrypt, and you may have
 multiple accounts configured if you run ACME clients on multiple servers.
 
 Your account ID is a URL of the form
-`https://acme-v01.api.letsencrypt.org/acme/reg/12345678`. You can also provide
-just the digits at the end of that URL as a shorthand.
+`https://acme-v02.api.letsencrypt.org/acme/acct/12345678` or
+`https://acme-v01.api.letsencrypt.org/acme/reg/12345678`.
 
 If you're using Certbot, you can find your account ID by looking at the "uri"
 field in


### PR DESCRIPTION
Updated the "Finding Account IDs" page (English content only) so that:

1) it includes both an ACME v2 and an ACME v1 account URL.
2) it doesn't reference the "shorthand" numeric form. Using only the full URL will help encourage RFC 8555 compatibility.