### PR TITLE
Update to Hugo 62

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: generic
 
 before_install:
-  - wget https://github.com/gohugoio/hugo/releases/download/v0.55.6/hugo_0.55.6_Linux-64bit.deb
-  - echo "afab8eaf12a9d72a072288f4ec5012cd889374cd56a855639b6ee1ba1686d174 hugo_0.55.6_Linux-64bit.deb" | sha256sum -c - || exit 1;
-  - sudo dpkg -i hugo_0.55.6_Linux-64bit.deb
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.62.0/hugo_0.62.0_Linux-64bit.deb
+  - echo "79e4594a891bf5b04997b175d549da6f3e3f913cd19c69fef7c289e50c63867c hugo_0.55.6_Linux-64bit.deb" | sha256sum -c - || exit 1;
+  - sudo dpkg -i hugo_0.62.0_Linux-64bit.deb
 
 install:
   - hugo env

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 
 before_install:
   - wget https://github.com/gohugoio/hugo/releases/download/v0.62.0/hugo_0.62.0_Linux-64bit.deb
-  - echo "79e4594a891bf5b04997b175d549da6f3e3f913cd19c69fef7c289e50c63867c hugo_0.55.6_Linux-64bit.deb" | sha256sum -c - || exit 1;
+  - echo "79e4594a891bf5b04997b175d549da6f3e3f913cd19c69fef7c289e50c63867c hugo_0.62.0_Linux-64bit.deb" | sha256sum -c - || exit 1;
   - sudo dpkg -i hugo_0.62.0_Linux-64bit.deb
 
 install:

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -41,7 +41,16 @@ baseName = "feed"
 
 # Hugo >= 0.33 is needed to get uglyURLs per section.
 [uglyURLs]
-  post = true
+post = true
 
 [permalinks]
-  post = "/:year/:month/:day/:slug/"
+post = "/:year/:month/:day/:slug/"
+
+[markup]
+# Since Hugo 60, goldmark is he default markdown renderer
+# and the currents .md files are not compatible with it (even with "[markup.goldmark.renderer] unsafe = true")
+defaultMarkdownHandler = "blackFriday"
+
+[markup.highlight]
+# There is an escaping bug with blackFriday and highlight. See https://discourse.gohugo.io/t/missing-escaping-in-code-blocks/22465
+codeFences = false

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build.environment]
-HUGO_VERSION = "0.55.6"
+HUGO_VERSION = "0.62.0"


### PR DESCRIPTION
- Keeps blackFriday as the markdown parser (goldmark is the new default since hugo 60, and the .md pages are not currently compatible with it and the `id` generation algorithm is different from § name)
- Keeps code highlight = false (true is the new default since hugo 60 but it has an escaping bug with blackFriday)

Tested with netlify: Hugo 62 is supported.

The diff is:
- Hugo version in meta/rss (of course)
- Insignificant whitespace
- In sitemaps `<priority>0</priority>` is added

Full diff:

```diff
diff -r 55.6/de/feed.xml 62.0/de/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/de/index.html 62.0/de/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/de/sitemap.xml 62.0/de/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
78d77
<     <priority>0</priority>
diff -r 55.6/en/sitemap.xml 62.0/en/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
78d77
<     <priority>0</priority>
1144d1142
<     <priority>0</priority>
diff -r 55.6/es/feed.xml 62.0/es/feed.xml
9c9
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/es/index.html 62.0/es/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/es/sitemap.xml 62.0/es/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
78d77
<     <priority>0</priority>
diff -r 55.6/feed.xml 62.0/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/fr/feed.xml 62.0/fr/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/fr/index.html 62.0/fr/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/fr/sitemap.xml 62.0/fr/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
78d77
<     <priority>0</priority>
diff -r 55.6/id/feed.xml 62.0/id/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/id/index.html 62.0/id/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/id/sitemap.xml 62.0/id/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
8d7
<     <priority>0</priority>
diff -r 55.6/index.html 62.0/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/ja/feed.xml 62.0/ja/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/ja/index.html 62.0/ja/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/ja/sitemap.xml 62.0/ja/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
8d7
<     <priority>0</priority>
diff -r 55.6/ko/feed.xml 62.0/ko/feed.xml
9c9
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/ko/index.html 62.0/ko/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/ko/sitemap.xml 62.0/ko/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
8d7
<     <priority>0</priority>
diff -r 55.6/pt-br/feed.xml 62.0/pt-br/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/pt-br/index.html 62.0/pt-br/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/pt-br/sitemap.xml 62.0/pt-br/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
78d77
<     <priority>0</priority>
diff -r 55.6/ru/feed.xml 62.0/ru/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/ru/index.html 62.0/ru/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/ru/sitemap.xml 62.0/ru/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
8d7
<     <priority>0</priority>
diff -r 55.6/sitemap.xml 62.0/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
diff -r 55.6/sr-sp/feed.xml 62.0/sr-sp/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/sr-sp/index.html 62.0/sr-sp/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/sr-sp/sitemap.xml 62.0/sr-sp/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
8d7
<     <priority>0</priority>
diff -r 55.6/sv/feed.xml 62.0/sv/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/sv/index.html 62.0/sv/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/sv/sitemap.xml 62.0/sv/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
78d77
<     <priority>0</priority>
diff -r 55.6/zh-cn/feed.xml 62.0/zh-cn/feed.xml
10c10
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/zh-cn/index.html 62.0/zh-cn/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/zh-cn/sitemap.xml 62.0/zh-cn/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
8d7
<     <priority>0</priority>
diff -r 55.6/zh-tw/feed.xml 62.0/zh-tw/feed.xml
9c9
<     <generator>Hugo v0.55.6</generator>
---
>     <generator>Hugo v0.62.0</generator>
diff -r 55.6/zh-tw/index.html 62.0/zh-tw/index.html
7c7
< 	<meta name="generator" content="Hugo 0.55.6" />
---
> 	<meta name="generator" content="Hugo 0.62.0" />
diff -r 55.6/zh-tw/sitemap.xml 62.0/zh-tw/sitemap.xml
1c1
< <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
---
> <?xml version="1.0" encoding="utf-8" standalone="yes"?>
8d7
<     <priority>0</priority>

```