### PR TITLE
Remove "Free SSL/TLS Certificates" from title

### DIFF
--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -1,4 +1,4 @@
-title = "Let's Encrypt - Free SSL/TLS Certificates"
+title = "Let's Encrypt"
 contentDir = "content/en"
 #The namge of the language, it that language (not in English if it's not English)
 languageName = "English"

--- a/config/_default/languages.he.toml
+++ b/config/_default/languages.he.toml
@@ -1,4 +1,4 @@
-title = "Let's Encrypt - Free SSL/TLS Certificates"
+title = "Let's Encrypt"
 contentDir = "content/he"
 languageName = "עברית"
 languageCode = "he"

--- a/config/_default/languages.ru.toml
+++ b/config/_default/languages.ru.toml
@@ -1,4 +1,4 @@
-title = "Let's Encrypt - Free SSL/TLS Certificates"
+title = "Let's Encrypt"
 contentDir = "content/ru"
 languageName = "Русский"
 languageCode = "ru-RU"


### PR DESCRIPTION
It's redundant (and serves no purpose).