### PR TITLE
Update cert-compat page for DST Root CA X3 expiry

### DIFF
--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -2,12 +2,12 @@
 title: Certificate Compatibility
 slug: certificate-compatibility
 top_graphic: 1
-lastmod: 2021-05-12
+lastmod: 2021-09-30
 show_lastmod: 1
 ---
 
 
-The main determining factor for whether a platform can validate Let's Encrypt certificates is whether that platform trusts ISRG's "ISRG Root X1" certificate. Some platforms can validate our certificates even though they don't include ISRG Root X1, because they trust IdenTrust's "DST Root CA X3" certificate. After September 2021, only those platforms that trust ISRG Root X1 will continue to validate Let's Encrypt certificates ([with the exception of Android][android-compat]).
+The main determining factor for whether a platform can validate Let's Encrypt certificates is whether that platform trusts ISRG's "ISRG Root X1" certificate. Prior to September 2021, some platforms could validate our certificates even though they don't include ISRG Root X1, because they trusted IdenTrust's "DST Root CA X3" certificate. From October 2021 onwards, only those platforms that trust ISRG Root X1 will validate Let's Encrypt certificates ([with the exception of Android][android-compat]).
 
 [android-compat]: /2020/12/21/extending-android-compatibility.html
 
@@ -31,26 +31,25 @@ Browsers (Chrome, Safari, Edge, Opera) generally trust the same root certificate
 
 [chrome-root-store]: https://www.chromium.org/Home/chromium-security/root-ca-policy
 
-# Platforms that trust DST Root CA X3
+# Platforms that trust DST Root CA X3 but not ISRG Root X1
 
-* Windows >= XP SP3
-* macOS (most versions)
-* iOS (most versions)
-* [Android >= v2.3.6](https://twitter.com/Tutancagamon/status/600783165087752192)
-* Mozilla Firefox >= v2.0
-* Ubuntu >= precise / 12.04
-* [Debian >= squeeze / 6](https://twitter.com/TokenScandi/status/600806080684359680)
-* Java 8 >= 8u101
-* Java 7 >= 7u111
-* NSS >= v3.11.9
-* Amazon FireOS (Silk Browser)
-* Cyanogen > v10
-* Jolla Sailfish OS > v1.1.2.16
-* Kindle > v3.4.1
-* Blackberry >= 10.3.3
-* PS4 game console with firmware >= 5.00
+These platforms would have worked up to September 2021 but will no longer
+validate Let's Encrypt certificates.
 
-You may want to visit [this 2015-2017 community forum discussion](https://community.letsencrypt.org/t/which-browsers-and-operating-systems-support-lets-encrypt/) for more information about compatibility.
+* macOS < 10.12.1
+* iOS < 10
+* Mozilla Firefox < 50
+* Ubuntu >= precise / 12.04 and < xenial / 16.04
+* [Debian >= squeeze / 6](https://twitter.com/TokenScandi/status/600806080684359680) and < jessie /8
+* Java 8 >= 8u101 and < 8u141
+* Java 7 >= 7u111 and < 7u151
+* NSS >= v3.11.9 and < 3.26
+* Amazon FireOS (Silk Browser) (version range unknown)
+* Cyanogen > v10 (version that added ISRG Root X1 unknown)
+* Jolla Sailfish OS > v1.1.2.16 (version that added ISRG Root X1 unknown)
+* Kindle > v3.4.1 (version that added ISRG Root X1 unknown)
+* Blackberry >= 10.3.3 (version that added ISRG Root X1 unknown)
+* PS4 game console with firmware >= 5.00 (version that added ISRG Root X1 unknown)
 
 # Known Incompatible
 
@@ -67,6 +66,5 @@ You may want to visit [this 2015-2017 community forum discussion](https://commun
 * PS4 game console with firmware < 5.00
 
 # ISRG Root X2 (new ECDSA root) - coming soon
+
 We have submitted ISRG Root X2 to the Microsoft, Apple, Google, Mozilla, and Oracle root programs for inclusion. ISRG Root X2 is already widely trusted via a cross-sign from our ISRG Root X1. For more information, check our our [community forum post](https://community.letsencrypt.org/t/isrg-root-x2-submitted-to-root-programs/149385)
-
-


### PR DESCRIPTION
Talk about the expiration in the past, and also update the "Platforms
that trust DST Root CA X3" section to indicate that those platforms will
no longer validate Let's Encrypt certificates.