### PR TITLE
Make the expiration emails page indicate that it's a best-effort service

### DIFF
--- a/content/en/docs/expiration-emails.md
+++ b/content/en/docs/expiration-emails.md
@@ -3,7 +3,7 @@ title: Expiration Emails
 slug: expiration-emails
 top_graphic: 1
 date: 2016-07-02
-lastmod: 2020-10-28
+lastmod: 2021-09-25
 show_lastmod: 1
 ---
 
@@ -11,10 +11,12 @@ show_lastmod: 1
 # Subscribing
 
 If you provide an email address to Let's Encrypt when you create your
-account, we'll automatically send you expiry notices when your certificate
-is coming up for renewal. We send the first notice at 20 days before
-your certificate expires, and more notices at 10 days and 1 day before
-it expires.
+account, we'll do our best to automatically send you expiry notices
+when your certificate is coming up for renewal. We try to send the first
+notice at 20 days before your certificate expires, and more notices
+at 10 days and 1 day before it expires. We recommend that you rely on
+your ACME client to automatically renew your certificates, and only use
+these expiry notices as a warning to check on your automation.
 
 # When You Get an Expiration Email
 


### PR DESCRIPTION
In response to [a note on the forum](https://community.letsencrypt.org/t/missing-expiration-note-email/160457/11?u=jcjones), this edit is to indicate the level of service we are intending to provide with the expiration mailer. In reality, with emails it's impossible to guarantee timely delivery on a mass scale, so subscribers should rely on automation first, and emails as a backup notice.
