### PR TITLE
Add new client implementation: acme-http-01-azure-key-vault-middleware

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -933,6 +933,19 @@
 			"url": "https://github.com/kpcyrd/acme-redirect",
 			"acme_v2": "true",
 			"category": "Rust"
+		},
+		{
+			"name": "acme-http-01-azure-key-vault-middleware",
+			"url": "https://github.com/compulim/acme-http-01-azure-key-vault-middleware",
+			"acme_v2": "true",
+			"category": "Node.js",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "false",
+				"TLS-SNI-01": "false",
+				"TLS-SNI-02": "false"
+			},
+			"comments": "(Express middleware for storing certificates securely on Azure Key Vault)"
 		}
 	]
 }

--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2021-01-07",
+	"lastmod": "2021-01-08",
 	"categories": [
 		"Bash",
 		"C",


### PR DESCRIPTION
Adding a new Node.js client implementation, https://github.com/compulim/acme-http-01-azure-key-vault-middleware.

The package consists of 2 parts:

- Node.js enrollment agent to order certificate from Let's Encrypt and save it to Azure Key Vault
- Express middleware for handling HTTP-01 challenges, using pre-generated responses from enrollment agent

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- ~If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.~
