### PR TITLE
Refer to ACME v1 phase-out as already completed

### DIFF
--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -2,7 +2,7 @@
 title: ACME Client Implementations
 slug: client-options
 top_graphic: 1
-lastmod: 2020-12-18
+lastmod: 2021-06-12
 ---
 
 {{< clientslastmod >}}
@@ -26,7 +26,7 @@ If Certbot does not meet your needs, or you'd simply like to try something else,
 
 # Other Client Options
 
-All of the following clients support the ACMEv2 API ([RFC 8555](https://tools.ietf.org/html/rfc8555)). We'll be entirely [phasing out support for ACMEv1](https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/) soon. If you're already using one of the clients below, make sure to upgrade to the latest version. If the client you're using isn't listed below it may not support ACMEv2, in which case we recommend contacting the project maintainers or switching to another client.
+All of the following clients support the ACMEv2 API ([RFC 8555](https://tools.ietf.org/html/rfc8555)). In June 2021 we [phased out support for ACMEv1](https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/27). If you're already using one of the clients below, make sure to upgrade to the latest version. If the client you're using isn't listed below it may not support ACMEv2, in which case we recommend contacting the project maintainers or switching to another client.
 
 {{< clients libraries="Libraries" projects="Projects integrating with Let's Encrypt" >}}
 


### PR DESCRIPTION
I don't know if this information is true other than from what I read on https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430/27 - but I guess that announcement is a reliable source.

I also edited https://en.wikipedia.org/w/index.php?title=Automated_Certificate_Management_Environment&type=revision&diff=1028228363&oldid=1027929407 based on the same source of information.