### PR TITLE
Remove unnecessary description comments from ACME Client list

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -779,22 +779,19 @@
 			"name": "lua-resty-acme",
 			"url": "https://github.com/fffonion/lua-resty-acme",
 			"category": "nginx",
-			"acme_v2": "true",
-			"comments": "Automatic Let's Encrypt certificate serving (RSA + ECC) and pure Lua implementation of the ACMEv2 protocol."
+			"acme_v2": "true"
 		},
 		{
 			"name": "acertmgr",
 			"url": "https://github.com/moepman/acertmgr",
 			"category": "Python",
-			"acme_v2": "true",
-			"comments": "Automated Certificate Manager using ACME"
+			"acme_v2": "true"
 		},
 		{
 			"name": "acme-cert-tool",
 			"url": "https://github.com/mk-fg/acme-cert-tool",
 			"category": "Python",
-			"acme_v2": "true",
-			"comments": "Simple one-stop tool to manage X.509/TLS certs and all ACME CA authorization"
+			"acme_v2": "true"
 		}
 	]
 }


### PR DESCRIPTION
Looks like lua-resty-acme started a trend of adding client description one-liner as a comments in clients list, which can be seen e.g. at the end here:
https://letsencrypt.org/docs/client-options/#clients-python

This doesn't seem to be the intended use of this field, but when adding new client to the list there, people tend to copy last item's format, and that's how these will probably continue to creep-in.
(was guilty of adding last such comment myself in #682)

IMO original use of this field for only relevant distinguishing features is a much better fit, as everything else can be found on the project page.

This commit removes such comments from last few projects, to clean up the misuse and so that anyone else adding projects to the end will have a proper example to follow.

Thanks!