### PR TITLE
Add link to challenge types in wildcard QA

### DIFF
--- a/content/de/docs/faq.md
+++ b/content/de/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: Frequently Asked Questions (FAQ)
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2017-07-06
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -86,7 +86,7 @@ Ja, dieselben Zertifikate können unterschiedliche Namen mit Benutzung des Subje
 
 ## Kann Let's Encrypt Wildcard-Zertifikate ausstellen?
 
-Ja. Wildcard müssen über ACMEv2 mit DNS-01 Challenge ausgestellt werden. Schauen Sie [diese Nachricht](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) für mehr technische Details.
+Ja. Wildcard müssen über ACMEv2 mit [DNS-01 Challenge](/docs/challenge-types) ausgestellt werden. Schauen Sie [diese Nachricht](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) für mehr technische Details.
 
 ## Gibt es einen Let's Encrypt (ACME) Client für mein Betriebssystem?
 

--- a/content/en/docs/faq.md
+++ b/content/en/docs/faq.md
@@ -3,7 +3,7 @@ title: FAQ
 linkTitle: Frequently Asked Questions (FAQ)
 slug: faq
 top_graphic: 1
-lastmod: 2020-04-23
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -89,7 +89,7 @@ Yes, the same certificate can contain several different names using the Subject 
 
 ## Does Let's Encrypt issue wildcard certificates?
 
-Yes. Wildcard issuance must be done via ACMEv2 using the DNS-01 challenge. See [this post](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) for more technical information.
+Yes. Wildcard issuance must be done via ACMEv2 using the [DNS-01 challenge](/docs/challenge-types). See [this post](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) for more technical information.
 
 ## Is there a Let's Encrypt (ACME) client for my operating system?
 

--- a/content/es/docs/faq.md
+++ b/content/es/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: Preguntas Frecuentes (FAQ)
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2017-07-06
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -89,7 +89,7 @@ Sí, el mismo certificado puede contener diferentes nombres de dominio usando el
 
 ## ¿Let’s Encrypt emite certificados wildcard?
 
-Sí. Emisión wildcard se debe realizar a través de ACMEv2 usando el reto DNS-01. Ve [este post](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) para más información técnica.
+Sí. Emisión wildcard se debe realizar a través de ACMEv2 usando [el reto DNS-01](/docs/challenge-types). Ve [este post](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) para más información técnica.
 
 ## ¿Hay un cliente Let's Encrypt (ACME para mi sistema operativo?
 

--- a/content/fr/docs/faq.md
+++ b/content/fr/docs/faq.md
@@ -3,7 +3,7 @@ title: Questions fréquentes (FAQ)
 linkTitle: Questions fréquentes (FAQ)
 slug: faq
 top_graphic: 1
-lastmod: 2020-02-20
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -88,7 +88,7 @@ Oui, le même certificat peut contenir plusieurs noms différents à l'aide du m
 
 ## Let's Encrypt émet-il des certificats génériques (wildcard)?
 
-Oui. L'émission de caractères génériques doit être effectuée via ACMEv2 à l'aide du défi DNS-01. Voir [ce sujet](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) pour plus de détails techniques.
+Oui. L'émission de caractères génériques doit être effectuée via ACMEv2 à l'aide [du défi DNS-01](/docs/challenge-types). Voir [ce sujet](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) pour plus de détails techniques.
 
 ## Existe-t-il un client Let's Encrypt (ACME) pour mon système d'exploitation?
 

--- a/content/he/docs/faq.md
+++ b/content/he/docs/faq.md
@@ -3,7 +3,7 @@ title: שו״ת
 linkTitle: שאלות ותשובות (שו״ת)
 slug: faq
 top_graphic: 1
-lastmod: 2020-02-20
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -88,7 +88,7 @@ https://letsencrypt.org/2015/10/29/phishing-and-malware.html
 
 ## האם Let's Encrypt מנפיקה אישורים כוללניים?
 
-כן. הנפקה כוללנית חובה לבצע דרך ACMEv2 באמצעות אתגר DNS-01. ב[רשומה הזאת](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) יש קצת יותר פירוט טכני.
+כן. הנפקה כוללנית חובה לבצע דרך ACMEv2 באמצעות [אתגר DNS-01](/docs/challenge-types). ב[רשומה הזאת](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) יש קצת יותר פירוט טכני.
 
 ## האם יש לקוח של Let's Encrypt‏ (ACME) למערכת ההפעלה שלי?
 

--- a/content/ja/docs/faq.md
+++ b/content/ja/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: よくある質問 (FAQ)
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2019-12-22
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -89,7 +89,7 @@ OV や EV 証明書を発行する予定はありません。
 
 ## Let's Encrypt はワイルドカード証明書を発行していますか？
 
-はい。ただし、ワイルドカード証明書の発行には DNS-01 を使用する ACMEv2 プロトコルでの認証が必要です。詳細な技術的な情報については、[この記事](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578)を読んでください。
+はい。ただし、ワイルドカード証明書の発行には [DNS-01](/docs/challenge-types) を使用する ACMEv2 プロトコルでの認証が必要です。詳細な技術的な情報については、[この記事](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578)を読んでください。
 
 ## 私が使っているオペレーティングシステムで使える Let's Encrypt (ACME) クライアントはありますか？
 

--- a/content/ko/docs/faq.md
+++ b/content/ko/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: Frequently Asked Questions (FAQ)
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2017-07-06
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -79,7 +79,7 @@ OV 또는 EV 인증서를 발급할 계획이 없습니다.
 
 ## Let's Encrypt는 와일드카드 인증서를 발행합니까?
 
-네. 와일드카드 발급은 DNS-01 과제를 사용하여 ACMEv2를 통해 수행해야 합니다. [이 글](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578)에서 자세한 기술 정보를 확인하십시오.
+네. 와일드카드 발급은 [DNS-01](/docs/challenge-types) 과제를 사용하여 ACMEv2를 통해 수행해야 합니다. [이 글](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578)에서 자세한 기술 정보를 확인하십시오.
 
 ## Let's Encrypt는 운영체제에 맞는 (ACME) 클라이언트가 있습니까?
 

--- a/content/pt-br/docs/faq.md
+++ b/content/pt-br/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: Perguntas Frequentes (FAQ)
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2017-07-06
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -89,7 +89,7 @@ Sim, o mesmo certificado pode conter diferentes nomes de domínio usando o mecan
 
 ## A Let's Encrypt emite certificados coringa?
 
-Sim. A emissão de certificados coringa precisa ser feita via ACMEv2 usando o desafio DNS-01. Veja [esta postagem](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) (Inglês) para obter mais informações técnicas.
+Sim. A emissão de certificados coringa precisa ser feita via ACMEv2 usando o [desafio DNS-01](/docs/challenge-types). Veja [esta postagem](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578) (Inglês) para obter mais informações técnicas.
 
 ## Existe um cliente da Let's Encrypt (ACME) para o meu sistema operacional?
 

--- a/content/ru/docs/faq.md
+++ b/content/ru/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: Часто задаваемые вопросы
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2019-12-22
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -88,7 +88,7 @@ Let’s Encrypt - небольшая компания, мы полагаемся
 
 ## Выпускает ли Let’s Encrypt сертификаты с возможностью подстановки (wildcard-сертификаты)?
 
-Да. Такие сертификаты выпускаются на основе протокола ACMEv2 с проверкой доменов по методу DNS-01. Узнайте подробности в статье [на форуме сообщества](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578).
+Да. Такие сертификаты выпускаются на основе протокола ACMEv2 с проверкой доменов по [методу DNS-01](/docs/challenge-types). Узнайте подробности в статье [на форуме сообщества](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578).
 
 ## Существует ли ACME-клиент Let's Encrypt для моей операционной системы?
 

--- a/content/sv/docs/faq.md
+++ b/content/sv/docs/faq.md
@@ -3,7 +3,7 @@ title: Vanliga frågor
 linkTitle: Vanliga frågor (FAQ)
 slug: faq
 top_graphic: 1
-lastmod: 2020-02-20
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -120,7 +120,7 @@ Alternative Name-mekanismen (SAN).
 ## Utfärdar Let's Encrypt wildcard-certifikat?
 
 Ja. Utfärdande av wildcard-certifikat (jokercertifikat) måste göras via ACMEv2
-genom utmaningen DNS-01. Se [det här
+genom [utmaningen DNS-01](/docs/challenge-types). Se [det här
 inlägget](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578)
 för mer teknisk information.
 

--- a/content/zh-cn/docs/faq.md
+++ b/content/zh-cn/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: 常见问题（FAQ）
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2020-02-20
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -89,7 +89,7 @@ Let’s Encrypt 证书是标准的域名验证性证书，因此您可以将它�
 
 ## Let's Encrypt 颁发通配符证书吗？
 
-是的。您必须使用 ACMEv2 协议并通过 DNS-01 验证方式来获取通配符证书。有关更多技术信息，请参阅[该网页](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578)。
+是的。您必须使用 ACMEv2 协议并通过 [DNS-01](/docs/challenge-types) 验证方式来获取通配符证书。有关更多技术信息，请参阅[该网页](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578)。
 
 ## 是否有 Let's Encrypt（ACME）客户端支持我的操作系统？
 

--- a/content/zh-tw/docs/faq.md
+++ b/content/zh-tw/docs/faq.md
@@ -4,7 +4,7 @@ linkTitle: 常見問題 (FAQ)
 slug: faq
 top_graphic: 1
 date: 2017-07-06
-lastmod: 2017-07-06
+lastmod: 2021-02-07
 menu:
   main:
     weight: 30
@@ -88,7 +88,7 @@ Let’s Encrypt 憑證是一個標準的域名驗證型憑證，因此你可以�
 
 ## Let’s Encrypt 可以頒發萬用憑證嗎？
 
-可以，萬用憑證的頒發必須透過 ACMEv2 協定並使用 DNS-01 驗證方式。更多技術資訊，請參考[這篇文章](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578)。
+可以，萬用憑證的頒發必須透過 ACMEv2 協定並使用 [DNS-01](/docs/challenge-types) 驗證方式。更多技術資訊，請參考[這篇文章](https://community.letsencrypt.org/t/acme-v2-production-environment-wildcards/55578)。
 
 ## Let's Encrypt (ACME) 客戶端支援我的作業系統嗎？
 


### PR DESCRIPTION
Might be helpful when someone comes across the FAQ, but doesn't know what challenge types are.

I hope I added the link correctly in the Hebrew translation. It had some, well, interesting cursor movements when I only pressed the "right" key on my keyboard. The fact the words `אתגר` and `באמצעות` are now in reverse order wasn't done by me, but just happened when I put the brackets around `אתגר`. Also, for the Japanese, Korean and both Chinese translations, I wasn't able to single out the word "challenge", so put the link only on the "DNS-01" text.