### PR TITLE
Update compatibility page to document X1 trust.

### DIFF
--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -2,37 +2,54 @@
 title: Certificate Compatibility
 slug: certificate-compatibility
 top_graphic: 1
-lastmod: 2020-02-07
+lastmod: 2021-01-21
 ---
 
 {{< lastmod >}}
 
-Let's Encrypt aims to be compatible with as much software as possible without compromising security. The main determining factor for whether a platform can validate Let's Encrypt certificates is whether that platform includes ISRG's "ISRG Root X1" certificate or IdenTrust's "DST Root CA X3" certificate in its trust store.
+The main determining factor for whether a platform can validate Let's Encrypt certificates is whether that platform trusts ISRG's "ISRG Root X1" certificate. Some platforms can validate our certificates even though they don't include ISRG Root X1, because they trust IdenTrust's "DST Root CA X3" certificate. After September 2021, only those platforms that trust ISRG Root X1 will continue to validate Let's Encrypt certificates ([with the exception of Android][android-compat]).
 
-If your certificate validates on some of the "Known Compatible" platforms but not others, the problem may be a web server misconfiguration. If you're having an issue with modern platforms, the most common cause is failure to provide the correct certificate chain. If you're having an issue with older platforms like Windows XP, the most common causes are failure to configure a ciphersuite or TLS version that is supported on the platform or that the platform lacks support for Server Name Indication (SNI). Test your site with [SSL Labs' Server Test](https://www.ssllabs.com/ssltest/). If that doesn't identify the problem, ask for help in our [Community Forums](https://community.letsencrypt.org/).
+[android-compat]: /2020/12/21/extending-android-compatibility.html
 
-You may want to visit [this particular community forum discussion](https://community.letsencrypt.org/t/which-browsers-and-operating-systems-support-lets-encrypt/) for more information about compatibility.
+If your certificate validates on some of the "Known Compatible" platforms but not others, the problem may be a web server misconfiguration. If you're having an issue with modern platforms, the most common cause is failure to provide the correct certificate chain. Test your site with [SSL Labs' Server Test](https://www.ssllabs.com/ssltest/). If that doesn't identify the problem, ask for help in our [Community Forums](https://community.letsencrypt.org/).
 
-# Known Compatible
+# Platforms that trust ISRG Root X1
 
+* Windows >= XP SP3 ([assuming Automatic Root Certificate Update isn't manually disabled](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/))
+* [macOS >= 10.12.1](https://twitter.com/letsencrypt/status/790960929504497665?lang=en)
+* [iOS >= 10](https://support.apple.com/en-us/HT207177) ([iOS 9 does not include it](https://support.apple.com/en-us/HT205205))
+* [Android >= 7.1.1](https://android.googlesource.com/platform/system/ca-certificates/+/android-7.1.1_r15)
+* [Mozilla Firefox >= 50.0](https://bugzilla.mozilla.org/show_bug.cgi?id=1204656)
+* [Ubuntu >= xenial / 16.04](https://packages.ubuntu.com/xenial/all/ca-certificates/filelist) (with updates applied)
+* [Debian >= jessie / 8](https://packages.debian.org/jessie/all/ca-certificates/filelist) (with updates applied)
+* [Java 8 >= 8u141](https://www.oracle.com/java/technologies/javase/8u141-relnotes.html)
+* [Java 7 >= 7u151](https://www.oracle.com/java/technologies/javase/7u151-relnotes.html)
+* [NSS >= 3.26](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/NSS_3.26_release_notes)
+
+Browsers (Chrome, Safari, Edge, Opera) generally trust the same root certificates as the operating system they are running on. Firefox is the exception: it has its own root store. Soon, new versions of Chrome will [also have their own root store][chrome-root-store].
+
+[chrome-root-store]: https://www.chromium.org/Home/chromium-security/root-ca-policy
+
+# Platforms that trust DST Root CA X3
+
+* Windows >= XP SP3
+* macOS (most versions)
+* iOS (most versions)
+* [Android >= v2.3.6](https://twitter.com/Tutancagamon/status/600783165087752192)
 * Mozilla Firefox >= v2.0
-* Google Chrome
-* Internet Explorer on Windows XP SP3 and higher
-* Microsoft Edge
-* Android OS >= v2.3.6
-* Safari >= v4.0 on macOS
-* Safari on iOS >= v3.1
-* Debian Linux >= v6
-* Ubuntu Linux >= v12.04
-* NSS Library >= v3.11.9
+* Ubuntu >= precise / 12.04
+* [Debian >= squeee / 6](https://twitter.com/TokenScandi/status/600806080684359680)
+* Java 8 >= 8u101
+* Java 7 >= 7u111
+* NSS >= v3.11.9
 * Amazon FireOS (Silk Browser)
 * Cyanogen > v10
 * Jolla Sailfish OS > v1.1.2.16
 * Kindle > v3.4.1
-* Java 7 >= 7u111
-* Java 8 >= 8u101
 * Blackberry >= 10.3.3
 * PS4 game console with firmware >= 5.00
+
+You may want to visit [this 2015-2017 community forum discussion](https://community.letsencrypt.org/t/which-browsers-and-operating-systems-support-lets-encrypt/) for more information about compatibility.
 
 # Known Incompatible
 


### PR DESCRIPTION
I've reorganized a bit, to talk about trust stores rather than
browsers or other software. I've removed some unnecessary verbiage in
the intro paragraph, removed a note about XP and SNI, and reordered
the platforms list.