### PR TITLE
Add links to CP and CPS from docs index

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -152,8 +152,8 @@ other = "Window Start"
 [certificate_transparency_window_end]
 other = "Window End"
 
-[certification_practices_framework]
-other = "Certification Practices Framework"
+[certification_practices_statement]
+other = "Certification Practices Statement"
 
 [overview]
 other = "Overview"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -122,6 +122,9 @@ other = "Japan users"
 [graph_percent_https]
 other = "Percent of Pageloads over HTTPS (14 day moving average)"
 
+[certificate_policy]
+other = "Certificate Policy"
+
 [certificate_transparency_name]
 other = "Name"
 
@@ -148,6 +151,9 @@ other = "Window Start"
 
 [certificate_transparency_window_end]
 other = "Window End"
+
+[certification_practices_framework]
+other = "Certification Practices Framework"
 
 [overview]
 other = "Overview"

--- a/layouts/shortcodes/docs_index.html
+++ b/layouts/shortcodes/docs_index.html
@@ -19,6 +19,8 @@
 <h1 id="{{ anchorize (i18n "advanced_subscriber_information") }}">{{ i18n "advanced_subscriber_information" }}</h1>
 
 <ul>
+    <li><a href="https://cp.letsencrypt.org">{{ i18n "certificate_policy" }}</a></li>
+    <li><a href="https://cps.letsencrypt.org">{{ i18n "certification_practices_framework" }}</a></li>
     <li>{{ template "link" (dict "context" . "page" "/docs/staging-environment") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/cert-compat") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/certificates") }}</li>

--- a/layouts/shortcodes/docs_index.html
+++ b/layouts/shortcodes/docs_index.html
@@ -20,7 +20,7 @@
 
 <ul>
     <li><a href="https://cp.letsencrypt.org">{{ i18n "certificate_policy" }}</a></li>
-    <li><a href="https://cps.letsencrypt.org">{{ i18n "certification_practices_framework" }}</a></li>
+    <li><a href="https://cps.letsencrypt.org">{{ i18n "certification_practices_statement" }}</a></li>
     <li>{{ template "link" (dict "context" . "page" "/docs/staging-environment") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/cert-compat") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/certificates") }}</li>


### PR DESCRIPTION
These are two of the most important documents that we host,
so it makes sense to ensure that they are easily findable and
accessible from our website, rather that only found through the
Certificate Policies extension on our subscriber certs.