### PR TITLE
content: getting-started pg, link ACME to RFC 8555.

### DIFF
--- a/content/en/getting-started.md
+++ b/content/en/getting-started.md
@@ -12,7 +12,7 @@ To enable HTTPS on your website, you need to get a certificate (a type of file)
 from a Certificate Authority (CA). Let's Encrypt is a CA. In order to get a
 certificate for your website's domain from Let's Encrypt, you have to demonstrate
 control over the domain. With Let's Encrypt, you do this using software that uses
-the [ACME protocol](https://ietf-wg-acme.github.io/acme/), which typically runs
+the [ACME protocol](https://tools.ietf.org/html/rfc8555) which typically runs
 on your web host.
 
 To figure out what method will work best for you, you will need to know whether

--- a/content/en/getting-started.md
+++ b/content/en/getting-started.md
@@ -3,7 +3,7 @@ title: Getting Started
 slug: getting-started
 top_graphic: 3
 aliases : [/howitworks]
-date: 2019-12-21
+date: 2020-02-04
 ---
 
 {{< lastmod >}}


### PR DESCRIPTION
Linking to https://ietf-wg-acme.github.io/acme/ isn't a very friendly experience. It's a landing page with a bunch of links and no clarity on which should be used.

E.g., Is it the link for ["Preview for branch omfg-make-it-stop"](https://ietf-wg-acme.github.io/acme/omfg-make-it-stop) ? (lol)

A link directly to RFC 8555 seems like a better choice.