### PR TITLE
Ubuntu 8.10 actually supported DST Root CA X3

### DIFF
--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -2,7 +2,7 @@
 title: Certificate Compatibility
 slug: certificate-compatibility
 top_graphic: 1
-lastmod: 2021-10-09
+lastmod: 2021-10-31
 show_lastmod: 1
 ---
 
@@ -39,7 +39,7 @@ validate Let's Encrypt certificates.
 * macOS < 10.12.1
 * iOS < 10
 * Mozilla Firefox < 50
-* Ubuntu >= lucid / 10.04
+* Ubuntu >= intrepid / 8.10
 * [Debian >= squeeze / 6](https://twitter.com/TokenScandi/status/600806080684359680) and < jessie /8
 * Java 8 >= 8u101 and < 8u141
 * Java 7 >= 7u111 and < 7u151


### PR DESCRIPTION
In #1322, I got as far as figuring out that Ubuntu 10.04 LTS supported DST Root CA X3.

I'm a bad sleuth. It turns out 8.10, 9.04 and 9.10 did, too! (8.04 really didn't.)

I had checked the non-LTS release situation for *ISRG Root X1*, but I had only checked which LTS release added DST Root CA X3. :-(

cc @jsha

```
$ wget -q https://old-releases.ubuntu.com/ubuntu/dists/intrepid/main/binary-amd64/Packages.bz2
$ rg -zA 7 '^Package: ca-certificates$' Packages.bz2
5367:Package: ca-certificates
5368-Priority: important
5369-Section: misc
5370-Installed-Size: 724
5371-Maintainer: Ubuntu Core Developers <ubuntu-devel-discuss@lists.ubuntu.com>
5372-Original-Maintainer: Fumitoshi UKAI <ukai@debian.or.jp>
5373-Architecture: all
5374-Version: 20080514-0ubuntu1
$ wget -q https://old-releases.ubuntu.com/ubuntu/pool/main/c/ca-certificates/ca-certificates_20080514-0ubuntu1_all.deb
$ dpkg -c ca-certificates_20080514-0ubuntu1_all.deb | rg DST_Root_CA_X3
-rw-r--r-- root/root      1201 2008-06-03 09:46 ./usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt
 ```

So... yeah...

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.