### PR TITLE
Update lua-resty-auto-ssl client with ACME v2 supported versions

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -275,6 +275,7 @@
 		{
 			"name": "lua-resty-auto-ssl",
 			"url": "https://github.com/GUI/lua-resty-auto-ssl",
+			"acme_v2": "lua-resty-auto-ssl >= 0.13.0",
 			"category": "nginx"
 		},
 		{


### PR DESCRIPTION
ACME v2 support was added in the v0.13.0 release: https://github.com/GUI/lua-resty-auto-ssl/releases/tag/v0.13.0