### PR TITLE
Don't quote HTML entities in languages.toml.

### DIFF
--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -8,7 +8,7 @@ beforeColon= ""
 # Weight used for sorting. (alphabetical order using languageCode, with English first)
 weight = 10
 description = """
-  Let&rsquo;s&nbsp;Encrypt is a free, automated, and open certificate
+  Let's Encrypt is a free, automated, and open certificate
   authority brought to you by the non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 
@@ -20,7 +20,7 @@ languageCode= "de-de"
 beforeColon= ""
 weight = 20
 description = """
-  Let&rsquo;s&nbsp;Encrypt ist eine freie, automatisierte und offene Zertifizierungsstelle,
+  Let's Encrypt ist eine freie, automatisierte und offene Zertifizierungsstelle,
   herausgebracht für Sie durch <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 
@@ -32,7 +32,7 @@ languageCode= "es-us"
 beforeColon= "&nbsp;"
 weight = 30
 description = """
-  Let&rsquo;s&nbsp;Encrypt es una autoridad de certificación gratuita, automatizada, y abierta traida a ustedes por la organización sin ánimos de lucro <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
+  Let's Encrypt es una autoridad de certificación gratuita, automatizada, y abierta traida a ustedes por la organización sin ánimos de lucro <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 
 [fr]
@@ -43,7 +43,7 @@ languageCode= "fr-fr"
 beforeColon= "&nbsp;"
 weight = 40
 description = """
-  Let&rsquo;s&nbsp;Encrypt est une autorité de certification gratuite, automatisée et ouverte
+  Let's Encrypt est une autorité de certification gratuite, automatisée et ouverte
   apporté par l'<a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>, organisme à but non lucratif.
 """
 
@@ -55,7 +55,7 @@ languageCode= "id-id"
 beforeColon= ""
 weight = 50
 description = """
-  Let&rsquo;s&nbsp;Encrypt adalah otoritas sertifikasi terbuka yang gratis dan terotomatisasi,
+  Let's Encrypt adalah otoritas sertifikasi terbuka yang gratis dan terotomatisasi,
   dipersembahkan oleh organisasi non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 
@@ -67,7 +67,7 @@ languageCode= "ja"
 beforeColon= ""
 weight = 60
 description = """
-  Let&rsquo;s&nbsp;Encrypt is a free, automated, and open certificate
+  Let's Encrypt is a free, automated, and open certificate
   authority brought to you by the non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 
@@ -79,7 +79,7 @@ languageCode= "ko-kr"
 beforeColon= ""
 weight = 70
 description = """
-  Let&rsquo;s&nbsp;Encrypt는 <a href="https://www.abetterinternet.org/"> 비영리 인터넷 보안 연구 그룹 (ISRG)</a>에서 가져온 무료, 자동 및 공개 인증 기관입니다.
+  Let's Encrypt는 <a href="https://www.abetterinternet.org/"> 비영리 인터넷 보안 연구 그룹 (ISRG)</a>에서 가져온 무료, 자동 및 공개 인증 기관입니다.
 """
 
 [pt-br]
@@ -90,7 +90,7 @@ languageCode= "pt-br"
 beforeColon= ""
 weight = 80
 description = """
-  Let&rsquo;s&nbsp;Encrypt é uma autoridade certificadora gratuita, automatizada e aberta
+  Let's Encrypt é uma autoridade certificadora gratuita, automatizada e aberta
   que se tornou possível graças à organização sem fins lucrativos <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>
 """
 
@@ -102,7 +102,7 @@ languageCode= "ru-ru"
 beforeColon= ""
 weight = 90
 description = """
-  Let&rsquo;s&nbsp;Encrypt - это бесплатный, автоматизированный и открытый Центр Сертификации, созданный для вас
+  Let's Encrypt - это бесплатный, автоматизированный и открытый Центр Сертификации, созданный для вас
   некоммерческой организацией <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 
@@ -114,7 +114,7 @@ languageCode= "sr-sp"
 beforeColon= ""
 weight = 95
 description = """
-  Let&rsquo;s&nbsp;Encrypt je besplatno, automatizovano, i otvoreno sertifikaciono
+  Let's Encrypt je besplatno, automatizovano, i otvoreno sertifikaciono
   telo omogućeno od strane ne profitne <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a> grupe.
 """
 
@@ -126,7 +126,7 @@ languageCode= "zh-cn"
 beforeColon= ""
 weight = 100
 description = """
-  Let&rsquo;s&nbsp;Encrypt 是免费、开放和自动化的证书颁发机构。由非盈利组织<a href="https://www.abetterinternet.org/"
+  Let's Encrypt 是免费、开放和自动化的证书颁发机构。由非盈利组织<a href="https://www.abetterinternet.org/"
   style="white-space:nowrap;">互联网安全研究小组（ISRG）</a>运营。
 """
 


### PR DESCRIPTION
These get re-quoted on HTML generation, providing wrong results.

Fixes #705