### PR TITLE
Add blog to the main nav, as the last item of the about menu.

### DIFF
--- a/content/en/post/_index.md
+++ b/content/en/post/_index.md
@@ -2,4 +2,8 @@
 title: Blog
 url: "/blog/"
 top_graphic: 2
+menu:
+  main:
+    weight: 100
+    parent: about
 ---


### PR DESCRIPTION
Based on #686.

We don't have room for another top-level item, so I added this to the "About" menu.

@bdaehlie Let me know if you think this is sufficient or if I should look into an alternative.

![Screen Shot 2021-11-08 at 3 46 08 PM](https://user-images.githubusercontent.com/83726258/140823506-bccc3d31-e445-4553-88fa-6a7a224c53c7.png)

