### PR TITLE
FAQ: New Google Safe Browsing URL

### DIFF
--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: Frequently Asked Questions (FAQ)
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2019-11-14
+lastmod: 2019-12-22
 menu:
   main:
     weight: 30
@@ -49,7 +49,7 @@ Here's a [video we like](https://www.youtube.com/watch?v=Xe1TZaElTAs) about the 
 
 We recommend reporting such sites to Google Safe Browsing and the Microsoft Smart Screen program, which are able to more effectively protect users. Here is the Google reporting URL:
 
-https://www.google.com/safebrowsing/report_badware/
+https://safebrowsing.google.com/safebrowsing/report\_badware/
 
 If you'd like to read more about our policies and rationale, you can do so here:
 

--- a/content/ru/docs/faq.md
+++ b/content/ru/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: Часто задаваемые вопросы
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2019-11-14
+lastmod: 2019-12-22
 menu:
   main:
     weight: 30
@@ -50,7 +50,7 @@ Let’s Encrypt - небольшая компания, мы полагаемся
 Мы рекомендуем уведомить об этом сервисы Google Safe Browsing и Microsoft Smart Screen, которые способны эффективно защитить пользователей Интернета.
 Ниже ссылка на форму сообщения::
 
-https://www.google.com/safebrowsing/report_badware/
+https://safebrowsing.google.com/safebrowsing/report\_badware/
 
 Хотите узнать больше? Ознакомьтесь со статьёй [из нашего блога](/2015/10/29/phishing-and-malware.html).
 

--- a/content/sv/docs/faq.md
+++ b/content/sv/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: Vanliga frågor (FAQ)
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2019-11-14
+lastmod: 2019-12-22
 menu:
   main:
     weight: 30
@@ -72,7 +72,7 @@ Vi rekommenderar att rapportera sådana sajter till Google Safe Browsing och
 Microsofts SmartScreen-initiativ som har möjlighet att mer effektivt skydda
 användare. Här är Googles rapporteringsadress:
 
-https://www.google.com/safebrowsing/report\_badware/
+https://safebrowsing.google.com/safebrowsing/report\_badware/
 
 Om du vill läsa mer om våra policyer och principer kan du göra detta här:
 


### PR DESCRIPTION
The URL https://www.google.com/safebrowsing/report_badware/ is used in
the FAQ but it redirects to
https://safebrowsing.google.com/safebrowsing/report_badware/ nowadays.
Change the URL to save the visitor a redirect.

Also escape the underscore in the URL since that's proper Markdown (vim
marks it with red otherwise).

Update all up-to-date translations to avoid unnecessary warnings about
out-of-date translation.