### PR TITLE
Sort Glossary

### DIFF
--- a/content/de/docs/glossary.md
+++ b/content/de/docs/glossary.md
@@ -176,6 +176,8 @@ Note for translators:
 
 {{% def id="X509" abbr="X.509" %}} Die Standarddefinition des Formats von Öffentliche-Schlüssel-Zertifikate. [Wikipedia](https://en.wikipedia.org/wiki/X.509) {{% /def %}}
 
-<link rel="stylesheet" href="/css/glossary.css" />
+{{% renderglossary %}}
+
+<link rel="stylesheet" href="/css/glossary.css">
 <script src="/js/glossary.js" async></script>
 

--- a/content/en/docs/glossary.md
+++ b/content/en/docs/glossary.md
@@ -175,5 +175,7 @@ Note for translators:
 
 {{% def id="X509" abbr="X.509" %}} The standard defining the format of public key certificates. [Wikipedia](https://en.wikipedia.org/wiki/X.509) {{% /def %}}
 
+{{% renderglossary %}}
+
 <link rel="stylesheet" href="/css/glossary.css">
 <script src="/js/glossary.js" async></script>

--- a/content/es/docs/glossary.md
+++ b/content/es/docs/glossary.md
@@ -175,5 +175,7 @@ Note for translators:
 
 {{% def id="X509" abbr="X.509" %}} El estándar que define el formato de los certificados de clave pública. [Wikipedia](https://en.wikipedia.org/wiki/X.509) {{% /def %}}
 
+{{% renderglossary %}}
+
 <link rel="stylesheet" href="/css/glossary.css">
 <script src="/js/glossary.js" async></script>

--- a/content/fr/docs/glossary.md
+++ b/content/fr/docs/glossary.md
@@ -175,5 +175,7 @@ Note for translators:
 
 {{% def id="X509" abbr="X.509" %}} Le standard définissant le format des certificats à clef publique. [Wikipédia](https://en.wikipedia.org/wiki/X.509) {{% /def %}}
 
+{{% renderglossary %}}
+
 <link rel="stylesheet" href="/css/glossary.css">
 <script src="/js/glossary.js" async></script>

--- a/content/he/docs/glossary.md
+++ b/content/he/docs/glossary.md
@@ -176,6 +176,8 @@ Note for translators:
 
 {{% def id="X509" abbr="X.509" %}} התקן שמגדיר את תצורת אישורי המפתח הציבורי. [ויקיפדיה](https://he.wikipedia.org/wiki/X.509) {{% /def %}}
 
+{{% renderglossary %}}
+
 <link rel="stylesheet" href="/css/glossary.css" />
 <script src="/js/glossary.js" async></script>
 

--- a/content/ko/docs/glossary.md
+++ b/content/ko/docs/glossary.md
@@ -175,5 +175,7 @@ Note for translators:
 
 {{% def id="X509" abbr="X.509" %}} 공용 키 인증서의 형식을 정의하는 표준입니다. [위키피디아](https://en.wikipedia.org/wiki/X.509) {{% /def %}}
 
+{{% renderglossary %}}
+
 <link rel="stylesheet" href="/css/glossary.css">
 <script src="/js/glossary.js" async></script>

--- a/content/zh-cn/docs/glossary.md
+++ b/content/zh-cn/docs/glossary.md
@@ -157,5 +157,7 @@ date: 2018-12-30
 
 {{% def id="X509" abbr="X.509" %}} 定义了公钥证书格式的标准。[维基百科条目](https://zh.wikipedia.org/wiki/X.509) {{% /def %}}
 
+{{% renderglossary %}}
+
 <link rel="stylesheet" href="/css/glossary.css">
 <script src="/js/glossary.js" async></script>

--- a/content/zh-tw/docs/glossary.md
+++ b/content/zh-tw/docs/glossary.md
@@ -176,5 +176,7 @@ Note for translators:
 
 {{% def id="X509" abbr="X.509" %}} 定義了公開金鑰憑證格式的標準。[維基百科](https://en.wikipedia.org/wiki/X.509) {{% /def %}}
 
+{{% renderglossary %}}
+
 <link rel="stylesheet" href="/css/glossary.css">
 <script src="/js/glossary.js" async></script>

--- a/layouts/shortcodes/def.html
+++ b/layouts/shortcodes/def.html
@@ -35,30 +35,26 @@ Notes:
 	lang="en" is used for the accent for screen readers
 -->
 
-<p class="definition">
-	<a href="#def-{{.Get "id" }}">
-	{{- if and (.Get "abbr") (eq (.Get "abbr_first") "1") -}}
-			<dfn id="def-{{.Get "id" }}"><abbr lang="en">{{ .Get "abbr" }}</abbr></dfn>
-				{{- if .Get "name" }} ({{.Get "name" }}{{ if .Get "english" }} - <i lang="en">{{ .Get "english" }}</i>{{ end }})
-				{{- else }}{{ if .Get "english" -}} (<i lang="en">{{ .Get "english" }}</i>{{ end }})
-				{{- end }}
-	{{- else -}}
-		{{- if .Get "name" -}}
-			<dfn id="def-{{.Get "id" }}">{{.Get "name" }}</dfn>
-			{{- if or (.Get "abbr") (.Get "english") -}}
-				{{- if .Get "english" }} ({{ with .Get "abbr" }}<abbr lang="en">{{ . }}</abbr> - {{ end -}}<i lang="en">{{ .Get "english" }}</i>)
-				{{- else }} (<abbr>{{ .Get "abbr" }}</abbr>)
-				{{- end }}
-			{{- end }}
-		{{- else -}}
-			{{- if .Get "english" -}}
-				<dfn id="def-{{.Get "id" }}" lang="en">{{.Get "english" }}</dfn>
-				{{- if .Get "abbr" }} (<abbr lang="en">{{ .Get "abbr" }}</abbr>){{- end }}
-			{{- else -}}
-				<dfn id="def-{{.Get "id" }}"><abbr>{{.Get "abbr" }}</abbr></dfn>
-			{{- end -}}
-		{{- end -}}
-	{{- end -}}
-	</a>
-	{{ .Site.Params.beforeColon | safeHTML }}: {{ .Inner }}
-</p>
+{{ $id := .Get "id" }}
+{{ $name := .Get "name" }}
+{{ $english := .Get "english" }}
+{{ $abbr := .Get "abbr" }}
+{{ $abbr_first := .Get "abbr_first" }}
+{{ $content := .Inner }}
+
+{{ $sortname := "" }}
+{{- if and ($abbr) (eq ($abbr_first) "1") -}}
+	{{ $sortname = $abbr }}
+{{- else -}}
+{{- if $name -}}
+	{{ $sortname = $name }}
+{{- else -}}
+{{- if $english -}}
+	{{ $sortname = $english }}
+{{- else -}}
+	{{ $sortname = $abbr }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{ .Page.Scratch.SetInMap "glossary" $sortname (dict "id" $id "name" $name "english" $english "abbr" $abbr "abbr_first" $abbr_first "content" $content) }}

--- a/layouts/shortcodes/renderglossary.html
+++ b/layouts/shortcodes/renderglossary.html
@@ -1,0 +1,31 @@
+{{ range (.Page.Scratch.GetSortedMapValues "glossary") }}
+<p class="definition">
+	<a href="#def-{{.id }}">
+	{{- if and (.abbr) (eq (.abbr_first) "1") -}}
+			<dfn id="def-{{.id }}"><abbr lang="en">{{ .abbr }}</abbr></dfn>
+				{{- if .name }} ({{.name }}{{ if .english }} - <i lang="en">{{ .english }}</i>{{ end }})
+				{{- else }}{{ if .english -}} (<i lang="en">{{ .english }}</i>{{ end }})
+				{{- end }}
+	{{- else -}}
+		{{- if .name -}}
+			<dfn id="def-{{.id }}">{{.name }}</dfn>
+			{{- if or (.abbr) (.english) -}}
+				{{- if .english }} ({{ with .abbr }}<abbr lang="en">{{ . }}</abbr> - {{ end -}}<i lang="en">{{ .english }}</i>)
+				{{- else }} (<abbr>{{ .abbr }}</abbr>)
+				{{- end }}
+			{{- end }}
+		{{- else -}}
+			{{- if .english -}}
+				<dfn id="def-{{.id }}" lang="en">{{.english }}</dfn>
+				{{- if .abbr }} (<abbr lang="en">{{ .abbr }}</abbr>){{- end }}
+			{{- else -}}
+				<dfn id="def-{{.id }}"><abbr>{{.abbr }}</abbr></dfn>
+			{{- end -}}
+		{{- end -}}
+	{{- end -}}
+	</a>
+	{{ .Site.Params.beforeColon | safeHTML }}: {{ .content }}
+</p>
+
+{{ end }}
+


### PR DESCRIPTION
Partial Fix for #1194

The sort is done using `GetSortedMapValues` so it doesn't handle the locale. Sort in some language could be incorrect. Related: https://discourse.gohugo.io/t/alphabetical-sort-order/20246/4

An alternative could be to sort using javascript, but it may break the anchors.

See discussion https://community.letsencrypt.org/t/glossary-edit-perhaps-a-cosmetic-one/146360/20