### PR TITLE
Real email instead of [at]

### DIFF
--- a/content/de/trademarks.md
+++ b/content/de/trademarks.md
@@ -241,7 +241,7 @@ ISRG verbunden oder wird von dieser gesponsert oder unterstützt.
 ## Melden von Markenmissbrauch
 
 Bitte melden Sie jeden Missbrauch der ISRG-Marken an
-press[at]letsencrypt.org, und geben Sie so viele Informationen wie
+[press@letsencrypt.org](mailto:press@letsencrypt.org), und geben Sie so viele Informationen wie
 möglich über die Verwendung an, die Ihrer Meinung nach möglicherweise
 verletzt wird. Wir werden die Verwendung untersuchen und gegebenenfalls
 entsprechende Massnahmen ergreifen.

--- a/content/en/trademarks.md
+++ b/content/en/trademarks.md
@@ -84,7 +84,7 @@ If you offer software or services that are related to ISRG software or services,
 
 ## Reporting Trademark Abuse
 
-Please report any misuse of the ISRG Marks to press[at]letsencrypt.org, and provide us with as much information as you can about the use you think might be infringing. We’ll investigate the use, and take appropriate action, if warranted.
+Please report any misuse of the ISRG Marks to [press@letsencrypt.org](mailto:press@letsencrypt.org), and provide us with as much information as you can about the use you think might be infringing. We’ll investigate the use, and take appropriate action, if warranted.
 
 ## Questions
 

--- a/content/es/trademarks.md
+++ b/content/es/trademarks.md
@@ -84,7 +84,7 @@ Si ofrece software o servicios relacionados con el software o servicios ISRG, no
 
 ## Informar abuso de marca registrada
 
-Informe cualquier mal uso de las Marcas ISRG a press[at]letsencrypt.org y proporciónenos la mayor cantidad de información posible sobre el uso que cree que podría estar infringiendo. Investigaremos el uso y tomaremos las medidas adecuadas, si está justificado.
+Informe cualquier mal uso de las Marcas ISRG a [press@letsencrypt.org](mailto:press@letsencrypt.org) y proporciónenos la mayor cantidad de información posible sobre el uso que cree que podría estar infringiendo. Investigaremos el uso y tomaremos las medidas adecuadas, si está justificado.
 
 ## Preguntas
 

--- a/content/ko/trademarks.md
+++ b/content/ko/trademarks.md
@@ -84,7 +84,7 @@ english_is_canonical: 1
 
   ## 상표권 침해 신고
 
-  ISRG 마크의 오용 여부를 press[at]letsencrypt.org에 보고하고, 침해할 수 있다고 생각되는 용도에 대해 가능한 한 많은 정보를 제공해 주십시오. 용도를 조사하고, 만약 그것이 타당하다면 적절한 조치를 취할 것입니다.
+  ISRG 마크의 오용 여부를 [press@letsencrypt.org](mailto:press@letsencrypt.org)에 보고하고, 침해할 수 있다고 생각되는 용도에 대해 가능한 한 많은 정보를 제공해 주십시오. 용도를 조사하고, 만약 그것이 타당하다면 적절한 조치를 취할 것입니다.
 
   ## 질문
 


### PR DESCRIPTION
Fix  #963
In https://letsencrypt.org/trademarks/ there is press[at]letsencrypt.org (to avoid spam I guess) but two lines after there is a real mailto: link to that email. I think it will be better to just always use the mailto:
