### PR TITLE
acmetool ACMEv2 support

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -215,7 +215,7 @@
 			"url": "https://github.com/hlandau/acmetool",
 			"category": "Go",
 			"library": "Go",
-			"library_url": "https://github.com/hlandau/acmeapi"
+			"library_url": "https://github.com/hlandau/acmeapi",
 			"acme_v2": "acmetool >= v0.2.1"
 		},
 		{

--- a/data/clients.json
+++ b/data/clients.json
@@ -212,10 +212,11 @@
 		},
 		{
 			"name": "acmetool",
-			"url": "https://github.com/hlandau/acme",
+			"url": "https://github.com/hlandau/acmetool",
 			"category": "Go",
 			"library": "Go",
 			"library_url": "https://github.com/hlandau/acmeapi"
+			"acme_v2": "acmetool >= v0.2.1"
 		},
 		{
 			"name": "Lets-proxy2",


### PR DESCRIPTION
ACME v2 support since https://github.com/hlandau/acmetool/releases/tag/v0.2.1
Also, homepage URL change