### PR TITLE
Simplify the translation of docs/index

### DIFF
--- a/content/base-l10n/docs/_index.md
+++ b/content/base-l10n/docs/_index.md
@@ -6,7 +6,7 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
+lastmod: 2019-10-09
 ---
 
 # Overview
@@ -34,6 +34,7 @@ lastmod: 2019-05-15
 * [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
 * [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
 * [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
+* [Onboarding Your Customers with Let's Encrypt and ACME](/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html)
 
 # Client Developer Information
 

--- a/content/base-l10n/docs/_index.md
+++ b/content/base-l10n/docs/_index.md
@@ -1,44 +1,10 @@
 ---
-untranslated: 1
 title: Documentation
 top_graphic: 1
 menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-10-09
 ---
 
-# Overview
-
-* [Getting Started]({{< ref "/getting-started.md" >}})
-* [How Let's Encrypt Works]({{< ref "/how-it-works.md" >}})
-* [Frequently Asked Questions (FAQ)]({{< ref "/docs/faq.md" >}})
-* [Glossary]({{< ref "/docs/glossary.md" >}})
-
-# Subscriber Information
-
-* [ACME Client Implementations]({{< ref "/docs/client-options.md" >}})
-* [Rate Limits]({{< ref "/docs/rate-limits.md" >}})
-* [Expiration Emails]({{< ref "/docs/expiration-emails.md" >}})
-
-# Advanced Subscriber Information
-
-* [Staging Environment]({{< ref "/docs/staging-environment.md" >}})
-* [Certificate Compatibility]({{< ref "/docs/cert-compat.md" >}})
-* [Chain of Trust (Root and Intermediate Certificates)]({{< ref "/certificates.md" >}})
-* [Upcoming Features]({{< ref "/upcoming-features.md" >}})
-* [Revoking Certificates]({{< ref "/docs/revoking.md" >}})
-* [Certificate Authority Authorization]({{< ref "/docs/caa.md" >}})
-* [Certificates for localhost]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
-* [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
-* [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
-* [Onboarding Your Customers with Let's Encrypt and ACME](/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html)
-
-# Client Developer Information
-
-* [Client and Large Provider Integration Guide]({{< ref "/docs/integration-guide.md" >}})
-* [ACME Protocol Updates]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [Differences from Current ACME Draft](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [Finding Account IDs]({{< ref "/docs/account-id.md" >}})
+{{% docs_index %}}

--- a/content/de/certificates.md
+++ b/content/de/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: Kette des Vertrauens
+linkTitle: Kette des Vertrauens (Root und Intermediate Zertificate)
 slug: certificates
 top_graphic: 5
 lastmod: 2019-05-01

--- a/content/de/docs/_index.md
+++ b/content/de/docs/_index.md
@@ -5,38 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
 ---
 
-# Übersicht
-
-* [Loslegen]({{< ref "/getting-started.md" >}})
-* [Wie Let's Encrypt funktioniert]({{< ref "/how-it-works.md" >}})
-* [Häufig gestellte Fragen (FAQ)]({{< ref "/docs/faq.md" >}})
-* [Glossar]({{< ref "/docs/glossary.md" >}})
-
-# Teilnehmerinformationen
-
-* [ACME Client Implementierungen]({{< ref "/docs/client-options.md" >}})
-* [Rate Limits]({{< ref "/docs/rate-limits.md" >}})
-* [Ablauf-Emails]({{< ref "/docs/expiration-emails.md" >}})
-
-# Erweiterte Teilnehmerinformationen
-
-* [Staging Environment]({{< ref "/docs/staging-environment.md" >}})
-* [Zertifikatskompatibiltät]({{< ref "/docs/cert-compat.md" >}})
-* [Kette des Vertrauens (Root und Intermediate Zertificate)]({{< ref "/certificates.md" >}})
-* [Zukünfige Funktionen]({{< ref "/upcoming-features.md" >}})
-* [Zertifikate sperren]({{< ref "/docs/revoking.md" >}})
-* [Zertifizierungsstellenberechtigung]({{< ref "/docs/caa.md" >}})
-* [Zertifikate für localhost]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
-* [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
-* [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
-
-# Informationen für Client Entwickler
-
-* [Client und Provider Integrationsleitfaden]({{< ref "/docs/integration-guide.md" >}})
-* [Aktualisierungen ACME Protokoll]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [Unterschiede von derzeitigen ACME Entwürfen (englisch)](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [Account IDs finden]({{< ref "/docs/account-id.md" >}})
+{{% docs_index %}}

--- a/content/de/docs/integration-guide.md
+++ b/content/de/docs/integration-guide.md
@@ -1,5 +1,6 @@
 --- 
 title: Integrationshandbuch
+linkTitle: Client und Provider Integrationsleitfaden
 slug: integration-guide
 top_graphic: 1
 date: 2016-08-08

--- a/content/de/how-it-works.md
+++ b/content/de/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: Wie es funktioniert
+linkTitle: Wie Let’s Encrypt funktioniert
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/content/en/certificates.md
+++ b/content/en/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: Chain of Trust
+linkTitle: Chain of Trust (Root and Intermediate Certificates)
 slug: certificates
 top_graphic: 5
 lastmod: 2019-05-01

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -5,7 +5,7 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
+lastmod: 2019-10-09
 ---
 
 # Overview

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -5,39 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-10-09
 ---
 
-# Overview
-
-* [Getting Started]({{< ref "/getting-started.md" >}})
-* [How Let's Encrypt Works]({{< ref "/how-it-works.md" >}})
-* [Frequently Asked Questions (FAQ)]({{< ref "/docs/faq.md" >}})
-* [Glossary]({{< ref "/docs/glossary.md" >}})
-
-# Subscriber Information
-
-* [ACME Client Implementations]({{< ref "/docs/client-options.md" >}})
-* [Rate Limits]({{< ref "/docs/rate-limits.md" >}})
-* [Expiration Emails]({{< ref "/docs/expiration-emails.md" >}})
-
-# Advanced Subscriber Information
-
-* [Staging Environment]({{< ref "/docs/staging-environment.md" >}})
-* [Certificate Compatibility]({{< ref "/docs/cert-compat.md" >}})
-* [Chain of Trust (Root and Intermediate Certificates)]({{< ref "/certificates.md" >}})
-* [Upcoming Features]({{< ref "/upcoming-features.md" >}})
-* [Revoking Certificates]({{< ref "/docs/revoking.md" >}})
-* [Certificate Authority Authorization]({{< ref "/docs/caa.md" >}})
-* [Certificates for localhost]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
-* [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
-* [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
-* [Onboarding Your Customers with Let's Encrypt and ACME](/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html)
-
-# Client Developer Information
-
-* [Client and Large Provider Integration Guide]({{< ref "/docs/integration-guide.md" >}})
-* [ACME Protocol Updates]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [Differences from Current ACME Draft](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [Finding Account IDs]({{< ref "/docs/account-id.md" >}})
+{{% docs_index %}}

--- a/content/en/docs/integration-guide.md
+++ b/content/en/docs/integration-guide.md
@@ -1,5 +1,6 @@
 ---
 title: Integration Guide
+linkTitle: Client and Large Provider Integration Guide
 slug: integration-guide
 top_graphic: 1
 date: 2016-08-08

--- a/content/en/how-it-works.md
+++ b/content/en/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: How It Works
+linkTitle: How Let's Encrypt Works
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/content/es/certificates.md
+++ b/content/es/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: Cadena de Confianza
+linkTitle: Cadena de Confianza (Certificados Raíz e Intermedios)
 slug: certificates
 top_graphic: 5
 lastmod: 2018-09-20

--- a/content/es/docs/_index.md
+++ b/content/es/docs/_index.md
@@ -8,36 +8,4 @@ menu:
 lastmod: 2019-05-15
 ---
 
-# General
-
-* [Comenzando]({{< ref "/getting-started.md" >}})
-* [Cómo Funciona Let's Encrypt]({{< ref "/how-it-works.md" >}})
-* [Preguntas Frecuentes (FAQ)]({{< ref "/docs/faq.md" >}})
-* [Glosario]({{< ref "/docs/glossary.md" >}})
-
-# Información para Subscriptor
-
-* [ACME Client Implementations]({{< ref "/docs/client-options.md" >}})
-* [Rate Limits]({{< ref "/docs/rate-limits.md" >}})
-* [Correos Electrónicos de Vencimiento]({{< ref "/docs/expiration-emails.md" >}})
-
-# Información Avanzada para Subscriptor
-
-* [Staging Environment]({{< ref "/docs/staging-environment.md" >}})
-* [Certificate Compatibility]({{< ref "/docs/cert-compat.md" >}})
-* [Cadena de Confianza (Certificados Raíz e Intermedios)]({{< ref "/certificates.md" >}})
-* [Próximas Funcionalidades]({{< ref "/upcoming-features.md" >}})
-* [Revoking Certificates]({{< ref "/docs/revoking.md" >}})
-* [Autorización de la Autoridad de Certificación (CAA)]({{< ref "/docs/caa.md" >}})
-* [Certificados para localhost]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
-* [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
-* [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
-
-# Información para Desarrolladores de Clientes
-
-* [Client and Large Provider Integration Guide]({{< ref "/docs/integration-guide.md" >}})
-* [Actualizaciones del protocolo ACME]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [Diferencias del  Borrador ACME Actual](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [Encontrando IDs de Cuentas]({{< ref "/docs/account-id.md" >}})
-
+{{% docs_index %}}

--- a/content/es/how-it-works.md
+++ b/content/es/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: Cómo Funciona
+linkTitle: Cómo Funciona Let's Encrypt
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/content/fr/certificates.md
+++ b/content/fr/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: Chaîne de confiance
+linkTitle: Chaîne de confiance (Certificats Racines et Intermédiaires)
 slug: certificates
 top_graphic: 5
 lastmod: 2019-05-01

--- a/content/fr/docs/_index.md
+++ b/content/fr/docs/_index.md
@@ -5,7 +5,7 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
+lastmod: 2019-10-09
 ---
 
 # Vue d'ensemble
@@ -33,6 +33,7 @@ lastmod: 2019-05-15
 * [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
 * [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
 * [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
+* [Intégrer de vos clients avec Let's Encrypt et ACME](/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html)
 
 # Client Developer Information
 

--- a/content/fr/docs/_index.md
+++ b/content/fr/docs/_index.md
@@ -5,40 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-10-09
 ---
 
-# Vue d'ensemble
-
-* [Commencer]({{< ref "/getting-started.md" >}})
-* [Comment ça marche]({{< ref "/how-it-works.md" >}})
-* [Frequently Asked Questions (FAQ)]({{< ref "/docs/faq.md" >}})
-* [Glossaire]({{< ref "/docs/glossary.md" >}})
-
-# Subscriber Information
-
-* [ACME Client Implementations]({{< ref "/docs/client-options.md" >}})
-* [Rate Limits]({{< ref "/docs/rate-limits.md" >}})
-* [Expiration Emails]({{< ref "/docs/expiration-emails.md" >}})
-
-# Advanced Subscriber Information
-
-* [Staging Environment]({{< ref "/docs/staging-environment.md" >}})
-* [Certificate Compatibility]({{< ref "/docs/cert-compat.md" >}})
-* [Chaîne de confiance (Certificats Racines et Intermédiaires)]({{< ref "/certificates.md" >}})
-* [Fonctionnalités à venir]({{< ref "/upcoming-features.md" >}})
-* [Revoking Certificates]({{< ref "/docs/revoking.md" >}})
-* [Certificate Authority Authorization]({{< ref "/docs/caa.md" >}})
-* [Certificates for localhost]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
-* [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
-* [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
-* [Intégrer de vos clients avec Let's Encrypt et ACME](/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html)
-
-# Client Developer Information
-
-* [Client and Large Provider Integration Guide]({{< ref "/docs/integration-guide.md" >}})
-* [ACME Protocol Updates]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [Differences from Current ACME Draft](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [Finding Account IDs]({{< ref "/docs/account-id.md" >}})
-
+{{% docs_index %}}

--- a/content/id/docs/_index.md
+++ b/content/id/docs/_index.md
@@ -5,6 +5,7 @@ menu: "main"
 menu:
   main:
     weight: 10
+lastmod: 2019-05-15
 ---
 
 # Ringkasan

--- a/content/id/docs/_index.md
+++ b/content/id/docs/_index.md
@@ -5,38 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
 ---
 
-# Ringkasan
-
-* [Memulai]({{< ref "/getting-started.md" >}})
-* [Bagaimana Let's Encrypt Bekerja]({{< ref "/how-it-works.md" >}})
-* [Pertanyaan yang Sering Ditanyakan (FAQ)]({{< ref "/docs/faq.md" >}})
-* [Glosarium]({{< ref "/docs/glossary.md" >}})
-
-# Informasi untuk Pelanggan (*Subcriber*)
-
-* [Implementasi Klien ACME]({{< ref "/docs/client-options.md" >}})
-* [Batasan Pemanggilan]({{< ref "/docs/rate-limits.md" >}})
-* [Email Pengkadaluarsaan]({{< ref "/docs/expiration-emails.md" >}})
-
-# Informasi untuk Pelanggan Tingkat Lanjut
-
-* [*Staging Environment*]({{< ref "/docs/staging-environment.md" >}})
-* [Kompabilitas Sertifikat]({{< ref "/docs/cert-compat.md" >}})
-* [Rantai Kepercayaan (Sertifikat *Root* dan *Intermediate*)]({{< ref "/certificates.md" >}})
-* [Fitur yang Akan Datang]({{< ref "/upcoming-features.md" >}})
-* [Menarik Kembali/Mencabut Sertifikat]({{< ref "/docs/revoking.md" >}})
-* [*Certificate Authority Authorization*]({{< ref "/docs/caa.md" >}})
-* [Sertifikat untuk `localhost`]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Kiat Penggunaan - Biarkan *Port* 80 Tetap Terbuka]({{< ref "/docs/allow-port-80.md" >}})
-* [Tipe Tantangan (*Challenge*)]({{< ref "/docs/challenge-types.md" >}})
-* [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
-
-# Informasi untuk Pengembang Klien (*Client Developer*)
-
-* [Panduan Integrasi untuk Klien dan Penyedia Layanan Besar]({{< ref "/docs/integration-guide.md" >}})
-* [Pembaharuan Protokol ACME]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [Perbedaan dari draf ACME terkini](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [Mencari ID Akun]({{< ref "/docs/account-id.md" >}})
+{{% docs_index %}}

--- a/content/ja/certificates.md
+++ b/content/ja/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: Chain of Trust
+linkTitle: Chain of Trust (ルートおよび中間証明書)
 slug: certificates
 top_graphic: 5
 lastmod: 2019-05-01

--- a/content/ja/docs/_index.md
+++ b/content/ja/docs/_index.md
@@ -5,38 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
 ---
 
-# 概要
-
-* [はじめる]({{< ref "/getting-started.md" >}})
-* [Let's Encrypt の動作のしくみ]({{< ref "/how-it-works.md" >}})
-* [よくある質問 (FAQ)]({{< ref "/docs/faq.md" >}})
-* [用語集]({{< ref "/docs/glossary.md" >}})
-
-# 利用者向けの情報
-
-* [ACME クライアント実装]({{< ref "/docs/client-options.md" >}})
-* [レート制限]({{< ref "/docs/rate-limits.md" >}})
-* [期限切れ通知メール]({{< ref "/docs/expiration-emails.md" >}})
-
-# 利用者向けの発展的な情報
-
-* [ステージング環境]({{< ref "/docs/staging-environment.md" >}})
-* [証明書の互換性]({{< ref "/docs/cert-compat.md" >}})
-* [Chain of Trust (ルートおよび中間証明書)]({{< ref "/certificates.md" >}})
-* [今後追加される機能]({{< ref "/upcoming-features.md" >}})
-* [証明書の無効化]({{< ref "/docs/revoking.md" >}})
-* [認証局の認可]({{< ref "/docs/caa.md" >}})
-* [localhost のための証明書]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [ベスト・プラクティス - ポート 80 番を開放しよう]({{< ref "/docs/allow-port-80.md" >}})
-* [チャレンジの種類]({{< ref "/docs/challenge-types.md" >}})
-* [証明書透明性 (Certificate Transparency; CT) のログ]({{< ref "/docs/ct-logs.html" >}})
-
-# クライアント開発者向けの情報
-
-* [クライアントと大規模プロバイダのインテグレーションガイド]({{< ref "/docs/integration-guide.md" >}})
-* [ACME プロトコルのアップデート]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [現在の ACME ドラフトとの違い](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [アカウント ID を見つける]({{< ref "/docs/account-id.md" >}})
+{{% docs_index %}}

--- a/content/ja/how-it-works.md
+++ b/content/ja/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: 動作の仕組み
+linkTitle: Let's Encrypt の動作のしくみ
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/content/ko/certificates.md
+++ b/content/ko/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: 신뢰의 사슬
+linkTitle: 신뢰의 체인 (root 및 중간 인증서)
 slug: certificates
 top_graphic: 5
 lastmod: 2019-05-01

--- a/content/ko/docs/_index.md
+++ b/content/ko/docs/_index.md
@@ -5,38 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
 ---
 
-# 개요
-
-* [시작하기]({{< ref "/getting-started.md" >}})
-* [Let's Encrypt의 작동 방식]({{< ref "/how-it-works.md" >}})
-* [자주 묻는 질문(FAQ)]({{< ref "/docs/faq.md" >}})
-* [용어 사전]({{< ref "/docs/glossary.md" >}})
-
-# 구독자 정보
-
-* [ACME 클라이언트 구현]({{< ref "/docs/client-options.md" >}})
-* [요금 제한]({{< ref "/docs/rate-limits.md" >}})
-* [만료 이메일]({{< ref "/docs/expiration-emails.md" >}})
-
-# 고급 구독자 정보
-
-* [준비 환경]({{< ref "/docs/staging-environment.md" >}})
-* [인증서 호환성]({{< ref "/docs/cert-compat.md" >}})
-* [신뢰의 체인 (root 및 중간 인증서)]({{< ref "/certificates.md" >}})
-* [추가될 기능]({{< ref "/upcoming-features.md" >}})
-* [인증서 해지]({{< ref "/docs/revoking.md" >}})
-* [인증 기관 인증]({{< ref "/docs/caa.md" >}})
-* [로컬 호스트용 인증서]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [모범 사례 - 80번 포트를 열어 두십시오.]({{< ref "/docs/allow-port-80.md" >}})
-* [도전 유형]({{< ref "/docs/challenge-types.md" >}})
-* [인증서 투명성(CT, Certificate Transparency) 로그]({{< ref "/docs/ct-logs.html" >}})
-
-# 클라이언트 개발자 정보
-
-* [클라이언트 및 대규모 제공자 통합 안내서]({{< ref "/docs/integration-guide.md" >}})
-* [ACME 프로토콜 업데이트]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [현재 ACME 초안과 다른점](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [계정 아이디 찾기]({{< ref "/docs/account-id.md" >}})
+{{% docs_index %}}

--- a/content/ko/docs/integration-guide.md
+++ b/content/ko/docs/integration-guide.md
@@ -1,5 +1,6 @@
 ---
 title: 통합 가이드
+linkTitle: 클라이언트 및 대규모 제공자 통합 안내서
 slug: integration-guide
 top_graphic: 1
 date: 2016-08-08

--- a/content/ko/how-it-works.md
+++ b/content/ko/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: 작동 방식
+linkTitle: Let's Encrypt의 작동 방식
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/content/ko/upcoming-features.md
+++ b/content/ko/upcoming-features.md
@@ -1,6 +1,6 @@
 ---
 title: 향후 기능
-slug: 향후 기능
+slug: upcoming-features
 top_graphic: 1
 lastmod: 2019-07-03
 ---

--- a/content/pt-br/docs/_index.md
+++ b/content/pt-br/docs/_index.md
@@ -5,38 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
 ---
 
-# Visão Geral
-
-* [Começando a usar]({{< ref "/getting-started.md" >}})
-* [Como a Let's Encrypt Funciona]({{< ref "/how-it-works.md" >}})
-* [Perguntas Frequentes (FAQ)]({{< ref "/docs/faq.md" >}})
-* [Glossary]({{< ref "/docs/glossary.md" >}})
-
-# Informações Para Usuário
-
-* [Implementações de Clientes ACME]({{< ref "/docs/client-options.md" >}})
-* [Limites de Requisições]({{< ref "/docs/rate-limits.md" >}})
-* [E-mails de expiração]({{< ref "/docs/expiration-emails.md" >}})
-
-# Informações Para Usuários Avançados
-
-* [Ambiente de Testes]({{< ref "/docs/staging-environment.md" >}})
-* [Compatibilidade de Certificados]({{< ref "/docs/cert-compat.md" >}})
-* [Chain of Trust (Root and Intermediate Certificates)]({{< ref "/certificates.md" >}})
-* [Upcoming Features]({{< ref "/upcoming-features.md" >}})
-* [Revogando Certificados]({{< ref "/docs/revoking.md" >}})
-* [Autorização de Autoridade Certificadora (AAC)]({{< ref "/docs/caa.md" >}})
-* [Certificates for localhost]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
-* [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
-* [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
-
-# Informações Para Desenvolvedores de Clientes
-
-* [Client and Large Provider Integration Guide]({{< ref "/docs/integration-guide.md" >}})
-* [ACME Protocol Updates]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [Differences from Current ACME Draft](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [Finding Account IDs]({{< ref "/docs/account-id.md" >}})
+{{% docs_index %}}

--- a/content/pt-br/how-it-works.md
+++ b/content/pt-br/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: Como a Let's Encrypt Funciona
+linkTitle: Como a Let's Encrypt Funciona
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/content/ru/certificates.md
+++ b/content/ru/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: Цепочка доверия
+linkTitle: Цепочка доверия (Корневые и промежуточные сертификаты)
 slug: certificates
 top_graphic: 5
 lastmod: 2019-05-01

--- a/content/ru/docs/_index.md
+++ b/content/ru/docs/_index.md
@@ -5,38 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
 ---
 
-# Обзор
-
-* [Приступая к работе]({{< ref "/getting-started.md" >}})
-* [Как работает Let's Encrypt]({{< ref "/how-it-works.md" >}})
-* [Часто задаваемые вопросы]({{< ref "/docs/faq.md" >}})
-* [Glossary]({{< ref "/docs/glossary.md" >}})
-
-# Информация для пользователей
-
-* [Реализации ACME-клиента]({{< ref "/docs/client-options.md" >}})
-* [Ограничения]({{< ref "/docs/rate-limits.md" >}})
-* [Уведомления об истечении срока действия]({{< ref "/docs/expiration-emails.md" >}})
-
-# Расширенная информация для пользователей
-
-* [Staging Environment]({{< ref "/docs/staging-environment.md" >}})
-* [Certificate Compatibility]({{< ref "/docs/cert-compat.md" >}})
-* [Цепочка доверия (Корневые и промежуточные сертификаты)]({{< ref "/certificates.md" >}})
-* [Планируемый функционал]({{< ref "/upcoming-features.md" >}})
-* [Revoking Certificates]({{< ref "/docs/revoking.md" >}})
-* [Certificate Authority Authorization]({{< ref "/docs/caa.md" >}})
-* [Certificates for localhost]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
-* [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
-* [Журналы Certificate Transparency (CT)]({{< ref "/docs/ct-logs.html" >}})
-
-# Информация для разработчиков
-
-* [Client and Large Provider Integration Guide]({{< ref "/docs/integration-guide.md" >}})
-* [ACME Protocol Updates]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [Differences from Current ACME Draft](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [Finding Account IDs]({{< ref "/docs/account-id.md" >}})
+{{% docs_index %}}

--- a/content/ru/how-it-works.md
+++ b/content/ru/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: Как работает Let's Encrypt
+linkTitle: Как работает Let's Encrypt
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/content/sr-sp/certificates.md
+++ b/content/sr-sp/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: Lanac poverenja
+linkTitle: Chain of Trust (Root and Intermediate Certificates)
 slug: certificates
 top_graphic: 5
 lastmod: 2019-05-01

--- a/content/sr-sp/docs/_index.md
+++ b/content/sr-sp/docs/_index.md
@@ -1,5 +1,4 @@
 ---
-untranslated: 1
 title: Dokumentacija
 top_graphic: 1
 menu: "main"

--- a/content/sr-sp/docs/_index.md
+++ b/content/sr-sp/docs/_index.md
@@ -5,38 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
 ---
 
-# Pregled
-
-* [Prvi koraci]({{< ref "/getting-started.md" >}})
-* [Kako Let's Encrypt funkcioniše?]({{< ref "/how-it-works.md" >}})
-* [Često postavljena pitanja (FAQ)]({{< ref "/docs/faq.md" >}})
-* [Rečnik]({{< ref "/docs/glossary.md" >}})
-
-# Pretplatničke informacije
-
-* [ACME Client Implementations]({{< ref "/docs/client-options.md" >}})
-* [Rate Limits]({{< ref "/docs/rate-limits.md" >}})
-* [Expiration Emails]({{< ref "/docs/expiration-emails.md" >}})
-
-# Napredne pretplatničke informacije
-
-* [Staging Environment]({{< ref "/docs/staging-environment.md" >}})
-* [Certificate Compatibility]({{< ref "/docs/cert-compat.md" >}})
-* [Chain of Trust (Root and Intermediate Certificates)]({{< ref "/certificates.md" >}})
-* [Upcoming Features]({{< ref "/upcoming-features.md" >}})
-* [Revoking Certificates]({{< ref "/docs/revoking.md" >}})
-* [Certificate Authority Authorization]({{< ref "/docs/caa.md" >}})
-* [Certificates for localhost]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
-* [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
-* [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
-
-# Informacije za programere klijentskog softvera
-
-* [Client and Large Provider Integration Guide]({{< ref "/docs/integration-guide.md" >}})
-* [ACME Protocol Updates]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [Differences from Current ACME Draft](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [Finding Account IDs]({{< ref "/docs/account-id.md" >}})
+{{% docs_index %}}

--- a/content/sr-sp/how-it-works.md
+++ b/content/sr-sp/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: Kako funkcioniše?
+linkTitle: Kako Let's Encrypt funkcioniše?
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/content/zh-cn/certificates.md
+++ b/content/zh-cn/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: 证书信任链
+linkTitle: 证书信任链（根证书和中间证书）
 slug: certificates
 top_graphic: 5
 lastmod: 2019-05-01

--- a/content/zh-cn/docs/_index.md
+++ b/content/zh-cn/docs/_index.md
@@ -5,39 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
 ---
 
-# 概述
-
-* [快速入门]({{< ref "/getting-started.md" >}})
-* [Let's Encrypt 的运作方式]({{< ref "/how-it-works.md" >}})
-* [常见问题（FAQ）]({{< ref "/docs/faq.md" >}})
-* [术语表]({{< ref "/docs/glossary.md" >}})
-
-# 用户信息
-
-* [ACME 客户端]({{< ref "/docs/client-options.md" >}})
-* [速率限制]({{< ref "/docs/rate-limits.md" >}})
-* [过期提醒邮件]({{< ref "/docs/expiration-emails.md" >}})
-
-# 高级用户信息
-
-* [测试环境]({{< ref "/docs/staging-environment.md" >}})
-* [证书兼容性]({{< ref "/docs/cert-compat.md" >}})
-* [证书信任链（根证书和中间证书）]({{< ref "/certificates.md" >}})
-* [即将推出的功能]({{< ref "/upcoming-features.md" >}})
-* [吊销证书]({{< ref "/docs/revoking.md" >}})
-* [证书颁发机构授权（CAA）]({{< ref "/docs/caa.md" >}})
-* [localhost 证书]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [最佳实践——开放 80 端口]({{< ref "/docs/allow-port-80.md" >}})
-* [验证方式]({{< ref "/docs/challenge-types.md" >}})
-* [证书透明度（CT）日志]({{< ref "/docs/ct-logs.html" >}})
-
-# 客户端开发者信息
-
-* [客户端和大型提供商集成指南]({{< ref "/docs/integration-guide.md" >}})
-* [ACME 协议更新日志]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [与当前 ACME 草案的不同](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [查找账户 ID]({{< ref "/docs/account-id.md" >}})
-
+{{% docs_index %}}

--- a/content/zh-cn/docs/integration-guide.md
+++ b/content/zh-cn/docs/integration-guide.md
@@ -1,5 +1,6 @@
 ---
 title: 集成指南
+linkTitle: 客户端和大型提供商集成指南
 slug: integration-guide
 top_graphic: 1
 date: 2016-08-08

--- a/content/zh-cn/how-it-works.md
+++ b/content/zh-cn/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: Let's Encrypt 的运作方式
+linkTitle: Let's Encrypt 的运作方式
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/content/zh-tw/certificates.md
+++ b/content/zh-tw/certificates.md
@@ -1,5 +1,6 @@
 ---
 title: 憑證信任鏈
+linkTitle: 憑證信任鏈 (根和中間憑證)
 slug: certificates
 top_graphic: 5
 lastmod: 2019-05-01

--- a/content/zh-tw/docs/_index.md
+++ b/content/zh-tw/docs/_index.md
@@ -5,39 +5,6 @@ menu: "main"
 menu:
   main:
     weight: 10
-lastmod: 2019-05-15
 ---
 
-# 概括
-
-* [入門]({{< ref "/getting-started.md" >}})
-* [Let's Encrypt工作方法]({{< ref "/how-it-works.md" >}})
-* [常問問題 (FAQ)]({{< ref "/docs/faq.md" >}})
-* [Glossary]({{< ref "/docs/glossary.md" >}})
-
-# 用戶（訂戶）訊息
-
-* [ACME用戶端]({{< ref "/docs/client-options.md" >}})
-* [速率限制]({{< ref "/docs/rate-limits.md" >}})
-* [過期提醒郵件]({{< ref "/docs/expiration-emails.md" >}})
-
-# 高級用戶（訂戶）訊息
-
-* [測試環境]({{< ref "/docs/staging-environment.md" >}})
-* [憑證相容性]({{< ref "/docs/cert-compat.md" >}})
-* [憑證信任鏈 (根和中間憑證)]({{< ref "/certificates.md" >}})
-* [即將推出功能]({{< ref "/upcoming-features.md" >}})
-* [吊銷憑證]({{< ref "/docs/revoking.md" >}})
-* [憑證頒發機構授權（CAA）]({{< ref "/docs/caa.md" >}})
-* [localhost憑證]({{< ref "/docs/certificates-for-localhost.md" >}})
-* [Best Practice - Keep Port 80 Open]({{< ref "/docs/allow-port-80.md" >}})
-* [Challenge Types]({{< ref "/docs/challenge-types.md" >}})
-* [Certificate Transparency (CT) Logs]({{< ref "/docs/ct-logs.html" >}})
-
-# 用戶端開發者訊息
-
-* [用戶端和大型提供商集成指南]({{< ref "/docs/integration-guide.md" >}})
-* [ACME協議更新]({{< ref "/docs/acme-protocol-updates.md" >}})
-* [當前ACME草案變化](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
-* [查找帳戶ID]({{< ref "/docs/account-id.md" >}})
-
+{{% docs_index %}}

--- a/content/zh-tw/how-it-works.md
+++ b/content/zh-tw/how-it-works.md
@@ -1,5 +1,6 @@
 ---
 title: Let's Encrypt運作方式
+linkTitle: Let's Encrypt工作方法
 slug: how-it-works
 top_graphic: 3
 lastmod: 2019-09-09

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -109,3 +109,21 @@ other = "Benutzer in Japan"
 
 [graph_percent_https]
 other = "Prozent der Seitenaufrufe über HTTPS (14 Tage Durchschnitt)"
+
+
+
+[overview]
+other = "Übersicht"
+
+[subscriber_information]
+other = "Teilnehmerinformationen"
+
+[advanced_subscriber_information]
+other = "Erweiterte Teilnehmerinformationen"
+
+[client_developer_information]
+other = "Informationen für Client Entwickler"
+
+[acme_divergences]
+other = "Unterschiede von derzeitigen ACME Entwürfen"
+

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -127,3 +127,21 @@ other = "URI"
 
 [certificate_transparency_public_key]
 other = "Public Key"
+
+[overview]
+other = "Overview"
+
+[subscriber_information]
+other = "Subscriber Information"
+
+[advanced_subscriber_information]
+other = "Advanced Subscriber Information"
+
+[client_developer_information]
+other = "Client Developer Information"
+
+[acme_divergences]
+other = "Differences from Current ACME Draft"
+
+[onboarding_customers]
+other = "Onboarding Your Customers with Let's Encrypt and ACME"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -109,3 +109,23 @@ other = "Usuarios de Japón"
 
 [graph_percent_https]
 other = "Porcentaje de Cargas de Página sober HTTPS (Media móvil de 14 días)"
+
+
+
+
+
+[overview]
+other = "General"
+
+[subscriber_information]
+other = "Información para Subscriptor"
+
+[advanced_subscriber_information]
+other = "Información Avanzada para Subscriptor"
+
+[client_developer_information]
+other = "Información para Desarrolladores de Clientes"
+
+[acme_divergences]
+other = "Diferencias del  Borrador ACME Actual"
+

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -102,10 +102,46 @@ other = "Émis par jour"
 other = "Tous les utilisateurs"
 
 [graph_usa_users]
-other = "Utilisateurs américain"
+other = "Utilisateurs des États-Unis"
 
 [graph_japan_users]
 other = "Utilisateurs du Japon"
 
 [graph_percent_https]
 other = "Pourcentage de chargement de page en HTTPS (moyenne glissante sur 14 jours)"
+
+[certificate_transparency_name]
+other = "Nom"
+
+[certificate_transparency_role]
+other = "Rôle"
+
+[certificate_transparency_role_production]
+other = "Production"
+
+[certificate_transparency_role_test]
+other = "Test"
+
+[certificate_transparency_uri]
+other = "URI"
+
+[certificate_transparency_public_key]
+other = "Clé publique"
+
+[overview]
+other = "Vue d'ensemble"
+
+[subscriber_information]
+other = "Informations pour les utilisateurs"
+
+[advanced_subscriber_information]
+other = "Informations pour les utilisateurs avancés"
+
+[client_developer_information]
+other = "Informations pour les développeurs de client"
+
+[acme_divergences]
+other = "Différences par rapport à l'ébauche actuelle d'ACME"
+
+[onboarding_customers]
+other = "Intégrer vos clients avec Let's Encrypt et ACME"

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -109,3 +109,24 @@ other = "Pengguna dari Jepang"
 
 [graph_percent_https]
 other = "Persentase Pageload lewat HTTPS (per 14 hari moving average)"
+
+
+
+
+
+
+[overview]
+other = "Ringkasan"
+
+[subscriber_information]
+other = "Informasi untuk Pelanggan (*Subcriber*)"
+
+[advanced_subscriber_information]
+other = "Informasi untuk Pelanggan Tingkat Lanjut"
+
+[client_developer_information]
+other = "Informasi untuk Pengembang Klien (*Client Developer*)"
+
+[acme_divergences]
+other = "Perbedaan dari draf ACME terkini"
+

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -109,3 +109,21 @@ other = "日本のユーザー"
 
 [graph_percent_https]
 other = "HTTPS で読み込まれたページの割合 (14 日間の平均)"
+
+
+
+[overview]
+other = "概要"
+
+[subscriber_information]
+other = "利用者向けの情報"
+
+[advanced_subscriber_information]
+other = "利用者向けの発展的な情報"
+
+[client_developer_information]
+other = "クライアント開発者向けの情報"
+
+[acme_divergences]
+other = "現在の ACME ドラフトとの違い"
+

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -127,3 +127,22 @@ other = "URI"
 
 [certificate_transparency_public_key]
 other = "공개키"
+
+
+
+
+[overview]
+other = "개요"
+
+[subscriber_information]
+other = "구독자 정보"
+
+[advanced_subscriber_information]
+other = "고급 구독자 정보"
+
+[client_developer_information]
+other = "클라이언트 개발자 정보"
+
+[acme_divergences]
+other = "현재 ACME 초안과 다른점"
+

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -109,3 +109,20 @@ other = "Usuários do Japão"
 
 [graph_percent_https]
 other = "Porcentagem de páginas carregadas usando HTTPS (média de 14 dias)"
+
+
+
+
+
+
+[overview]
+other = "Visão Geral"
+
+[subscriber_information]
+other = "Informações Para Usuário"
+
+[advanced_subscriber_information]
+other = "Informações Para Usuários Avançados"
+
+[client_developer_information]
+other = "Informações Para Desenvolvedores de Clientes"

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -127,3 +127,20 @@ other = "URI"
 
 [certificate_transparency_public_key]
 other = "Открытый ключ"
+
+
+
+
+
+
+[overview]
+other = "Обзор"
+
+[subscriber_information]
+other = "Информация для пользователей"
+
+[advanced_subscriber_information]
+other = "Расширенная информация для пользователей"
+
+[client_developer_information]
+other = "Информация для разработчиков"

--- a/i18n/sr-sp.toml
+++ b/i18n/sr-sp.toml
@@ -109,3 +109,20 @@ other = "Korisnici iz Japana"
 
 [graph_percent_https]
 other = "Procenat učitavanja stranica (pageload) preko HTTPS (prosek za 14 dana)"
+
+
+
+
+
+
+[overview]
+other = "Pregled"
+
+[subscriber_information]
+other = "Pretplatničke informacije"
+
+[advanced_subscriber_information]
+other = "Napredne pretplatničke informacije"
+
+[client_developer_information]
+other = "Informacije za programere klijentskog softvera"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -127,3 +127,24 @@ other = "链接"
 
 [certificate_transparency_public_key]
 other = "公钥"
+
+
+
+
+
+
+[overview]
+other = "概述"
+
+[subscriber_information]
+other = "用户信息"
+
+[advanced_subscriber_information]
+other = "高级用户信息"
+
+[client_developer_information]
+other = "客户端开发者信息"
+
+[acme_divergences]
+other = "与当前 ACME 草案的不同"
+

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -80,3 +80,23 @@ other = "該網頁暫時未被翻譯。 您可以點擊 <a href=\"https://github
 [english_is_canonical]
 other = "此頁內容請以英文頁面為準"
 
+
+
+
+
+
+[overview]
+other = "概括"
+
+[subscriber_information]
+other = "用戶（訂戶）訊息"
+
+[advanced_subscriber_information]
+other = "高級用戶（訂戶）訊息"
+
+[client_developer_information]
+other = "用戶端開發者訊息"
+
+[acme_divergences]
+other = "當前ACME草案變化"
+

--- a/layouts/shortcodes/docs_index.md
+++ b/layouts/shortcodes/docs_index.md
@@ -1,0 +1,56 @@
+
+# {{ i18n "overview" }}
+
+* {{ template "link" (dict "context" . "page" "/getting-started") }}
+* {{ template "link" (dict "context" . "page" "/how-it-works") }}
+* {{ template "link" (dict "context" . "page" "/docs/faq") }}
+* {{ template "link" (dict "context" . "page" "/docs/glossary") }}
+
+# {{ i18n "subscriber_information" }}
+
+* {{ template "link" (dict "context" . "page" "/docs/client-options") }}
+* {{ template "link" (dict "context" . "page" "/docs/rate-limits") }}
+* {{ template "link" (dict "context" . "page" "/docs/expiration-emails") }}
+
+# {{ i18n "advanced_subscriber_information" }}
+
+* {{ template "link" (dict "context" . "page" "/docs/staging-environment") }}
+* {{ template "link" (dict "context" . "page" "/docs/cert-compat") }}
+* {{ template "link" (dict "context" . "page" "/certificates") }}
+* {{ template "link" (dict "context" . "page" "/upcoming-features") }}
+* {{ template "link" (dict "context" . "page" "/docs/revoking") }}
+* {{ template "link" (dict "context" . "page" "/docs/caa") }}
+* {{ template "link" (dict "context" . "page" "/docs/certificates-for-localhost") }}
+* {{ template "link" (dict "context" . "page" "/docs/allow-port-80") }}
+* {{ template "link" (dict "context" . "page" "/docs/challenge-types") }}
+* {{ template "link" (dict "context" . "page" "/docs/ct-logs") }}
+* [{{ i18n "onboarding_customers" }}](/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme)
+
+# {{ i18n "client_developer_information" }}
+
+* {{ template "link" (dict "context" . "page" "/docs/integration-guide") }}
+* {{ template "link" (dict "context" . "page" "/docs/acme-protocol-updates") }}
+* [{{ i18n "acme_divergences" }}](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)
+* {{ template "link" (dict "context" . "page" "/docs/account-id") }}
+
+{{- define "link" -}}
+{{- $page := .context.Site.GetPage .page }}
+{{- if or (not $page) (not $page.RelPermalink) }}{{ errorf "Unknown page %q" .page }}{{ end }}
+{{- $tmp := newScratch }}
+{{- if .title }}
+{{- $tmp.Set "title" .title }}
+{{- else if $page.LinkTitle }}
+{{- $tmp.Set "title" $page.LinkTitle }}
+{{- else if $page.Title }}
+{{- $tmp.Set "title" $page.Title }}
+{{- else }}{{/* search the English name of an untranslated page */}}
+    {{- range first 1 (where $page.Translations "Lang" "eq" "en") }}
+        {{- if .LinkTitle}}
+            {{- $tmp.Set "title" .LinkTitle }}
+        {{- else }}
+            {{- $tmp.Set "title" .Title }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+[{{$tmp.Get "title"}}]({{ $page.RelPermalink }})
+{{- end }}

--- a/layouts/shortcodes/i18n_status.html
+++ b/layouts/shortcodes/i18n_status.html
@@ -21,9 +21,7 @@
     </tr>
   </thead>
   <tbody>
-    {{ $pages := sort $.Site.RegularPages "RelPermalink" }}
-    {{ $pages = $pages | append (.Site.GetPage "/docs") }}
-    {{ range $pages }}
+    {{ range sort $.Site.RegularPages "RelPermalink" }}
       {{ $page := . }}
       {{ if and .Translations (not .Page.Params.do_not_translate) }}
       <tr>

--- a/layouts/shortcodes/i18n_status.html
+++ b/layouts/shortcodes/i18n_status.html
@@ -21,7 +21,9 @@
     </tr>
   </thead>
   <tbody>
-    {{ range sort $.Site.RegularPages "RelPermalink" }}
+    {{ $pages := sort $.Site.RegularPages "RelPermalink" }}
+    {{ $pages = $pages | append (.Site.GetPage "/docs") }}
+    {{ range $pages }}
       {{ $page := . }}
       {{ if and .Translations (not .Page.Params.do_not_translate) }}
       <tr>
@@ -36,10 +38,10 @@
 
         <td>
           <a href="{{ .Permalink }}">
-            {{ if  $lastmod }}
+            {{ if $lastmod }}
               {{ .Lastmod.Format "January 2, 2006" }}
             {{ else }}
-              (no lastmod date)
+              {{ errorf "Missing lastmod in %q" .RelPermalink }}
             {{ end }}
           </a>
         </td>
@@ -54,7 +56,7 @@
                 {{ if eq $lang .Language }}
                 
                 {{ if .Params.aliases }}
-                  {{ .Translations_must_not_have_aliases }}{{/* force build to fail if a translation have aliases*/}}
+                  {{ errorf "Translated page %q mush not have aliases" $page.RelPermalink }}
                 {{ end }}
 
                 <a href="{{ .Permalink }}">
@@ -64,21 +66,19 @@
                   {{ else if  $lastmod }}
                     {{ $scratch_translated.Set .Lang ( add 1 ( $scratch_translated.Get .Lang ) ) }}
                     {{ if not .Lastmod }}
-                      {{ .PageMustHaveLastMod }}
+                      {{ errorf "Missing lastmod in %q" .RelPermalink }}
                     {{ else if ne  .Lastmod $lastmod }}
                         <span style="color:orange">{{ .Lastmod.Format "January 2, 2006" }}</span>
                     {{ else }}
                       {{ $scratch_up_to_date.Set .Lang ( add 1 ( $scratch_up_to_date.Get .Lang ) ) }}
                         <span style="color:grey">{{ .Lastmod.Format "January 2, 2006" }}</span>
                     {{ end }}
-                  {{ else }}
-                    {{ .TranslationMustHaveLastMod }}
                   {{ end }}
                 </a>
                 {{ end }}
               {{ end }}
               {{ if not ( $scratch.Get "with_page") }}
-                <span style="color:red">Missing template placeholder</span>
+                {{ errorf "Missing templatte placeholder for page %q in " $page.Path $lang }}
               {{ end }}
             </td>
             {{ end }}


### PR DESCRIPTION
Move the content of `/content/en/docs/_index.md` to `layouts/shortcodes/docs_index.md` so translators don't have to translate it and keep it in sync with the English version:

- Links automatically use the `title` of the page (or `linkTitle` if provided)
- Header names (and others sentences) are moved to `i18n/en.toml`

(and a few languages fix)