### PR TITLE
Improve translation (remove useless things)

### DIFF
--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -20,7 +20,17 @@ If you are interested to add a new language, please open an issue with the infor
 
 Someone from Let's Encrypt will add the language to Crowdin so you can start translating on https://crowdin.com/project/lets-encrypt-website
 
-When enough pages are translated, someone from Let's Encrypt will create the first pull request:
+The first files that needs to be translated on Crowdin are:
+- `en.toml`
+- `content/about.md`
+- `content/getting-started.md`
+
+It's also preferable to translated first:
+- `content/client-options.md`
+- `content/how-it-works.md`
+- `content/faq.md`
+
+When enough pages are translated on Crowdin, someone from Let's Encrypt will create the first pull request:
 
 ### First pull-request
 

--- a/config/_default/menu.de.toml
+++ b/config/_default/menu.de.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "Spenden"
 weight = 30
 identifier = "donate"
-url = "/de/donate/"
 [[main]]
 name = "Über uns"
 weight = 40
 identifier = "about"
-url = "/de/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.en.toml
+++ b/config/_default/menu.en.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "Donate"
 weight = 30
 identifier = "donate"
-url = "/donate/"
 [[main]]
 name = "About Us"
 weight = 40
 identifier = "about"
-url = "/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.es.toml
+++ b/config/_default/menu.es.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/c/help/ayuda-en-espanol/22"
 name = "Donar"
 weight = 30
 identifier = "donate"
-url = "/es/donate/"
 [[main]]
 name = "Acerca De"
 weight = 40
 identifier = "about"
-url = "/es/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.fr.toml
+++ b/config/_default/menu.fr.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/c/help/aide-en-francais"
 name = "Faire un don"
 weight = 30
 identifier = "donate"
-url = "/fr/donate/"
 [[main]]
 name = "À propos de nous"
 weight = 40
 identifier = "about"
-url = "/fr/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.he.toml
+++ b/config/_default/menu.he.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "תרומה"
 weight = 30
 identifier = "donate"
-url = "/he/donate/"
 [[main]]
 name = "עלינו"
 weight = 40
 identifier = "about"
-url = "/he/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.id.toml
+++ b/config/_default/menu.id.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "Donasi"
 weight = 30
 identifier = "donate"
-url = "/id/donate/"
 [[main]]
 name = "Tentang Kami"
 weight = 40
 identifier = "about"
-url = "/id/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.ja.toml
+++ b/config/_default/menu.ja.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "寄付"
 weight = 30
 identifier = "donate"
-url = "/ja/donate/"
 [[main]]
 name = "私たちについて"
 weight = 40
 identifier = "about"
-url = "/ja/about/"
 [[main]]
 name = "インターネット・セキュリティ研究グループ (ISRG)"
 weight = 20

--- a/config/_default/menu.ko.toml
+++ b/config/_default/menu.ko.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "후원"
 weight = 30
 identifier = "donate"
-url = "/ko/donate/"
 [[main]]
 name = "소개"
 weight = 40
 identifier = "about"
-url = "/ko/about/"
 [[main]]
 name = "비영리 인터넷 보안 연구 그룹 (ISRG)"
 weight = 20

--- a/config/_default/menu.pt-br.toml
+++ b/config/_default/menu.pt-br.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/c/help/ajuda-em-portugues"
 name = "Doar"
 weight = 30
 identifier = "donate"
-url = "/pt-br/donate/"
 [[main]]
 name = "Sobre Nós"
 weight = 40
 identifier = "about"
-url = "/pt-br/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.ru.toml
+++ b/config/_default/menu.ru.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "Поддержите нас"
 weight = 30
 identifier = "donate"
-url = "/ru/donate/"
 [[main]]
 name = "О сервисе"
 weight = 40
 identifier = "about"
-url = "/ru/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.sr.toml
+++ b/config/_default/menu.sr.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "Doniraj"
 weight = 30
 identifier = "donate"
-url = "/sr/donate/"
 [[main]]
 name = "O nama"
 weight = 40
 identifier = "about"
-url = "/sr/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.sv.toml
+++ b/config/_default/menu.sv.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "Donera"
 weight = 30
 identifier = "donate"
-url = "/sv/donate/"
 [[main]]
 name = "Om oss"
 weight = 40
 identifier = "about"
-url = "/sv/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.uk.toml
+++ b/config/_default/menu.uk.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "Підтримати"
 weight = 30
 identifier = "donate"
-url = "/uk/donate/"
 [[main]]
 name = "Про сервіс"
 weight = 40
 identifier = "about"
-url = "/uk/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.vi.toml
+++ b/config/_default/menu.vi.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "Quyên Góp"
 weight = 30
 identifier = "donate"
-url = "/vi/donate/"
 [[main]]
 name = "Giới Thiệu"
 weight = 40
 identifier = "about"
-url = "/vi/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/config/_default/menu.zh-cn.toml
+++ b/config/_default/menu.zh-cn.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "捐赠"
 weight = 30
 identifier = "donate"
-url = "/zh-cn/donate/"
 [[main]]
 name = "关于"
 weight = 40
 identifier = "about"
-url = "/zh-cn/about/"
 [[main]]
 name = "互联网安全研究小组（ISRG）"
 weight = 20

--- a/config/_default/menu.zh-tw.toml
+++ b/config/_default/menu.zh-tw.toml
@@ -6,12 +6,10 @@ url = "https://community.letsencrypt.org/"
 name = "捐贈"
 weight = 30
 identifier = "donate"
-url = "/zh-tw/donate/"
 [[main]]
 name = "關於我們"
 weight = 40
 identifier = "about"
-url = "/zh-tw/about/"
 [[main]]
 name = "Internet Security Research Group (ISRG)"
 weight = 20

--- a/content/base-l10n/docs/lencr-org.md
+++ b/content/base-l10n/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/de/docs/lencr-org.md
+++ b/content/de/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/es/docs/lencr-org.md
+++ b/content/es/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/fr/docs/lencr-org.md
+++ b/content/fr/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/id/docs/lencr-org.md
+++ b/content/id/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/it/docs/lencr-org.md
+++ b/content/it/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/ja/docs/lencr-org.md
+++ b/content/ja/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/ko/docs/lencr-org.md
+++ b/content/ko/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/pt-br/docs/lencr-org.md
+++ b/content/pt-br/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/ru/docs/lencr-org.md
+++ b/content/ru/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/sr/docs/lencr-org.md
+++ b/content/sr/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/sv/docs/lencr-org.md
+++ b/content/sv/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/vi/docs/lencr-org.md
+++ b/content/vi/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/zh-cn/docs/lencr-org.md
+++ b/content/zh-cn/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre

--- a/content/zh-tw/docs/lencr-org.md
+++ b/content/zh-tw/docs/lencr-org.md
@@ -1,26 +1,4 @@
 ---
-title: lencr.org
 slug: lencr.org
-top_graphic: 1
-date: 2020-12-04
-lastmod: 2020-12-04
 untranslated: 1
-show_lastmod: 1
 ---
-
-
-# What's lencr.org?
-
-`lencr.org` is a domain owned by Let's Encrypt. We use it to host OCSP, CRLs,
-and issuer certificates: all the URLs that show up in certificates.
-
-We used to use longer URLs like `http://ocsp.int-x3.letsencrypt.org/`. However,
-when we issued our [new root and intermediate certificates][1], we wanted to
-make them as small as possible. Every HTTPS connection on the web (billions per
-day) has to send a copy of a certificate, so every byte matters. We chose
-`lencr.org` because of its similarity with our name: **L**et's **ENCR**ypt. We
-pronounce it much like the fictional region of [Lancre] in Terry Pratchett's
-_Discworld_ novels.
-
-[1]: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
-[Lancre]: https://discworld.fandom.com/wiki/Lancre


### PR DESCRIPTION

- Remove useless body of untranslated `lencr.org` pages (the `untranslated: 1` automatically trigger the macro that replace the content of the page with the current English version)

- remove useless url on `donate` and `about` main menu