### PR TITLE
Update FAQ page lastmod date

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: Frequently Asked Questions (FAQ)
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2017-07-06
+lastmod: 2019-11-14
 menu:
   main:
     weight: 30


### PR DESCRIPTION
The FAQ page was updated via https://github.com/letsencrypt/website/pull/764 but the lastmod date still says 2017.