### PR TITLE
CSP broken after enabling shopify for summer giving campaign

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -69,6 +69,8 @@ Content-Security-Policy = """
     connect-src 'self'
         https://d4twhgtvn0ff5.cloudfront.net/
         https://letsencrypt-merch.myshopify.com
+        https://monorail-edge.shopifysvc.com
+
     ;
 """
 


### PR DESCRIPTION
This fixes some CSP errors on the donate page created by a recent commit.
