### PR TITLE
Add referral header when navigating to Webtrust seals

### DIFF
--- a/content/en/_headers
+++ b/content/en/_headers
@@ -1,7 +1,11 @@
+/repository
+    # CPA of Canada requires a referral header when attempting to view the Webtrust seals
+    Referrer-Policy: origin-when-cross-origin;
+
 /*
     Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline' 'self' https://cdnjs.cloudflare.com; script-src 'unsafe-eval' 'unsafe-inline' 'self' data: https://www.google-analytics.com https://www.googleadservices.com https://www.googletagmanager.com https://googleads.g.doubleclick.net https://donorbox.org https://js.stripe.com/v3/ https://sdks.shopifycdn.com; img-src 'self' data: https://www.google-analytics.com https://www.paypal.com https://www.paypalobjects.com https://ak2s.abmr.net https://ak1s.abmr.net https://www.google.com https://cdn.shopify.com https://v.shopify.com; frame-src https://donorbox.org https://www.youtube.com https://www.youtube-nocookie.com https://bid.g.doubleclick.net https://js.stripe.com/v3/ https://js.stripe.com/v2/; font-src 'self' https://cdnjs.cloudflare.com;connect-src 'self' https://d4twhgtvn0ff5.cloudfront.net/ https://letsencrypt-merch.myshopify.com;
     X-Frame-Options: DENY
     X-XSS-Protection: 1; mode=block
     X-Content-Type-Options: nosniff
-    Referrer-Policy: origin-when-cross-origin;
+    Referrer-Policy: no-referrer
     Feature-Policy: geolocation none;midi none;notifications none;push none;sync-xhr none;microphone none;camera none;magnetometer none;gyroscope none;speaker self;vibrate none;fullscreen self;

--- a/content/en/_headers
+++ b/content/en/_headers
@@ -1,7 +1,3 @@
-/repository
-    # CPA of Canada requires a referral header when attempting to view the Webtrust seals
-    Referrer-Policy: origin-when-cross-origin;
-
 /*
     Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline' 'self' https://cdnjs.cloudflare.com; script-src 'unsafe-eval' 'unsafe-inline' 'self' data: https://www.google-analytics.com https://www.googleadservices.com https://www.googletagmanager.com https://googleads.g.doubleclick.net https://donorbox.org https://js.stripe.com/v3/ https://sdks.shopifycdn.com; img-src 'self' data: https://www.google-analytics.com https://www.paypal.com https://www.paypalobjects.com https://ak2s.abmr.net https://ak1s.abmr.net https://www.google.com https://cdn.shopify.com https://v.shopify.com; frame-src https://donorbox.org https://www.youtube.com https://www.youtube-nocookie.com https://bid.g.doubleclick.net https://js.stripe.com/v3/ https://js.stripe.com/v2/; font-src 'self' https://cdnjs.cloudflare.com;connect-src 'self' https://d4twhgtvn0ff5.cloudfront.net/ https://letsencrypt-merch.myshopify.com;
     X-Frame-Options: DENY

--- a/content/en/_headers
+++ b/content/en/_headers
@@ -3,5 +3,5 @@
     X-Frame-Options: DENY
     X-XSS-Protection: 1; mode=block
     X-Content-Type-Options: nosniff
-    Referrer-Policy: no-referrer
+    Referrer-Policy: origin-when-cross-origin;
     Feature-Policy: geolocation none;midi none;notifications none;push none;sync-xhr none;microphone none;camera none;magnetometer none;gyroscope none;speaker self;vibrate none;fullscreen self;

--- a/content/en/repository.md
+++ b/content/en/repository.md
@@ -86,8 +86,8 @@ do_not_translate: 1
 
 ## Operational Audits
 
-* August 31, 2019: [Trust Services Principles and Criteria for Certification Authorities Version 2.1](https://www.cpacanada.ca/webtrustseal?sealid=10336)
-* August 31, 2019: [WebTrust Principles and Criteria for Certification Authorities – SSL Baseline with Network Security – Version 2.3](https://www.cpacanada.ca/webtrustseal?sealid=10337)
+* August 31, 2019: <a href="https://www.cpacanada.ca/webtrustseal?sealid=10336" referrerpolicy=origin>Trust Services Principles and Criteria for Certification Authorities Version 2.1</a>
+* August 31, 2019: <a href="https://www.cpacanada.ca/webtrustseal?sealid=10337" referrerpolicy=origin>WebTrust Principles and Criteria for Certification Authorities – SSL Baseline with Network Security – Version 2.3</a>
 * November 30, 2018: [Trust Services Principles and Criteria for Certification Authorities Version 2.1](/audits/ISRG-2018-WebTrust-for-CAs-Report.pdf)
 * November 30, 2018: [WebTrust Principles and Criteria for Certification Authorities – SSL Baseline with Network Security – Version 2.3](/audits/ISRG-2018-WebTrust-for-CAs-SSL-Baseline-Report.pdf)
 * December 15, 2017: [Trust Services Principles and Criteria for Certification Authorities Version 2.0](/audits/ISRG-2017-WebTrust-for-CAs-Report.pdf)


### PR DESCRIPTION
The CPA of Canada requires a referral header to be sent to allow access to the newest Webtrust audit seals.
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

I should be able to click on the following links in the repository and see the seals.
* August 31, 2019: https://www.cpacanada.ca/webtrustseal?sealid=10336
* August 31, 2019: https://www.cpacanada.ca/webtrustseal?sealid=10337

Testing
```
curl -I --referer https://letsencrypt.org https://www.cpacanada.ca/webtrustseal?sealid=10336
curl -I --referer https://letsencrypt.org https://www.cpacanada.ca/webtrustseal?sealid=10337
```