### PR TITLE
Adds "library" or "category" for clients with only the acme_v2 flag.

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -5,6 +5,7 @@
 		"C",
 		"C++",
 		"Clojure",
+		"Configuration management tools",
 		"D",
 		"Docker",
 		"Go",
@@ -668,7 +669,7 @@
 			"challenges": {
 				"TLS-ALPN-01": "ansible >= 2.7"
 			},
-			"category": "Python"
+			"category": "Configuration management tools"
 		},
 		{
 			"name": "WinCertes Windows ACMEv2 client",

--- a/data/clients.json
+++ b/data/clients.json
@@ -135,11 +135,6 @@
 	],
 	"list": [
 		{
-			"name": "Certbot",
-			"url": "https://certbot.eff.org/",
-			"acme_v2": "Certbot >= 0.22.0"
-		},
-		{
 			"name": "GetSSL",
 			"url": "https://github.com/srvrco/getssl/tree/APIv2",
 			"acme_v2": "`APIv2` branch",
@@ -626,6 +621,7 @@
 			"name": "Net::ACME2",
 			"url": "https://metacpan.org/pod/Net::ACME2",
 			"acme_v2": "true",
+			"library": "Perl",
 			"challenges": {
 				"TLS-ALPN-01": "true"
 			}
@@ -638,27 +634,32 @@
 		{
 			"name": "LEClient PHP library",
 			"url": "https://github.com/yourivw/LEClient",
-			"acme_v2": "true"
+			"acme_v2": "true",
+			"library": "PHP"
 		},
 		{
 			"name": "le-acme2-php library",
 			"url": "https://github.com/fbett/le-acme2-php",
-			"acme_v2": "true"
+			"acme_v2": "true",
+			"library": "PHP"
 		},
 		{
 			"name": "stonemax/acme2 PHP client",
 			"url": "https://github.com/stonemax/acme2",
-			"acme_v2": "true"
+			"acme_v2": "true",
+			"library": "PHP"
 		},
 		{
 			"name": "itr-acme-client PHP library",
 			"url": "https://github.com/ITronic/itr-acme-client",
-			"acme_v2": "true"
+			"acme_v2": "true",
+			"category": "PHP"
 		},
 		{
 			"name": "Certify The Web (Windows)",
 			"url": "https://certifytheweb.com",
-			"acme_v2": "v4 onwards"
+			"acme_v2": "v4 onwards",
+			"category": "Windows / IIS"
 		},
 		{
 			"name": "Ansible acme_certificate module",
@@ -666,12 +667,14 @@
 			"acme_v2": "ansible >= 2.6",
 			"challenges": {
 				"TLS-ALPN-01": "ansible >= 2.7"
-			}
+			},
+			"category": "Python"
 		},
 		{
 			"name": "WinCertes Windows ACMEv2 client",
 			"url": "https://github.com/aloopkin/WinCertes",
-			"acme_v2": "true"
+			"acme_v2": "true",
+			"category": "Windows / IIS"
 		},
 		{
 			"name": "uacme",


### PR DESCRIPTION
So they are still listed.
Also remove the Certbot client (present inline in the template)