### PR TITLE
Update acme-lw library to V2

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -167,7 +167,9 @@
 		{
 			"name": "acme-lw",
 			"url": "https://github.com/jmccl/acme-lw",
-			"category": "C++"
+			"category": "C++",
+			"acme_v2": "true",
+			"library": "C++"
 		},
 		{
 			"name": "certificaat",

--- a/data/clients.json
+++ b/data/clients.json
@@ -24,6 +24,7 @@
 		"Windows / IIS"
 	],
 	"libraries": [
+		"C++",
 		"D",
 		"Delphi",
 		"Go",
@@ -168,7 +169,7 @@
 			"name": "acme-lw",
 			"url": "https://github.com/jmccl/acme-lw",
 			"category": "C++",
-			"acme_v2": "true",
+			"acme_v2": "acme-lw >= v0.2",
 			"library": "C++"
 		},
 		{


### PR DESCRIPTION
I updated the code to use the V2 endpoint. From looking at the source, this change will end up updating the website somehow. If that's not the case please point me at what I should be changing.