### PR TITLE
Update to hugo 0.64.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: generic
 
 before_install:
-  - wget https://github.com/gohugoio/hugo/releases/download/v0.62.0/hugo_extended_0.62.0_Linux-64bit.deb
-  - echo "bd6373455c7fd4de184095d157f2b2bf82d490d01b6a1744d781c51db1848b46 hugo_extended_0.62.0_Linux-64bit.deb" | sha256sum -c - || exit 1;
-  - sudo dpkg -i hugo_extended_0.62.0_Linux-64bit.deb
+  - wget https://github.com/gohugoio/hugo/releases/download/v0.64.1/hugo_extended_0.64.1_Linux-64bit.deb
+  - echo "19f60f8bbfbe060635e127b8d0c32b9c7a0dd3fbc6830add4a86d0d3c55ca3d1 hugo_extended_0.64.1_Linux-64bit.deb" | sha256sum -c - || exit 1;
+  - sudo dpkg -i hugo_extended_0.64.1_Linux-64bit.deb
 
 install:
   - npm install && npm run build && npm test

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -109,3 +109,14 @@ do_not_translate: 1
 The file `layouts/_default/shortcodes/docs_index.md` must be updated.
 
 The name of the link will be the `linkTitle` of the target page (if present) or the `title` of the target page.
+
+# How to upgrade Hugo
+
+https://github.com/gohugoio/hugo/releases
+
+1. Generate the website using the current version: `hugo -d /tmp/current`
+2. Generate the website using the updated version: `hugo -d /tmp/updated`
+3. Check the diff to be sure nothing is broken: `diff -r /tmp/current /tmp/updated` (the diff is **never** empty, you must see at least the version updated in two files per languages)
+4. If necessary, updates the code to be compatible with the new hugo version
+5. Update `netlify.toml` and `.travis.yml` to the new hugo version
+6. After opening the PR, check the Netlify preview: in the source you need to check in the `<head>` the meta tag `<meta name="generator" content="Hugo 0.XX.X">` to be sure that version of Hugo is avaliable on Netlify.

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ publish = "public/"
 command = "hugo -d public"
 
 [build.environment]
-HUGO_VERSION = "0.62.0"
+HUGO_VERSION = "0.64.1"
 
 [[redirects]]
 from = "/jobs"


### PR DESCRIPTION
And adds some documentation.

The diff between hugo 0.62.0 and 0.64.1 is empty (not even whitespace!), only the version changes.
