### PR TITLE
Add the Ambassador Edge Stack project

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -8,6 +8,7 @@
 		"Configuration management tools",
 		"D",
 		"Docker",
+		"Envoy Proxy",
 		"Go",
 		"HAProxy",
 		"Java",
@@ -129,6 +130,10 @@
 		{
 			"name": "Apache HTTP Server",
 			"url": "https://httpd.apache.org"
+		},
+		{
+			"name": "Ambassador Edge Stack",
+			"url": "https://www.getambassador.io"
 		}
 	],
 	"list": [
@@ -816,6 +821,12 @@
 			"comments": "allows IoT devices to get certificates",
 			"acme_v2": "true",
 			"library": "C++"
-		}
+		},
+		{
+			"name": "Ambassador Edge Stack",
+			"url": "https://www.getambassador.io",
+			"acme_v2": "true",
+			"category": "Envoy Proxy"
+		},
 	]
 }

--- a/data/clients.json
+++ b/data/clients.json
@@ -827,6 +827,6 @@
 			"url": "https://www.getambassador.io",
 			"acme_v2": "true",
 			"category": "Envoy Proxy"
-		},
+		}
 	]
 }


### PR DESCRIPTION
Ambassador is an API Gateway built on Envoy Proxy and written for Kubernetes users. It includes Acme v2 support.