### PR TITLE
The lang select menu stays on the same page

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,20 +27,20 @@
           </li>
           {{ end }}
           {{ $home := .Site.Home }}
-          {{ if gt (len $home.AllTranslations ) 1 }}
+          {{ $langs := slice }}
+          {{ if .Translations }}
+            {{ range .AllTranslations }}
+              {{ $langs = $langs | append . }}
+            {{ end }}
+          {{ else }}
+            {{ range $home.AllTranslations }}
+              {{ $langs = $langs | append . }}
+            {{ end }}
+          {{ end }}
+          {{ if gt (len $langs ) 1 }}
           <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
             <a href="#" class="pure-menu-link">{{ i18n "languages" }} </a>
             <ul class="pure-menu-children">
-              {{ $langs := slice }}
-              {{ if .Translations }}
-                {{ range .Translations }}
-                  {{ $langs = $langs | append . }}
-                {{ end }}
-              {{ else }}
-                {{ range $home.AllTranslations }}
-                  {{ $langs = $langs | append . }}
-                {{ end }}
-              {{ end }}
               {{ range $langs }}
               {{ $isCurrentLang := eq $home.Language .Language }}
               <li class="pure-menu-item">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,7 +31,17 @@
           <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
             <a href="#" class="pure-menu-link">{{ i18n "languages" }} </a>
             <ul class="pure-menu-children">
-              {{ range $home.AllTranslations }}
+              {{ $langs := slice }}
+              {{ if .Translations }}
+                {{ range .Translations }}
+                  {{ $langs = $langs | append . }}
+                {{ end }}
+              {{ else }}
+                {{ range $home.AllTranslations }}
+                  {{ $langs = $langs | append . }}
+                {{ end }}
+              {{ end }}
+              {{ range $langs }}
               {{ $isCurrentLang := eq $home.Language .Language }}
               <li class="pure-menu-item">
                 <a href="{{ .RelPermalink }}" lang="{{ .Language.Params.languageCode }}" hreflang="{{ .Language.Params.languageCode }}" class="pure-menu-link">{{ if $isCurrentLang  }}✓ {{ end }}{{ .Language.LanguageName }}</a>


### PR DESCRIPTION
When on a page that can be translated (not a blog page), the menu stays on that page, only change the lang. On other pages, it goes to the home of the selected language.