### PR TITLE
Show only ACMEv2 clients on client-options.

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -24,15 +24,15 @@ We recommend that most people start with the [Certbot](https://certbot.eff.org/)
 
 If certbot does not meet your needs, or you’d simply like to try something else, there are many more clients to choose from below, grouped by the language or environment they run in.
 
-{{< clients acme_v2="ACME v2 Compatible Clients" libraries="Libraries" projects="Projects integrating with Let’s Encrypt" >}}
+{{< clients libraries="Libraries" projects="Projects integrating with Let’s Encrypt" >}}
 
-the Python [acme](https://github.com/certbot/certbot/tree/master/acme) module is part of the Certbot tree, but is also used by a number of other clients and is available as a standalone package via [PyPI](https://pypi.python.org/pypi/acme), [Debian](https://packages.debian.org/search?keywords=python-acme), [Ubuntu](https://launchpad.net/ubuntu/+source/python-acme), [Fedora](https://bodhi.fedoraproject.org/updates/?packages=python-acme) and other distributions.
+The Python [acme](https://github.com/certbot/certbot/tree/master/acme) module is part of Certbot, but is also used by a number of other clients and is available as a standalone package via [PyPI](https://pypi.python.org/pypi/acme), [Debian](https://packages.debian.org/search?keywords=python-acme), [Ubuntu](https://launchpad.net/ubuntu/+source/python-acme), [Fedora](https://bodhi.fedoraproject.org/updates/?packages=python-acme) and other distributions.
 
 {{< /clients >}}
 
 # Adding your client/project
 
-If you know of an ACME client or a project that has integrated with Let's Encrypt that is not present in the above page please submit a pull request to our [website repository](https://github.com/letsencrypt/website/) on Github, updating the `data/clients.json` file.
+If you know of an ACME client or a project that has integrated with Let's Encrypt's ACMEv2 API that is not present in the above page please submit a pull request to our [website repository](https://github.com/letsencrypt/website/) on Github, updating the `data/clients.json` file.
 
 Before submitting a pull request please make sure:
 

--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -24,6 +24,13 @@ We recommend that most people start with the [Certbot](https://certbot.eff.org/)
 
 If certbot does not meet your needs, or you’d simply like to try something else, there are many more clients to choose from below, grouped by the language or environment they run in.
 
+# ACMEv1 and ACMEv2
+
+Let's Encrypt supports the ACMEv2 API, which is compatible with the
+[final ACME standard](https://tools.ietf.org/html/rfc8555). We're [phasing out
+the older ACMEv1 API](https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/)
+in 2020 and 2021. All the clients on this list support ACMEv2.
+
 {{< clients libraries="Libraries" projects="Projects integrating with Let’s Encrypt" >}}
 
 The Python [acme](https://github.com/certbot/certbot/tree/master/acme) module is part of Certbot, but is also used by a number of other clients and is available as a standalone package via [PyPI](https://pypi.python.org/pypi/acme), [Debian](https://packages.debian.org/search?keywords=python-acme), [Ubuntu](https://launchpad.net/ubuntu/+source/python-acme), [Fedora](https://bodhi.fedoraproject.org/updates/?packages=python-acme) and other distributions.

--- a/data/clients.json
+++ b/data/clients.json
@@ -99,8 +99,7 @@
 		},
 		{
 			"name": "Synchronet BBS System",
-			"url": "http://www.synchro.net",
-			"comments": "(ACMEv2 only)"
+			"url": "http://www.synchro.net"
 		},
 		{
 			"name": "ruxy",
@@ -247,7 +246,7 @@
 			"category": "HAProxy"
 		},
 		{
-			"name": "HAProxy ACME v2 client",
+			"name": "HAProxy client",
 			"url": "https://github.com/haproxytech/haproxy-lua-acme",
 			"acme_v2": "true",
 			"category": "HAProxy"
@@ -669,7 +668,7 @@
 			"category": "Configuration management tools"
 		},
 		{
-			"name": "WinCertes Windows ACMEv2 client",
+			"name": "WinCertes Windows client",
 			"url": "https://github.com/aloopkin/WinCertes",
 			"acme_v2": "true",
 			"category": "Windows / IIS"
@@ -708,7 +707,6 @@
 			"url": "https://github.com/cschlote/acme-lw-d",
 			"category": "D",
 			"library": "D",
-			"comments": "An ACME v2 client/library written in the D computer language",
 			"acme_v2": "true"
 		},
 		{

--- a/layouts/shortcodes/clients.html
+++ b/layouts/shortcodes/clients.html
@@ -3,15 +3,14 @@
     {{ $category := . }}
     <ul>
     {{ range $.Site.Data.clients.list }}
-        {{ if eq $category .category }}
-        <li {{ if not .acme_v2 }}style="color:grey"{{ end }}>
-            <a {{ if not .acme_v2 }}style="color:grey"{{ end }} href="{{ .url }}">{{ .name }}</a>
+        {{ if and .acme_v2 (eq $category .category) }}
+        <li>
+            <a href="{{ .url }}">{{ .name }}</a>
             {{ if .category_comments }}
                 {{ .category_comments | markdownify }}
             {{ else if .comments }}
                 {{ .comments | markdownify }}
             {{ end }}
-            {{ if not .acme_v2 }}<a href="#acme_v1">*</a>{{ end }}
         </li>
         {{ end }}
     {{ end }}
@@ -30,27 +29,19 @@
         <li>{{ $certbot | markdownify }}</li>
     {{ end }}
     {{ range $.Site.Data.clients.list }}
-        {{ if eq $library .library }}
-        <li {{ if not .acme_v2 }}style="color:grey"{{ end }}>
-            <a {{ if not .acme_v2 }}style="color:grey"{{ end }} href="{{ if .library_url }}{{ .library_url }}{{ else }}{{ .url }}{{ end }}">{{ .name }}</a>
+        {{ if and .acme_v2 (eq $library .library) }}
+        <li>
+            <a href="{{ if .library_url }}{{ .library_url }}{{ else }}{{ .url }}{{ end }}">{{ .name }}</a>
             {{ if .library_comments }}
                 {{ .library_comments | markdownify }}
             {{ else if .comments }}
                 {{ .comments | markdownify }}
             {{ end }}
-            {{ if not .acme_v2 }}<a href="#acme_v1">*</a>{{ end }}
         </li>
         {{ end }}
     {{ end }}
     </ul>
 {{ end }}
-
-<div id="acme_v1">
-    * Clients in <span style="color:grey">grey</span> don't support the new ACME v2 API, only the old, deprecated API ACME v1. They will be removed from this list soon.
-</div>
-<div>
-    Note for clients developers: If your client is compatible with ACME v2 but appears in <span style="color:grey">grey</span>, please submit a pull-request to update <code>data/clients.json</code> on <a href="https://github.com/letsencrypt/website">https://github.com/letsencrypt/website</a>
-</div>
 
 <h1 id="projects-integrating-with-let-s-encrypt">{{ .Get "projects" }}</h1>
 


### PR DESCRIPTION
Now that account creation is disabled, it doesn't make sense to
recommend a v1 client to any new users.
    
Tidied up the description of the Python acme module.
    
Removed the note to developers about submitting edits for upgrades to
v2. We have a footer with instructions on adding clients. I added an
ACMEv2 mention there.

Removed "v2" language from client comments. Since all displayed
comments now support ACMEv2, it would be confusing for only
some clients to mention it.

Add a heading section addressing ACMEv1 deprecation.