### PR TITLE
Fix #590

### DIFF
--- a/content/pull_request_template.md
+++ b/content/pull_request_template.md
@@ -1,0 +1,5 @@
+# Important
+
+- If this PR updates a file with a `lastmod` field, it **must** be updated.
+
+- If this PR is a translation, please read [TRANSLATION.md](https://github.com/letsencrypt/website/blob/master/TRANSLATION.md) first.


### PR DESCRIPTION
To help fix #590 here is my solution:

- A template for pull requests to remind people that `lastmod` must be updated (and more details for translators)

- The settings of the repository should be changed to add the `Require status checks to pass before merging ` option, to forbid direct commits, so people must create a PR (which is better to follow the updated than a direct push) so they must see the reminder about `lastmod` update.

That settings can be found here: https://github.com/letsencrypt/website/settings/branches > `Branch protection rules` > `edit` on the `master` branch rule > `Rule settings `  in the bottom of the page:

![image](https://user-images.githubusercontent.com/1955774/63125888-0674a300-bfaf-11e9-84f4-7aa3a00c5d24.png)

`Include administrators` is better checked too...

Docs about template for pull requests: https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository
