### PR TITLE
Making it more clear that Crypt::LE is a separate project.

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -200,7 +200,7 @@
 			"category": "Docker"
 		},
 		{
-			"name": "ZeroSSL",
+			"name": "Crypt::LE",
 			"url": "https://hub.docker.com/r/zerossl/client/",
 			"acme_v2": "true",
 			"category": "Docker"
@@ -348,11 +348,10 @@
 			"category": "OpenShift"
 		},
 		{
-			"name": "ZeroSSL project",
+			"name": "Crypt::LE (previously ZeroSSL project)",
 			"url": "https://github.com/do-know/Crypt-LE",
 			"acme_v2": "true",
-			"category": "Windows / IIS",
-			"library": "Perl"
+			"category": "Windows / IIS"
 		},
 		{
 			"name": "Crypt::LE",


### PR DESCRIPTION
Since ZeroSSL has changed ownership, making it more clear that Crypt::LE is a separate project now.

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
