### PR TITLE
Fix repository anchors

### DIFF
--- a/content/en/repository.html
+++ b/content/en/repository.html
@@ -97,7 +97,7 @@ do_not_translate: 1
   <li><a href="https://www.abetterinternet.org/nondiscrimination/">Current ISRG Non-Discrimination Statement and Policy</a></li>
 </ul>
 
-<h1 id="isrg-legal-transparency-report">ISRG Legal Transparency Reports</h1>
+<h1 id="isrg-legal-transparency-reports">ISRG Legal Transparency Reports</h1>
 
 <ul>
   <li><a href="/documents/ISRG-Legal-Transparency-Report-October-1-2019.pdf">Current Report, October 1, 2019</a></li>
@@ -116,7 +116,7 @@ do_not_translate: 1
 </ul>
 </div>
 
-<h1 id="wettrust-audits">WebTrust Audits</h1>
+<h1 id="webtrust-audits">WebTrust Audits</h1>
 
 <ul>
   <li>August 31, 2019: <a href="https://www.cpacanada.ca/webtrustseal?sealid=10336" referrerpolicy=origin>Trust Services Principles and Criteria for Certification Authorities Version 2.1</a></li>

--- a/content/en/repository.html
+++ b/content/en/repository.html
@@ -13,7 +13,7 @@ do_not_translate: 1
 
 <p><a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a> is the non-profit entity that operates the Let's Encrypt certificate authority. Some policies that apply to Let's Encrypt are ISRG policies, some are specific to Let's Encrypt.</p>
 
-<h1>Let's Encrypt Subscriber Agreement</h1>
+<h1 id="let-s-encrypt-subscriber-agreement">Let's Encrypt Subscriber Agreement</h1>
 <p>Current Agreements</p>
 <ul>
   <li><a href="/documents/LE-SA-v1.2-November-15-2017.pdf">v1.2, November 15, 2017</a></li>
@@ -30,7 +30,7 @@ do_not_translate: 1
 </ul>
 </div>
 
-<h1>ISRG Certificate Policy</h1>
+<h1 id="isrg-certificate-policy">ISRG Certificate Policy</h1>
 
 <ul>
   <li><a href="/documents/isrg-cp-v2.4/">v2.4, January 21, 2020</a></li>
@@ -49,7 +49,7 @@ do_not_translate: 1
 </ul>
 </div>
 
-<h1>ISRG Certification Practice Statement</h1>
+<h1 id="isrg-certification-practice-statement">ISRG Certification Practice Statement</h1>
 
 <ul>
   <li><a href="/documents/isrg-cps-v2.7/">v2.7, January 21, 2020</a></li>
@@ -73,31 +73,31 @@ do_not_translate: 1
 </ul>
 </div>
 
-<h1>Let's Encrypt Privacy Policy</h1>
+<h1 id="let-s-encrypt-privacy-policy">Let's Encrypt Privacy Policy</h1>
 
 <ul>
   <li><a href="/privacy/">Current Privacy Policy</a></li>
 </ul>
 
-<h1>Let's Encrypt Trademark Policy</h1>
+<h1 id="let-s-encrypt-trademark-policy">Let's Encrypt Trademark Policy</h1>
 
 <ul>
   <li><a href="/trademarks/">Current Trademark Policy</a></li>
 </ul>
 
-<h1>ISRG Code of Conduct</h1>
+<h1 id="isrg-code-of-conduct">ISRG Code of Conduct</h1>
 
 <ul>
   <li><a href="https://www.abetterinternet.org/code-of-conduct/">Current ISRG Code of Conduct</a></li>
 </ul>
 
-<h1>ISRG Non-Discrimination Statement and Policy</h1>
+<h1 id="isrg-non-discrimination-statement-and-policy">ISRG Non-Discrimination Statement and Policy</h1>
 
 <ul>
   <li><a href="https://www.abetterinternet.org/nondiscrimination/">Current ISRG Non-Discrimination Statement and Policy</a></li>
 </ul>
 
-<h1>ISRG Legal Transparency Reports</h1>
+<h1 id="isrg-legal-transparency-report">ISRG Legal Transparency Reports</h1>
 
 <ul>
   <li><a href="/documents/ISRG-Legal-Transparency-Report-October-1-2019.pdf">Current Report, October 1, 2019</a></li>
@@ -116,7 +116,7 @@ do_not_translate: 1
 </ul>
 </div>
 
-<h1>WebTrust Audits</h1>
+<h1 id="wettrust-audits">WebTrust Audits</h1>
 
 <ul>
   <li>August 31, 2019: <a href="https://www.cpacanada.ca/webtrustseal?sealid=10336" referrerpolicy=origin>Trust Services Principles and Criteria for Certification Authorities Version 2.1</a></li>
@@ -138,7 +138,7 @@ do_not_translate: 1
 </ul>
 </div>
 
-<h1>Certificate Problem Reports</h1>
+<h1 id="certificate-problem-reports">Certificate Problem Reports</h1>
 
 <p>To report private key compromise, certificate misuse, or other types of fraud, compromise, misuse, inappropriate conduct, or any other matter related to certificates, please email <a href="mailto:cert-prob-reports@letsencrypt.org">cert-prob-reports@letsencrypt.org</a>.</p>
 


### PR DESCRIPTION
A few pages use them:

    https://letsencrypt.org/repository/#isrg-certification-practice-statement
    https://letsencrypt.org/repository/#isrg-certificate-policy

They disappeared with the md=>html conversion https://github.com/letsencrypt/website/commit/da125f66f762bb6fd15746eec5a623277cfcd8f4
