### PR TITLE
Referrer-Policy: strict-origin for repository

### DIFF
--- a/content/en/_headers
+++ b/content/en/_headers
@@ -7,3 +7,10 @@
     X-Content-Type-Options: nosniff
     Referrer-Policy: no-referrer
     Feature-Policy: geolocation none;midi none;notifications none;push none;sync-xhr none;microphone none;camera none;magnetometer none;gyroscope none;speaker self;vibrate none;fullscreen self;
+
+# For webtrust documents
+/repository
+    Referrer-Policy: strict-origin
+
+/*/repository
+    Referrer-Policy: strict-origin

--- a/content/en/repository.html
+++ b/content/en/repository.html
@@ -119,8 +119,8 @@ do_not_translate: 1
 <h1 id="webtrust-audits">WebTrust Audits</h1>
 
 <ul>
-  <li>August 31, 2019: <a href="https://www.cpacanada.ca/webtrustseal?sealid=10336" referrerpolicy=origin>Trust Services Principles and Criteria for Certification Authorities Version 2.1</a></li>
-  <li>August 31, 2019: <a href="https://www.cpacanada.ca/webtrustseal?sealid=10337" referrerpolicy=origin>WebTrust Principles and Criteria for Certification Authorities – SSL Baseline with Network Security – Version 2.3</a></li>
+  <li>August 31, 2019: <a href="https://www.cpacanada.ca/webtrustseal?sealid=10336">Trust Services Principles and Criteria for Certification Authorities Version 2.1</a></li>
+  <li>August 31, 2019: <a href="https://www.cpacanada.ca/webtrustseal?sealid=10337">WebTrust Principles and Criteria for Certification Authorities – SSL Baseline with Network Security – Version 2.3</a></li>
 </ul>
 <p><button type="button" class="collapsible-button" id="webtrust-history">View History</button></p>
 <div class="collapsible-content" id="webtrust-history-content">


### PR DESCRIPTION
Fix #975

> strict-origin
    Only send the origin of the document as the referrer when the protocol security level stays the same (HTTPS→HTTPS), but don't send it to a less secure destination (HTTPS→HTTP).