### PR TITLE
Adding HCL Domino

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -957,6 +957,20 @@
 				"TLS-ALPN-01": "terraform-provider-acme >= 2.4.0"
 			},
 			"category": "Configuration management tools"
+		},
+		{
+		        "name": "HCL Domino",
+       			"url": "https://help.hcltechsw.com/domino/12.0.0/admin/secu_le_using_certificate_manager.html",
+			"library": "Domino",
+			"category": "Domino",
+			"comments": "(Full ACME V2 flow integration for HCL Domino™ servers)",
+			"acme_v2": "true",
+			"challenges": {
+                                "HTTP-01": "true",
+                                "DNS-01": "true",
+                                "TLS-SNI-01": "false",
+                                "TLS-SNI-02": "false"
+                        }
 		}
 	]
 }

--- a/data/clients.json
+++ b/data/clients.json
@@ -961,7 +961,6 @@
 		{
 		        "name": "HCL Domino",
        			"url": "https://help.hcltechsw.com/domino/12.0.0/admin/secu_le_using_certificate_manager.html",
-			"library": "Domino",
 			"category": "Domino",
 			"comments": "(Full ACME V2 flow integration for HCL Domino™ servers)",
 			"acme_v2": "true",

--- a/data/clients.json
+++ b/data/clients.json
@@ -976,19 +976,19 @@
 				"TLS-SNI-02": "false",
 				"TLS-ALPN-01": "false"
 			}
-    },
-    {
-      "name": "HCL Domino",
+		},
+		{
+			"name": "HCL Domino",
 			"url": "https://help.hcltechsw.com/domino/12.0.0/admin/secu_le_using_certificate_manager.html",
 			"category": "Domino",
 			"comments": "(Full ACME V2 flow integration for HCL Domino™ servers)",
 			"acme_v2": "true",
 			"challenges": {
-        "HTTP-01": "true",
-        "DNS-01": "true",
-        "TLS-SNI-01": "false",
-        "TLS-SNI-02": "false"
-      }
+				"HTTP-01": "true",
+				"DNS-01": "true",
+				"TLS-SNI-01": "false",
+				"TLS-SNI-02": "false"
+			}
 		}
 	]
 }

--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2021-03-20",
+	"lastmod": "2021-06-21",
 	"categories": [
 		"Bash",
 		"C",

--- a/data/clients.json
+++ b/data/clients.json
@@ -960,7 +960,7 @@
 		},
 		{
 		        "name": "HCL Domino",
-       			"url": "https://help.hcltechsw.com/domino/12.0.0/admin/secu_le_using_certificate_manager.html",
+			"url": "https://help.hcltechsw.com/domino/12.0.0/admin/secu_le_using_certificate_manager.html",
 			"category": "Domino",
 			"comments": "(Full ACME V2 flow integration for HCL Domino™ servers)",
 			"acme_v2": "true",


### PR DESCRIPTION
Adding HCL Domino V12 which now natively supports Let's Encrypt

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
