### PR TITLE
Remove the /jobs alias in translations

### DIFF
--- a/content/de/jobs/_index.md
+++ b/content/de/jobs/_index.md
@@ -1,7 +1,0 @@
-<meta http-equiv="refresh" content="0; url=https://www.abetterinternet.org/careers/" />
-
-<script type="text/javascript">
-    window.location.href = "https://www.abetterinternet.org/careers/";
-</script>
-
-Redirecting...

--- a/content/es/jobs/_index.md
+++ b/content/es/jobs/_index.md
@@ -1,7 +1,0 @@
-<meta http-equiv="refresh" content="0; url=https://www.abetterinternet.org/careers/" />
-
-<script type="text/javascript">
-    window.location.href = "https://www.abetterinternet.org/careers/";
-</script>
-
-Redirecting...

--- a/content/fr/jobs/_index.md
+++ b/content/fr/jobs/_index.md
@@ -1,7 +1,0 @@
-<meta http-equiv="refresh" content="0; url=https://www.abetterinternet.org/careers/" />
-
-<script type="text/javascript">
-    window.location.href = "https://www.abetterinternet.org/careers/";
-</script>
-
-Redirecting...

--- a/content/ko/jobs/_index.md
+++ b/content/ko/jobs/_index.md
@@ -1,7 +1,0 @@
-<meta http-equiv="refresh" content="0; url=https://www.abetterinternet.org/careers/" />
-
-<script type="text/javascript">
-    window.location.href = "https://www.abetterinternet.org/careers/";
-</script>
-
-Redirecting...

--- a/content/ru/jobs/_index.md
+++ b/content/ru/jobs/_index.md
@@ -1,7 +1,0 @@
-<meta http-equiv="refresh" content="0; url=https://www.abetterinternet.org/careers/" />
-
-<script type="text/javascript">
-    window.location.href = "https://www.abetterinternet.org/careers/";
-</script>
-
-Redirecting...


### PR DESCRIPTION
I think that alias is useless (except in English). Cf #497 for history