### PR TITLE
Lua-resty-acme 0.5.0 release: native tls-alpn-01 challenge handler for Nginx/Openresty

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2020-02-07",
+	"lastmod": "2020-02-10",
 	"categories": [
 		"Bash",
 		"C",

--- a/data/clients.json
+++ b/data/clients.json
@@ -785,7 +785,10 @@
 			"name": "lua-resty-acme",
 			"url": "https://github.com/fffonion/lua-resty-acme",
 			"category": "nginx",
-			"acme_v2": "true"
+			"acme_v2": "true",
+			"challenges": {
+				"TLS-ALPN-01": "true"
+			}
 		},
 		{
 			"name": "acertmgr",


### PR DESCRIPTION
https://community.letsencrypt.org/t/lua-resty-acme-0-5-0-release-native-tls-alpn-01-challenge-handler-for-nginx-openresty/112704
