### PR TITLE
clients.json: update acme_v2 compatibility for golang.org/x/crypto/acme

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -225,6 +225,7 @@
 		{
 			"name": "autocert",
 			"url": "https://godoc.org/golang.org/x/crypto/acme/autocert",
+			"acme_v2": "true",
 			"category": "Go",
 			"challenges": {
 				"TLS-ALPN-01": "true"


### PR DESCRIPTION
`golang.org/x/crypto/acme` now implements ACME v2 and should not be in gray anymore on the website

see: https://github.com/golang/go/issues/21081
cc @x1ddos @bradfitz

thanks!