### PR TITLE
Doc index: Add .html suffix to link to blog post

### DIFF
--- a/layouts/shortcodes/docs_index.md
+++ b/layouts/shortcodes/docs_index.md
@@ -25,7 +25,7 @@
 * {{ template "link" (dict "context" . "page" "/docs/challenge-types") }}
 * {{ template "link" (dict "context" . "page" "/docs/ct-logs") }}
 * {{ template "link" (dict "context" . "page" "/docs/godaddy") }}
-* [{{ i18n "onboarding_customers" }}](/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme)
+* [{{ i18n "onboarding_customers" }}](/2019/10/09/onboarding-your-customers-with-lets-encrypt-and-acme.html)
 
 # {{ i18n "client_developer_information" }}
 


### PR DESCRIPTION
The link to the blog post about onboarding customers with Let's Encrypt
and ACME in the documentation index doesn't work using "hugo server -F"
(Hugo v0.59.1), but it works on the live site and on Netlify pull
request previews.

Add the missing .html suffix to the link in order to make it work
locally as well.