### PR TITLE
Add margin-top to the donate button

### DIFF
--- a/src/css/_layout.scss
+++ b/src/css/_layout.scss
@@ -150,6 +150,7 @@ html[dir="rtl"] .site-title {
         a {
             font-size: 24px;
         }
+        margin-top: 1.5em;
         margin-bottom: 1.5em;
     }
 }


### PR DESCRIPTION
On the small screen, I feel the top margin of the "Donate" button at the bottom of the page is a bit too narrow.

This PR adds a wider `margin-top` to the button.

## Screenshot

Here are the visual changes.

### Small screen

**Before**

<img width="411" alt="Screen Shot 2021-10-07 at 21 11 13" src="https://user-images.githubusercontent.com/1425259/136383319-8dd8006f-02c2-4d64-ad04-343fe06dd197.png">

**After**

<img width="405" alt="Screen Shot 2021-10-07 at 21 11 22" src="https://user-images.githubusercontent.com/1425259/136383323-3334e13a-08a3-4ece-89f7-f30b1434b351.png">

### Wide screen

**Before**

<img width="828" alt="Screen Shot 2021-10-07 at 21 12 33" src="https://user-images.githubusercontent.com/1425259/136383330-6a88d48b-638f-4931-859c-af261a823442.png">

**After**

<img width="824" alt="Screen Shot 2021-10-07 at 21 12 26" src="https://user-images.githubusercontent.com/1425259/136383326-5f9eeea9-7b7f-43c9-8c79-a24f35881c3d.png">
