### PR TITLE
Update openshift-acme client info to acme_v2

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2020-02-13",
+	"lastmod": "2020-03-26",
 	"categories": [
 		"Bash",
 		"C",
@@ -329,6 +329,7 @@
 		{
 			"name": "openshift-acme",
 			"url": "https://github.com/tnozicka/openshift-acme",
+			"acme_v2": "true",
 			"category": "OpenShift"
 		},
 		{


### PR DESCRIPTION
openshift-acme client now supports ACME v2 protocol since https://github.com/tnozicka/openshift-acme/pull/92