### PR TITLE
Update Hugo to 0.79.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: generic
 env:
   global:
     # same as netlify.toml
-    - HUGO_VERSION=0.67.1
-    - HUGO_SHA256=2eb98c21962d09950620dc0b77be67d6073c81153a6a1e80c228a1924faf5dc4
+    - HUGO_VERSION=0.79.1
+    - HUGO_SHA256=ca544fe0934bfcf97a9bb6bd778905e3936101b1e01859f908e6c12c79567313
 
 before_install:
   - wget https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
     # same as netlify.toml
     - HUGO_VERSION=0.79.1
-    - HUGO_SHA256=ca544fe0934bfcf97a9bb6bd778905e3936101b1e01859f908e6c12c79567313
+    - HUGO_SHA256=43c40c3909d7a3fec0eda190ddd7351b57211059825de511a0e30e9628d97cac
 
 before_install:
   - wget https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@ command = "hugo -d public"
 
 [build.environment]
 # same as .travis.yml
-HUGO_VERSION = "0.67.1"
+HUGO_VERSION = "0.79.1"
 
 # https://docs.netlify.com/routing/headers/#syntax-for-the-netlify-configuration-file
 # headers must be the same than in config/_default/server.toml (for Hugo)


### PR DESCRIPTION
Minor quotes differences, and align for table is using css instead of deprecated attributes.