### PR TITLE
Enable HSTS preload and includeSubDomains

### DIFF
--- a/content/en/_headers
+++ b/content/en/_headers
@@ -5,3 +5,4 @@
     X-Content-Type-Options: nosniff
     Referrer-Policy: no-referrer
     Feature-Policy: geolocation none;midi none;notifications none;push none;sync-xhr none;microphone none;camera none;magnetometer none;gyroscope none;speaker self;vibrate none;fullscreen self;
+    Strict-Transport-Security: max-age=31536000; includeSubDomains; preload


### PR DESCRIPTION
I don't see any good reason why letsencrypt.org **or any of it's subdomains** should be accessible with *http* (instead of *https*) from a webbrowser (as HSTS is for them)

- The current header is the Netlify default: `Strict-Transport-Security: max-age=31536000`
- The effect of `includeSubDomains` is to instruct a webbrowser who visited letsencrypt.org that it must use https for all subdomains (and not only first-level subdomains)
- The effect of `preload` is to allow letsencrypt.org to be added to the Chromium preload list at https://hstspreload.org (`includeSubDomains` is required for that)

NB: some *http* domains/urls are legitimate, such as  http://ocsp.int-x3.letsencrypt.org (OCSP) or http://cert.int-x3.letsencrypt.org/ (CA Issuers) but HSTS shouldn't impact http clients that contacts them.

Once this PR is merged, anybody can add letsencrypt.org to https://hstspreload.org/?domain=letsencrypt.org which will impact Chromium (Chrome, Edge, ...) and later Firefox.

I open this PR in `draft` mode only to be sure it's not merged without careful consideration.