### PR TITLE
Fix html for ct-logs shortcode

### DIFF
--- a/layouts/shortcodes/ct_logs.html
+++ b/layouts/shortcodes/ct_logs.html
@@ -1,15 +1,12 @@
-{{ $inner := .Inner }}
-{{ $data := .Get "data" }}
-{{ range $.Site.Data.transparency.categories }}
-    {{ $category := . }}
-    {{ if (eq $category $data "$category") }}
-        {{ if eq $data "production" }}
-            <h3>{{ i18n "certificate_transparency_role_production"}}</h3>
-        {{ else }}
-            <h3>{{ i18n "certificate_transparency_role_testing"}}</h3>
-        {{ end }}
-        <ul>
-        {{ $inner }}
+{{ $category := .Get "data" }}
+{{ if eq $category "production" }}
+    <h3>{{ i18n "certificate_transparency_role_production"}}</h3>
+{{ else }}
+    <h3>{{ i18n "certificate_transparency_role_testing"}}</h3>
+{{ end }}
+<ul>
+    {{ .Inner }}
+    <li class="list-style-none">
         <ul>
         {{ range $.Site.Data.transparency.transparencyLogs }}
             {{ if and .role (eq $category .role) }}
@@ -28,7 +25,6 @@
             </li>
             {{ end }}
         {{ end }}
-    </ul>
-    </ul>
-    {{ end }}
-{{ end }}
+        </ul>
+    </li>
+</ul>

--- a/src/css/_base.scss
+++ b/src/css/_base.scss
@@ -283,3 +283,7 @@ pre {
 .home_sponsors img {
     background-color: #fff;
 }
+
+.list-style-none {
+    list-style-type:none;
+}


### PR DESCRIPTION
Cf https://github.com/tdelmas/website/pull/32

The current shortcode generate the following html:
```html
<ul>
  <li>explanation...</li>
  <li>explanation...</li>
  <ul>
    <li>log1</li>
    <li>log2</li>
  </ul>
</ul>
```


The markup of this PR is:

```html
<ul>
  <li>explanation...</li>
  <li>explanation...</li>
  <li style="list-style-type:none;">
    <ul>
      <li>log1</li>
      <li>log2</li>
    </ul>
  </li>
</ul>
```

In https://github.com/letsencrypt/website/pull/970 the "ct-logs" blacklist can be removed

