### PR TITLE
Fix url rewrite with anchors

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,79 +1,84 @@
-{{ define "main" }}
+{{- define "main" -}}
 
-{{ if .Page.Params.untranslated }}
-	{{ range .Page.Translations }}
-		{{ if eq "en" .Language.Lang }}
-			{{ partial "hero" . }}
-		{{ end }}
-	{{ end }}
-{{ else }}
-	{{ partial "hero" . }}
-{{ end }}
+{{- if .Page.Params.untranslated -}}
+	{{- range .Page.Translations -}}
+		{{- if eq "en" .Language.Lang -}}
+			{{- partial "hero" . -}}
+		{{- end -}}
+	{{- end -}}
+{{- else -}}
+	{{- partial "hero" . -}}
+{{- end -}}
 <div class="page-content">
 	<div class="wrapper">
 
-	{{ partial "langs" . }}
+	{{- partial "langs" . -}}
 
-	{{ if .Page.Params.untranslated }}
+	{{- if .Page.Params.untranslated -}}
 
-		{{ if not .Page.Params.do_not_translate }}
+		{{- if not .Page.Params.do_not_translate -}}
 			<!--googleoff: all-->
-			<div>{{ i18n "not_yet_translated" | safeHTML }}</div>
+			<div>{{- i18n "not_yet_translated" | safeHTML -}}</div>
 			<!--googleon: all-->
-		{{ end }}
+		{{- end -}}
 
-		{{ $currentpage := .Page }}
-		{{ $lang := .Page.Language.Lang }}
-		{{ $scratch := newScratch }}
+		{{- $currentpage := .Page -}}
+		{{- $lang := .Page.Language.Lang -}}
+		{{- $scratch := newScratch -}}
 
-		{{ range .Page.Translations }}
-			{{ if eq "en" .Language.Lang }}
-			{{ $currentpage_en := .Page }}
+		{{- range .Page.Translations -}}
+			{{- if eq "en" .Language.Lang -}}
+			{{- $currentpage_en := .Page -}}
 			<div lang="en">
-				{{ $scratch.Set "content"  .Content }}
-				{{ range $.Site.Pages }}
+				{{- $scratch.Set "content"  .Content -}}
+				{{- range $.Site.Pages -}}
 				{{/* search all English urls */}}
-					{{ range .Page.Translations }}
-						{{ if eq "en" .Language.Lang }}
-							{{ $en_link_page := .Page }}
-							{{ $url_en := printf "href=\"%s\"" $en_link_page.RelPermalink }}
-							{{ range .Page.Translations }}
-								{{ if eq $lang .Language.Lang }}
+					{{- range .Page.Translations -}}
+						{{- if eq "en" .Language.Lang -}}
+							{{- $en_link_page := .Page -}}
+							{{- $url_en := printf "href=\"%s\"" $en_link_page.RelPermalink -}}
+							{{- $url_en2 := printf "href=\"%s#" $en_link_page.RelPermalink -}}
+							{{- range .Page.Translations -}}
+								{{- if eq $lang .Language.Lang -}}
 									{{/* Note: it also works for urls with anchor (#id) */}}
-									{{ $url_lang := printf "href=\"%s\"" .Page.RelPermalink }}
+									{{- $url_lang := printf "href=\"%s\"" .Page.RelPermalink -}}
+									{{- $url_lang2 := printf "href=\"%s#" .Page.RelPermalink -}}
 
-									{{ $scratch.Set "content" (replace ($scratch.Get "content") $url_en $url_lang) }}
+									{{- $scratch.Set "content" (replace ($scratch.Get "content") $url_en $url_lang) -}}
+									{{- $scratch.Set "content" (replace ($scratch.Get "content") $url_en2 $url_lang2) -}}
 
 									{{/* now the English url without "/" in the end. */}}
-									{{ $url_en := $url_en | replaceRE "/\"$" "\"" }}
-									{{ $scratch.Set "content" (replace ($scratch.Get "content") $url_en $url_lang) }}
+									{{- $url_en := $url_en | replaceRE "/\"$" "\"" -}}
+									{{- $scratch.Set "content" (replace ($scratch.Get "content") $url_en $url_lang) -}}
+									{{- $url_en2 := $url_en2 | replaceRE "/\"$" "\"" -}}
+									{{- $scratch.Set "content" (replace ($scratch.Get "content") $url_en2 $url_lang2) -}}
 
-									{{ $url_en := printf "href=\"%s\"" $en_link_page.Permalink }}
-									{{ if in ($scratch.Get "content") $url_en }}
-										{{ errorf "Absolute url to %q found in %q. relatives urls must be used to avoid breaking netlify preview." $url_en $currentpage_en.RelPermalink }}
-									{{ end }}
-								{{ end }}
-							{{ end }}
-						{{ end }}
-					{{ end }}
-				{{ end }}
-				{{ $scratch.Get "content" | safeHTML }}
+									{{- $url_en := printf "href=\"%s\"" $en_link_page.Permalink -}}
+									{{- if in ($scratch.Get "content") $url_en -}}
+										{{- errorf "Absolute url to %q found in %q. relatives urls must be used to avoid breaking netlify preview." $url_en $currentpage_en.RelPermalink -}}
+									{{- end -}}
+								{{- end -}}
+							{{- end -}}
+						{{- end -}}
+					{{- end -}}
+				{{- end -}}
+				{{- $scratch.Get "content" | safeHTML -}}
 			</div>
-			{{ end }}
-		{{ end }}
+			{{- end -}}
+		{{- end -}}
 
 
-	{{ else }}
+	{{- else -}}
 
-		{{ if and (.Page.Params.english_is_canonical) (ne "en" .Language.Lang)  }}
+		{{- if and (.Page.Params.english_is_canonical) (ne "en" .Language.Lang)  -}}
 		<div class="canonical-warning" style="">
 			<i class="fas fa-exclamation-circle" aria-hidden="true"></i>
-			{{ i18n "english_is_canonical" | safeHTML }}
+			{{- i18n "english_is_canonical" | safeHTML -}}
 		</div>
-		{{ end }}
+		{{- end -}}
 
-		{{ .Content }}
-	{{ end }}
+		{{- .Content -}}
+	{{- end -}}
 	</div>
 </div>
-{{ end }}
+{{- end -}}


### PR DESCRIPTION
For not-yet-translated page, fix url rewriting with anchor: now, in FR  it does find "href="/repository/#isrg-certificate-policy" to rewrite into "href="/fr/repository/#isrg-certificate-policy" for example.

Tested with a full html diff. Fix two links in glossary for fr,id,ja,pt-br,ru,sr,sv,vi

Now those links correctly go to the not translated page `repository` of the current language instead of going back into the English page of `repository`

Also remove unnecessary whitespaces.


