### PR TITLE
Add country to ISRG address in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -38,7 +38,7 @@
 
       <div class="footer-col  footer-col-2">
         <p class="text">{{ .Site.Params.description | safeHTML }}</p>
-        <div itemscope itemtype="https://schema.org/PostalAddress">
+        <div itemscope itemtype="http://schema.org/PostalAddress">
           <span itemprop="streetAddress">1 Letterman Drive, Suite D4700</span>,
           <span itemprop="addressLocality">San Francisco</span>,
           <span itemprop="addressRegion">CA</span>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -38,11 +38,12 @@
 
       <div class="footer-col  footer-col-2">
         <p class="text">{{ .Site.Params.description | safeHTML }}</p>
-        <div itemscope itemtype="http://schema.org/PostalAddress">
-          <span itemprop="streetAddress">1 Letterman Drive, Suite D4700,</span>
-          <span itemprop="addressLocality">San Francisco,</span>
+        <div itemscope itemtype="https://schema.org/PostalAddress">
+          <span itemprop="streetAddress">1 Letterman Drive, Suite D4700</span>,
+          <span itemprop="addressLocality">San Francisco</span>,
           <span itemprop="addressRegion">CA</span>
-          <span itemprop="postalCode">94129</span>
+          <span itemprop="postalCode">94129</span>,
+          <span itemprop="addressCountry">USA</span>
         </div>
         <p class="text">{{ i18n "linux_foundation_trademark" }}</p>
       </div>


### PR DESCRIPTION
Even though San Francisco is a world-famous city and letters probably
will be delivered anyway, include the country "USA" in the address so
that people outside USA can easier send properly addressed letters.
Within USA it hopefully doesn't hurt to state the country as well.

Also move some comma separators outside of the schema defined fields
since they're not part of the field.