### PR TITLE
Updating v2 flags for Crypt::LE and ZeroSSL Docker.

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -183,6 +183,7 @@
 		{
 			"name": "ZeroSSL",
 			"url": "https://hub.docker.com/r/zerossl/client/",
+			"acme_v2": "true",
 			"category": "Docker"
 		},
 		{
@@ -332,6 +333,7 @@
 		{
 			"name": "Crypt::LE",
 			"url": "https://metacpan.org/pod/Crypt::LE",
+			"acme_v2": "true",
 			"category": "Perl",
 			"library": "Perl"
 		},


### PR DESCRIPTION
Crypt::LE and ZeroSSL were wrongly flagged as not supporting ACME v2 when acme_v2 flag was introduced it seems. Setting that, so they would be misleadingly looking as outdated on the list.