### PR TITLE
Use netlify.toml to specify Hugo version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build.environment]
-HUGO_VERSION = "0.61.0"
+HUGO_VERSION = "0.55.6"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build.environment]
-HUGO_VERSION = "0.55.6"
+HUGO_VERSION = "0.61.0"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+HUGO_VERSION = "0.55.6"


### PR DESCRIPTION
Docs: https://gohugo.io/hosting-and-deployment/hosting-on-netlify/#configure-hugo-version-in-netlify

I tested that it correctly override the  HUGO_VERSION specified in the "Environment variables" of the Netlify config.

It think it's better to specify it here (than in https://app.netlify.com/sites/XXX/settings/deploys) so a simple PR can upgrade it's version, and it's publicly documented.