### PR TITLE
Rearrange language order in the header menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,6 +30,53 @@ time_format_default = "Jan 2, 2006"
 enableMissingTranslationPlaceholders = true
 
 [languages]
+
+[languages.de]
+title = "Let's Encrypt - Freie SSL/TLS Zertifikate"
+contentDir = "content/de"
+languageName ="Deutsch"
+languageCode= "de-de"
+#if colon ":" must be prefixed
+beforeColon= ""
+# Weight used for sorting.
+weight = 10
+description = """
+  Let&rsquo;s&nbsp;Encrypt ist eine freie, automatisierte und offene Zertifizierungsstelle,
+  herausgebracht für Sie durch <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
+"""
+[[languages.de.menu.main]]
+ name = "Hilfe bekommen"
+ weight = 20
+ url = "https://community.letsencrypt.org/"
+ [[languages.de.menu.main]]
+ name = "Spenden"
+ weight = 30
+ identifier = "donate"
+ url = "/de/donate/"
+ [[languages.de.menu.main]]
+ name = "Über uns"
+ weight = 40
+ identifier = "about"
+ url = "/de/about/"
+ [[languages.de.menu.main]]
+ name = "Internet Security Research Group (ISRG)"
+ weight = 20
+ identifier = "isrg"
+ parent = "about"
+ url = "https://www.abetterinternet.org/about/"
+ [[languages.de.menu.main]]
+ name = "Dienstestatus"
+ weight = 60
+ identifier = "status"
+ parent = "about"
+ url = "https://letsencrypt.status.io/"
+ [[languages.de.menu.main]]
+ name = "Freie Stellen"
+ weight = 80
+ identifier = "careers"
+ parent = "about"
+ url = "https://www.abetterinternet.org/careers/"
+
 [languages.en]
 title = "Let's Encrypt - Free SSL/TLS Certificates"
 contentDir = "content/en"
@@ -38,7 +85,7 @@ languageCode= "en-us"
 #if colon ":" must be prefixed
 beforeColon= ""
 # Weight used for sorting.
-weight = 10
+weight = 20
 description = """
   Let&rsquo;s&nbsp;Encrypt is a free, automated, and open certificate
   authority brought to you by the non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
@@ -71,52 +118,6 @@ description = """
  url = "https://letsencrypt.status.io/"
  [[languages.en.menu.main]]
  name = "Careers"
- weight = 80
- identifier = "careers"
- parent = "about"
- url = "https://www.abetterinternet.org/careers/"
-
-[languages.fr]
-title = "Let's Encrypt - Certificats SSL/TLS gratuits"
-languageName = "Français"
-contentDir = "content/fr"
-languageCode= "fr-fr"
-#if colon ":" must be prefixed
-beforeColon= "&nbsp;"
-# Weight used for sorting.
-weight = 20
-description = """
-  Let&rsquo;s&nbsp;Encrypt est une autorité de certification gratuite, automatisée et ouverte
-  apporté par l'<a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>, organisme à but non lucratif.
-"""
-[[languages.fr.menu.main]]
- name = "Obtenir de l'aide"
- weight = 20
- url = "https://community.letsencrypt.org/c/help/aide-en-francais"
- [[languages.fr.menu.main]]
- name = "Faire un don"
- weight = 30
- identifier = "donate"
- url = "/fr/donate/"
- [[languages.fr.menu.main]]
- name = "À propos de nous"
- weight = 40
- identifier = "about"
- url = "/fr/about/"
- [[languages.fr.menu.main]]
- name = "Internet Security Research Group (ISRG)"
- weight = 20
- identifier = "isrg"
- parent = "about"
- url = "https://www.abetterinternet.org/about/"
- [[languages.fr.menu.main]]
- name = "État du service"
- weight = 60
- identifier = "status"
- parent = "about"
- url = "https://letsencrypt.status.io/"
- [[languages.fr.menu.main]]
- name = "Emplois"
  weight = 80
  identifier = "careers"
  parent = "about"
@@ -167,6 +168,235 @@ description = """
  parent = "about"
  url = "https://www.abetterinternet.org/careers/"
 
+[languages.fr]
+title = "Let's Encrypt - Certificats SSL/TLS gratuits"
+languageName = "Français"
+contentDir = "content/fr"
+languageCode= "fr-fr"
+#if colon ":" must be prefixed
+beforeColon= "&nbsp;"
+# Weight used for sorting.
+weight = 40
+description = """
+  Let&rsquo;s&nbsp;Encrypt est une autorité de certification gratuite, automatisée et ouverte
+  apporté par l'<a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>, organisme à but non lucratif.
+"""
+[[languages.fr.menu.main]]
+ name = "Obtenir de l'aide"
+ weight = 20
+ url = "https://community.letsencrypt.org/c/help/aide-en-francais"
+ [[languages.fr.menu.main]]
+ name = "Faire un don"
+ weight = 30
+ identifier = "donate"
+ url = "/fr/donate/"
+ [[languages.fr.menu.main]]
+ name = "À propos de nous"
+ weight = 40
+ identifier = "about"
+ url = "/fr/about/"
+ [[languages.fr.menu.main]]
+ name = "Internet Security Research Group (ISRG)"
+ weight = 20
+ identifier = "isrg"
+ parent = "about"
+ url = "https://www.abetterinternet.org/about/"
+ [[languages.fr.menu.main]]
+ name = "État du service"
+ weight = 60
+ identifier = "status"
+ parent = "about"
+ url = "https://letsencrypt.status.io/"
+ [[languages.fr.menu.main]]
+ name = "Emplois"
+ weight = 80
+ identifier = "careers"
+ parent = "about"
+ url = "https://www.abetterinternet.org/careers/"
+
+[languages.id]
+title = "Let's Encrypt - Sertifikat SSL/TLS Gratis"
+contentDir = "content/id"
+languageName ="Bahasa Indonesia"
+languageCode= "id-id"
+#if colon ":" must be prefixed
+beforeColon= ""
+# Weight used for sorting.
+weight = 50
+description = """
+  Let&rsquo;s&nbsp;Encrypt adalah otoritas sertifikasi terbuka yang gratis dan terotomatisasi,
+  dipersembahkan oleh organisasi non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
+"""
+[[languages.id.menu.main]]
+ name = "Dapatkan Bantuan"
+ weight = 20
+ url = "https://community.letsencrypt.org/"
+ [[languages.id.menu.main]]
+ name = "Donasi"
+ weight = 30
+ identifier = "donate"
+ url = "/donate/"
+ [[languages.id.menu.main]]
+ name = "Tentang Kami"
+ weight = 40
+ identifier = "about"
+ url = "/about/"
+ [[languages.id.menu.main]]
+ name = "Internet Security Research Group (ISRG)"
+ weight = 20
+ identifier = "isrg"
+ parent = "about"
+ url = "https://www.abetterinternet.org/about/"
+ [[languages.id.menu.main]]
+ name = "Status Layanan"
+ weight = 60
+ identifier = "status"
+ parent = "about"
+ url = "https://letsencrypt.status.io/"
+ [[languages.id.menu.main]]
+ name = "Karir"
+ identifier = "careers"
+ parent = "about"
+ url = "https://www.abetterinternet.org/careers/"
+
+[languages.ja]
+title = "Let's Encrypt - フリーな SSL/TLS 証明書"
+contentDir = "content/ja"
+languageName ="日本語"
+languageCode= "ja"
+#if colon ":" must be prefixed
+beforeColon= ""
+# Weight used for sorting.
+weight = 60
+description = """
+  Let&rsquo;s&nbsp;Encrypt is a free, automated, and open certificate
+  authority brought to you by the non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
+"""
+[[languages.ja.menu.main]]
+ name = "コミュニティ"
+ weight = 20
+ url = "https://community.letsencrypt.org/"
+ [[languages.ja.menu.main]]
+ name = "寄付"
+ weight = 30
+ identifier = "donate"
+ url = "/donate/"
+ [[languages.ja.menu.main]]
+ name = "私たちについて"
+ weight = 40
+ identifier = "about"
+ url = "/about/"
+ [[languages.ja.menu.main]]
+ name = "インターネット・セキュリティ研究グループ (ISRG)"
+ weight = 20
+ identifier = "isrg"
+ parent = "about"
+ url = "https://www.abetterinternet.org/about/"
+ [[languages.ja.menu.main]]
+ name = "サービス・ステータス"
+ weight = 60
+ identifier = "status"
+ parent = "about"
+ url = "https://letsencrypt.status.io/"
+ [[languages.ja.menu.main]]
+ name = "キャリア"
+ weight = 80
+ identifier = "careers"
+ parent = "about"
+ url = "https://www.abetterinternet.org/careers/"
+
+[languages.pt-br]
+title = "Let's Encrypt - Certificados SSL/TLS Gratuitos"
+contentDir = "content/pt-br"
+languageName ="Português do Brasil"
+languageCode= "pt-br"
+#if colon ":" must be prefixed
+beforeColon= ""
+# Weight used for sorting.
+weight = 70
+description = """
+  Let&rsquo;s&nbsp;Encrypt é uma autoridade certificadora gratuita, automatizada e aberta
+  que se tornou possível graças à organização sem fins lucrativos <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>
+"""
+[[languages.pt-br.menu.main]]
+ name = "Obter Ajuda"
+ weight = 20
+ url = "https://community.letsencrypt.org/c/help/ajuda-em-portugues"
+ [[languages.pt-br.menu.main]]
+ name = "Doar"
+ weight = 30
+ identifier = "donate"
+ url = "/pt-br/donate/"
+ [[languages.pt-br.menu.main]]
+ name = "Sobre Nós"
+ weight = 40
+ identifier = "about"
+ url = "/pt-br/about/"
+ [[languages.pt-br.menu.main]]
+ name = "Internet Security Research Group (ISRG)"
+ weight = 20
+ identifier = "isrg"
+ parent = "about"
+ url = "https://www.abetterinternet.org/about/"
+ [[languages.pt-br.menu.main]]
+ name = "Status do Serviço"
+ weight = 60
+ identifier = "status"
+ parent = "about"
+ url = "https://letsencrypt.status.io/"
+ [[languages.pt-br.menu.main]]
+ name = "Carreiras"
+ weight = 80
+ identifier = "careers"
+ parent = "about"
+ url = "https://www.abetterinternet.org/careers/"
+
+[languages.ru]
+title = "Let's Encrypt - Free SSL/TLS Certificates"
+contentDir = "content/ru"
+languageName ="Русский"
+languageCode= "ru-ru"
+#if colon ":" must be prefixed
+beforeColon= ""
+# Weight used for sorting.
+weight = 80
+description = """
+  Let&rsquo;s&nbsp;Encrypt - это бесплатный, автоматизированный и открытый Центр Сертификации, созданный для вас
+  некоммерческой организацией <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
+"""
+[[languages.ru.menu.main]]
+ name = "Помощь"
+ weight = 20
+ url = "https://community.letsencrypt.org/"
+ [[languages.ru.menu.main]]
+ name = "Поддержите нас"
+ weight = 30
+ identifier = "donate"
+ url = "/ru/donate/"
+ [[languages.ru.menu.main]]
+ name = "О сервисе"
+ weight = 40
+ identifier = "about"
+ url = "/ru/about/"
+ [[languages.ru.menu.main]]
+ name = "Internet Security Research Group (ISRG)"
+ weight = 20
+ identifier = "isrg"
+ parent = "about"
+ url = "https://www.abetterinternet.org/about/"
+ [[languages.ru.menu.main]]
+ name = "Состояние сервиса"
+ weight = 60
+ identifier = "status"
+ parent = "about"
+ url = "https://letsencrypt.status.io/"
+ [[languages.ru.menu.main]]
+ name = "Карьера"
+ weight = 80
+ identifier = "careers"
+ parent = "about"
+ url = "https://www.abetterinternet.org/careers/"
+
 [languages.zh-cn]
 title = "Let's Encrypt - 免费的SSL/TLS证书"
 contentDir = "content/zh-cn"
@@ -175,7 +405,7 @@ languageCode= "zh-cn"
 #if colon ":" must be prefixed
 beforeColon= ""
 # Weight used for sorting.
-weight = 40
+weight = 90
 description = """
   Let&rsquo;s&nbsp;Encrypt 是免费、开放和自动化的证书颁发机构。由非盈利组织<a href="https://www.abetterinternet.org/"
   style="white-space:nowrap;">互联网安全研究小组（ISRG）</a>运营。
@@ -221,7 +451,7 @@ languageCode= "zh-tw"
 #if colon ":" must be prefixed
 beforeColon= ""
 # Weight used for sorting.
-weight = 40
+weight = 91
 description = """
   Let's Encrypt 是由非營利性互聯網安全研究組（ISRG）提供給您的免費，自動化和開放的證書頒發機構。
   """
@@ -253,235 +483,6 @@ description = """
   url = "https://letsencrypt.status.io/"
 [[languages.zh-tw.menu.main]]
  name = "招募"
- weight = 80
- identifier = "careers"
- parent = "about"
- url = "https://www.abetterinternet.org/careers/"
-
-[languages.de]
-title = "Let's Encrypt - Freie SSL/TLS Zertifikate"
-contentDir = "content/de"
-languageName ="Deutsch"
-languageCode= "de-de"
-#if colon ":" must be prefixed
-beforeColon= ""
-# Weight used for sorting.
-weight = 40
-description = """
-  Let&rsquo;s&nbsp;Encrypt ist eine freie, automatisierte und offene Zertifizierungsstelle,
-  herausgebracht für Sie durch <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
-"""
-[[languages.de.menu.main]]
- name = "Hilfe bekommen"
- weight = 20
- url = "https://community.letsencrypt.org/"
- [[languages.de.menu.main]]
- name = "Spenden"
- weight = 30
- identifier = "donate"
- url = "/de/donate/"
- [[languages.de.menu.main]]
- name = "Über uns"
- weight = 40
- identifier = "about"
- url = "/de/about/"
- [[languages.de.menu.main]]
- name = "Internet Security Research Group (ISRG)"
- weight = 20
- identifier = "isrg"
- parent = "about"
- url = "https://www.abetterinternet.org/about/"
- [[languages.de.menu.main]]
- name = "Dienstestatus"
- weight = 60
- identifier = "status"
- parent = "about"
- url = "https://letsencrypt.status.io/"
- [[languages.de.menu.main]]
- name = "Freie Stellen"
- weight = 80
- identifier = "careers"
- parent = "about"
- url = "https://www.abetterinternet.org/careers/"
-
-[languages.ru]
-title = "Let's Encrypt - Free SSL/TLS Certificates"
-contentDir = "content/ru"
-languageName ="Русский"
-languageCode= "ru-ru"
-#if colon ":" must be prefixed
-beforeColon= ""
-# Weight used for sorting.
-weight = 40
-description = """
-  Let&rsquo;s&nbsp;Encrypt - это бесплатный, автоматизированный и открытый Центр Сертификации, созданный для вас
-  некоммерческой организацией <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
-"""
-[[languages.ru.menu.main]]
- name = "Помощь"
- weight = 20
- url = "https://community.letsencrypt.org/"
- [[languages.ru.menu.main]]
- name = "Поддержите нас"
- weight = 30
- identifier = "donate"
- url = "/ru/donate/"
- [[languages.ru.menu.main]]
- name = "О сервисе"
- weight = 40
- identifier = "about"
- url = "/ru/about/"
- [[languages.ru.menu.main]]
- name = "Internet Security Research Group (ISRG)"
- weight = 20
- identifier = "isrg"
- parent = "about"
- url = "https://www.abetterinternet.org/about/"
- [[languages.ru.menu.main]]
- name = "Состояние сервиса"
- weight = 60
- identifier = "status"
- parent = "about"
- url = "https://letsencrypt.status.io/"
- [[languages.ru.menu.main]]
- name = "Карьера"
- weight = 80
- identifier = "careers"
- parent = "about"
- url = "https://www.abetterinternet.org/careers/"
-
-[languages.pt-br]
-title = "Let's Encrypt - Certificados SSL/TLS Gratuitos"
-contentDir = "content/pt-br"
-languageName ="Português do Brasil"
-languageCode= "pt-br"
-#if colon ":" must be prefixed
-beforeColon= ""
-# Weight used for sorting.
-weight = 50
-description = """
-  Let&rsquo;s&nbsp;Encrypt é uma autoridade certificadora gratuita, automatizada e aberta
-  que se tornou possível graças à organização sem fins lucrativos <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>
-"""
-[[languages.pt-br.menu.main]]
- name = "Obter Ajuda"
- weight = 20
- url = "https://community.letsencrypt.org/c/help/ajuda-em-portugues"
- [[languages.pt-br.menu.main]]
- name = "Doar"
- weight = 30
- identifier = "donate"
- url = "/pt-br/donate/"
- [[languages.pt-br.menu.main]]
- name = "Sobre Nós"
- weight = 40
- identifier = "about"
- url = "/pt-br/about/"
- [[languages.pt-br.menu.main]]
- name = "Internet Security Research Group (ISRG)"
- weight = 20
- identifier = "isrg"
- parent = "about"
- url = "https://www.abetterinternet.org/about/"
- [[languages.pt-br.menu.main]]
- name = "Status do Serviço"
- weight = 60
- identifier = "status"
- parent = "about"
- url = "https://letsencrypt.status.io/"
- [[languages.pt-br.menu.main]]
- name = "Carreiras"
- weight = 80
- identifier = "careers"
- parent = "about"
- url = "https://www.abetterinternet.org/careers/"
-
-[languages.id]
-title = "Let's Encrypt - Sertifikat SSL/TLS Gratis"
-contentDir = "content/id"
-languageName ="Bahasa Indonesia"
-languageCode= "id-id"
-#if colon ":" must be prefixed
-beforeColon= ""
-# Weight used for sorting.
-weight = 10
-description = """
-  Let&rsquo;s&nbsp;Encrypt adalah otoritas sertifikasi terbuka yang gratis dan terotomatisasi,
-  dipersembahkan oleh organisasi non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
-"""
-[[languages.id.menu.main]]
- name = "Dapatkan Bantuan"
- weight = 20
- url = "https://community.letsencrypt.org/"
- [[languages.id.menu.main]]
- name = "Donasi"
- weight = 30
- identifier = "donate"
- url = "/donate/"
- [[languages.id.menu.main]]
- name = "Tentang Kami"
- weight = 40
- identifier = "about"
- url = "/about/"
- [[languages.id.menu.main]]
- name = "Internet Security Research Group (ISRG)"
- weight = 20
- identifier = "isrg"
- parent = "about"
- url = "https://www.abetterinternet.org/about/"
- [[languages.id.menu.main]]
- name = "Status Layanan"
- weight = 60
- identifier = "status"
- parent = "about"
- url = "https://letsencrypt.status.io/"
- [[languages.id.menu.main]]
- name = "Karir"
- identifier = "careers"
- parent = "about"
- url = "https://www.abetterinternet.org/careers/"
-
-[languages.ja]
-title = "Let's Encrypt - フリーな SSL/TLS 証明書"
-contentDir = "content/ja"
-languageName ="日本語"
-languageCode= "ja"
-#if colon ":" must be prefixed
-beforeColon= ""
-# Weight used for sorting.
-weight = 50
-description = """
-  Let&rsquo;s&nbsp;Encrypt is a free, automated, and open certificate
-  authority brought to you by the non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
-"""
-[[languages.ja.menu.main]]
- name = "コミュニティ"
- weight = 20
- url = "https://community.letsencrypt.org/"
- [[languages.ja.menu.main]]
- name = "寄付"
- weight = 30
- identifier = "donate"
- url = "/donate/"
- [[languages.ja.menu.main]]
- name = "私たちについて"
- weight = 40
- identifier = "about"
- url = "/about/"
- [[languages.ja.menu.main]]
- name = "インターネット・セキュリティ研究グループ (ISRG)"
- weight = 20
- identifier = "isrg"
- parent = "about"
- url = "https://www.abetterinternet.org/about/"
- [[languages.ja.menu.main]]
- name = "サービス・ステータス"
- weight = 60
- identifier = "status"
- parent = "about"
- url = "https://letsencrypt.status.io/"
- [[languages.ja.menu.main]]
- name = "キャリア"
  weight = 80
  identifier = "careers"
  parent = "about"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -38,7 +38,7 @@
               {{ range $home.AllTranslations }}
               {{ $isCurrentLang := eq $home.Language .Language }}
               <li class="pure-menu-item">
-                <a href="{{ .Permalink }}" class="pure-menu-link">{{ if $isCurrentLang  }}✓ {{ end }}{{ .Language.LanguageName }}</a>
+                <a href="{{ .Permalink }}" class="pure-menu-link">{{ if $isCurrentLang  }}✓ {{ end }}{{ .Language.LanguageName }} ({{ .Language }})</a>
               </li>
               {{ end }}
             </ul>


### PR DESCRIPTION
Currently, languages in the header menu seem in disorder. This PR rearrange them alphabetically and add language code label in order to make the reason for order clear.

## Screenshot
### Before

<img width="399" alt="before the change" src="https://user-images.githubusercontent.com/1425259/63650392-39741f00-c785-11e9-87c6-bfd45b6d111c.png">

### After

<img width="432" alt="after the change (rearrange orders and adding language code label)" src="https://user-images.githubusercontent.com/1425259/63650371-0e89cb00-c785-11e9-8dd9-1b31699448b2.png">

## Reference

I used [the way in MDN](https://developer.mozilla.org/docs/MDN/Doc_status) as reference.

<img width="1000" alt="language selector on MDN" src="https://user-images.githubusercontent.com/1425259/63650414-95d73e80-c785-11e9-9766-212edbb47db6.png">
