### PR TITLE
Add CSP frame-ancestors: 'none'

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,8 +35,10 @@ Feature-Policy = """
 # "img-src data: blob:" is for Plotly download feature
 # "script-src unsafe-eval unsafe-inline data:": For Google Analytics
 # "form-action" is NOT set, so it allows everything (it doesn't default to default-src). If restricted, It must allow at least www.paypal.com and its redirects
+# "frame-ancestors" is a modern equivalent and successfor to the X-Frame-Options header
 Content-Security-Policy = """
     default-src 'none';
+    frame-ancestors 'none';
     font-src 'self';
     style-src 'unsafe-inline' 'self';
     script-src 'unsafe-eval' 'unsafe-inline' 'self' data:


### PR DESCRIPTION
"Setting this directive to 'none' is similar to X-Frame-Options: deny (which is also supported in older browsers)."

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors