### PR TITLE
Fix Lua category and add tests

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -11,6 +11,7 @@
 		"Go",
 		"HAProxy",
 		"Java",
+		"Lua",
 		"Microsoft Azure",
 		"nginx",
 		"Node.js",

--- a/layouts/shortcodes/clients.html
+++ b/layouts/shortcodes/clients.html
@@ -64,3 +64,15 @@
         </li>
 {{ end }}
 </ul>
+
+{{ range $.Site.Data.clients.list }}
+    {{ if and (not .category) (not .library) }}
+            {{ $.MissingLibraryOrCategory }}
+    {{ end }}
+    {{ if and .category (not (in $.Site.Data.clients.categories .category)) }}
+            {{ $.CategoryUnknow }}
+    {{ end }}
+    {{ if and .library (not (in $.Site.Data.clients.libraries .library)) }}
+            {{ $.LibraryUnknow }}
+    {{ end }}
+{{ end }}


### PR DESCRIPTION
The client from #582 had the acme_v2 flag and the "Lua" category, but because that category wasn't defined, when the ACME V2 section was removed, the client disappeared. This PR add the `Lua` category and force a build to fail if the category is unknown, the section is unknown, or one none of the two are given.