### PR TITLE
Update cert-compat.md

### DIFF
--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -2,7 +2,7 @@
 title: Certificate Compatibility
 slug: certificate-compatibility
 top_graphic: 1
-lastmod: 2020-02-07
+lastmod: 2020-06-19
 ---
 
 {{< lastmod >}}
@@ -47,3 +47,9 @@ You may want to visit [this particular community forum discussion](https://commu
   * cannot handle certificates without a CRL
 * PS3 game console
 * PS4 game console with firmware < 5.00
+
+# envirement that doesn't include ISRG X1 in their trust store
+
+* Android < v7.1.2
+* Mac OS x < v10
+* iOS < 10.12.1


### PR DESCRIPTION
as those environments doesn't have ISRG root in it and relies on DST root CA X3, we need to mention it before change default CA path
more digging may be able to find more things that doesn't have ISRG root in it. 
maybe more explanation on this page for what this means. 

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
