### PR TITLE
Redirect lencr.org -> letsencrypt.org/docs/lencr.org

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -209,4 +209,10 @@ force = false
 from = "https://lencr.org/*"
 to = "https://letsencrypt.org/docs/lencr.org"
 status = 302
-force = false
+force = true
+
+[[redirects]]
+from = "https://www.lencr.org/*"
+to = "https://letsencrypt.org/docs/lencr.org"
+status = 302
+force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -204,3 +204,9 @@ from = "/vi/*"
 to = "/vi/404.html"
 status = 404
 force = false
+
+[[redirects]]
+from = "https://lencr.org/*"
+to = "https://letsencrypt.org/docs/lencr.org"
+status = 302
+force = false


### PR DESCRIPTION
Adds a redirection rule from https://lencr.org to https://letsencrypt.org/docs/lencr.org