### PR TITLE
Hardcode the link to the RSS feed to /feed.xml

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -38,7 +38,7 @@
                 {{ end }}
               </ul>
               {{ with .OutputFormats.Get "RSS" -}}
-                <p class="rss-subscribe">{{ i18n "subscribe_rss" . | safeHTML }}</p>
+                <p class="rss-subscribe">{{ i18n "subscribe_rss" (dict "Permalink" "/feed.xml") | safeHTML }}</p>
               {{ end  }}
           </div>
         </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,6 +13,6 @@
     <link rel="stylesheet" href="{{ "css/main.min.css" | relURL }}">
     <link rel="canonical" href="{{ .Permalink }}">
     {{ with .Site.Home.OutputFormats.Get "RSS" -}}
-    <link rel="{{ .Rel }}" href="{{ .Permalink }}" type="application/rss+xml" title="{{ i18n "blog_feed" }}" />
+    <link rel="alternate" href="/feed.xml" type="application/rss+xml" title="{{ i18n "blog_feed" }}" />
     {{ end  }}
 </head>


### PR DESCRIPTION
So it's the same link for all languages, and they don't point anymore to an empty feed as blog posts are not translated
Fix #407

nb: use the `dict` syntax to create an object with the `Permalink` attribute to avoid updating translations and allow a easy revert.