### PR TITLE
ISRG Root X1 is supported in Ubuntu 12.04 ESM

### DIFF
--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -39,6 +39,7 @@ validate Let's Encrypt certificates.
 * macOS < 10.12.1
 * iOS < 10
 * Mozilla Firefox < 50
+* Ubuntu >= lucid / 10.04 (with updates applied)
 * [Debian >= squeeze / 6](https://twitter.com/TokenScandi/status/600806080684359680) and < jessie /8
 * Java 8 >= 8u101 and < 8u141
 * Java 7 >= 7u111 and < 7u151

--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -2,7 +2,7 @@
 title: Certificate Compatibility
 slug: certificate-compatibility
 top_graphic: 1
-lastmod: 2021-09-30
+lastmod: 2021-10-09
 show_lastmod: 1
 ---
 
@@ -21,7 +21,7 @@ If your certificate validates on some of the "Known Compatible" platforms but no
 * [iPhone 5 and above can upgrade to iOS 10](https://en.wikipedia.org/wiki/IPhone_5) and can thus trust ISRG Root X1
 * [Android >= 7.1.1](https://android.googlesource.com/platform/system/ca-certificates/+/android-7.1.1_r15) (but Android >= 2.3.6 will work by default [due to our special cross-sign](https://letsencrypt.org/2020/12/21/extending-android-compatibility.html))
 * [Mozilla Firefox >= 50.0](https://bugzilla.mozilla.org/show_bug.cgi?id=1204656)
-* [Ubuntu >= xenial / 16.04](https://packages.ubuntu.com/xenial/all/ca-certificates/filelist) (with updates applied)
+* Ubuntu >= precise / 12.04 (with updates applied)
 * [Debian >= jessie / 8](https://packages.debian.org/jessie/all/ca-certificates/filelist) (with updates applied)
 * [Java 8 >= 8u141](https://www.oracle.com/java/technologies/javase/8u141-relnotes.html)
 * [Java 7 >= 7u151](https://www.oracle.com/java/technologies/javase/7u151-relnotes.html)

--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -39,7 +39,7 @@ validate Let's Encrypt certificates.
 * macOS < 10.12.1
 * iOS < 10
 * Mozilla Firefox < 50
-* Ubuntu >= lucid / 10.04 (with updates applied)
+* Ubuntu >= lucid / 10.04
 * [Debian >= squeeze / 6](https://twitter.com/TokenScandi/status/600806080684359680) and < jessie /8
 * Java 8 >= 8u101 and < 8u141
 * Java 7 >= 7u111 and < 7u151

--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -39,7 +39,6 @@ validate Let's Encrypt certificates.
 * macOS < 10.12.1
 * iOS < 10
 * Mozilla Firefox < 50
-* Ubuntu >= precise / 12.04 and < xenial / 16.04
 * [Debian >= squeeze / 6](https://twitter.com/TokenScandi/status/600806080684359680) and < jessie /8
 * Java 8 >= 8u101 and < 8u141
 * Java 7 >= 7u111 and < 7u151


### PR DESCRIPTION
`cert-compat.md` says that ISRG Root X1 was added in Ubuntu 16.04, but, "with updates applied," it goes back farther.

For Ubuntu 12.04 LTS, it was added at some point during the ESM period. (ESM is paid support after normal support ends, but it's also free for up to 3 computers. Ubuntu likes TLAs!) Moreover, after ESM support ended this year, they actually published all the updated packages, so anyone can install them now.

Not sure if there's web-browser-readable evidence of that, but if you go to https://old-releases.ubuntu.com/ubuntu/dists/precise-updates/main/binary-amd64/, you can see that the files were updated a few months ago, and:

```
$ wget -q https://old-releases.ubuntu.com/ubuntu/dists/precise-updates/main/binary-amd64/Packages.bz2
$ rg -zA 2 "Package: ca-certificates" Packages.bz2
3048:Package: ca-certificates
3049-Architecture: all
3050-Version: 20190110~12.04.1
$ wget -q https://old-releases.ubuntu.com/ubuntu/pool/main/c/ca-certificates/ca-certificates_20190110~12.04.1_all.deb
$ dpkg -c ca-certificates_20190110~12.04.1_all.deb | rg ISRG_Root_X1
-rw-r--r-- root/root      1939 2020-06-01 15:07 ./usr/share/ca-certificates/mozilla/ISRG_Root_X1.crt
```

If you don't want to count that, it was added to Ubuntu 14.04 LTS during regular support; it had up to `ca-certificates` version `20170717~14.04.2`.

I don't know what the first Ubuntu release with ISRG Root X1 from creation was.

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.