### PR TITLE
Fix #722 : update library_url for Go client acmetool

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -211,7 +211,7 @@
 			"url": "https://github.com/hlandau/acme",
 			"category": "Go",
 			"library": "Go",
-			"library_url": "https://github.com/hlandau/acme/tree/master/acmeapi"
+			"library_url": "https://github.com/hlandau/acmeapi"
 		},
 		{
 			"name": "Lets-proxy2",


### PR DESCRIPTION
Fix #722