### PR TITLE
Update revoking.md FR

### DIFF
--- a/content/fr/docs/revoking.md
+++ b/content/fr/docs/revoking.md
@@ -47,7 +47,7 @@ mettre une [valeur dans un enregistrement de type TXT du DNS](https://tools.ietf
 ```bash
 certbot certonly --manual --preferred-challenges=dns -d ${YOUR_DOMAIN} -d nonexistent.${YOUR_DOMAIN}
 ```
-Puis suivez les instructions. si vous péférez la validation utilisant le port HTTP plutôt que le DNS, remplacez l'option  `--preferred-challenges` par `--preferred-challenges=http`.
+Puis suivez les instructions. Si vous préférez la validation utilisant le port HTTP plutôt que le DNS, remplacez l'option  `--preferred-challenges` par `--preferred-challenges=http`.
 
 Une fois que vous avez validé le contrôle de tous les noms de domaine dans le certificat que vous souhaitez révoquer, vous pouvez télécharger le certificat depuis [crt.sh] (https://crt.sh/), puis révoquez le certificat comme si vous l'aviez délivré:
 


### PR DESCRIPTION
Correction de deux fautes d'orthographe pour la page [https://letsencrypt.org/fr/docs/revoking/](https://letsencrypt.org/fr/docs/revoking/) en FR.