### PR TITLE
Adds an icon in the select lang menu

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -29,7 +29,7 @@
           {{ $home := .Site.Home }}
           {{ if gt (len $home.AllTranslations ) 1 }}
           <li class="pure-menu-item pure-menu-has-children pure-menu-allow-hover">
-            <a href="#" class="pure-menu-link">{{ i18n "languages" }} </a>
+            <a href="#" class="pure-menu-link">{{ i18n "languages" }} <span class="fas fa-language fa-lg" aria-hidden="true"></span></a>
             <ul class="pure-menu-children">
               {{ range $home.AllTranslations }}
               {{ $isCurrentLang := eq $home.Language .Language }}


### PR DESCRIPTION
To make it more visible, with an icon respecting best practices (*not* a flag) 

![image](https://user-images.githubusercontent.com/1955774/73146997-a46bae00-40b5-11ea-871e-c19509524a81.png)

But maybe that icon could be better: http://www.languageicon.org/ ?
![image](https://user-images.githubusercontent.com/1955774/73147060-00cecd80-40b6-11ea-8f11-7130a9a0bb20.png)
