### PR TITLE
Correct serbian footer translation

### DIFF
--- a/i18n/sr.toml
+++ b/i18n/sr.toml
@@ -31,7 +31,7 @@ other = "Podržite sigurniji internet koji poštuje privatnost"
 other = "Doniraj"
 
 [footer_mailing]
-other = "Сва писма и упите шаљите на:"
+other = "Sva pisma i upite šaljite na:"
 
 [footer_policies]
 other = """


### PR DESCRIPTION
Original translation for mailing address was in the wrong alphabet 