### PR TITLE
Re-add Net::ACME2

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -340,6 +340,13 @@
 			"library": "Perl"
 		},
 		{
+			"name": "Net::ACME2",
+			"url": "https://metacpan.org/pod/Net::ACME2",
+			"acme_v2": "true",
+			"category": "Perl",
+			"library": "Perl"
+		},
+		{
 			"name": "Net::ACME",
 			"url": "https://metacpan.org/pod/Net::ACME",
 			"category": "Perl",


### PR DESCRIPTION
At some point, Net::ACME2 was removed from the list of ACME clients. This re-adds it.

Thank you!