### PR TITLE
Add NethServer and OPNsense

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2021-06-21",
+	"lastmod": "2021-08-20",
 	"categories": [
 		"Bash",
 		"C",
@@ -139,6 +139,14 @@
 		{
 			"name": "Gitlab",
 			"url": "https://about.gitlab.com"
+        },
+        {
+        	"name": "NethServer",
+			"url": "https://www.nethserver.org/"
+        },
+        {
+        	"name": "OPNsense",
+			"url": "https://opnsense.org/"
         }
 	],
 	"list": [


### PR DESCRIPTION
Add Nethserver and OPNsense to projects integrating with Let's Encrypt

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
