### PR TITLE
Update OpenBSD acme-client

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -164,8 +164,8 @@
 			}
 		},
 		{
-			"name": "acme-client",
-			"url": "https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.sbin/acme-client/",
+			"name": "OpenBSD acme-client",
+			"url": "https://man.openbsd.org/acme-client.1",
 			"acme_v2": "OpenBSD >= 6.6",
 			"category": "C"
 		},

--- a/data/clients.json
+++ b/data/clients.json
@@ -165,7 +165,8 @@
 		},
 		{
 			"name": "acme-client",
-			"url": "https://kristaps.bsd.lv/acme-client/",
+			"url": "https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.sbin/acme-client/",
+			"acme_v2": "OpenBSD >= 6.6",
 			"category": "C"
 		},
 		{


### PR DESCRIPTION
OpenBSD's acme-client lives in OpenBSD main source.
It supports ACMEv2.
The old project website is outdated and no longer
maintained.