### PR TITLE
Fix wrong CLI param for staging certs

### DIFF
--- a/content/en/docs/staging-environment.md
+++ b/content/en/docs/staging-environment.md
@@ -3,7 +3,7 @@ title: Staging Environment
 slug: staging-environment
 top_graphic: 1
 date: 2018-01-05
-lastmod: 2021-05-13
+lastmod: 2021-11-09
 show_lastmod: 1
 ---
 

--- a/content/en/docs/staging-environment.md
+++ b/content/en/docs/staging-environment.md
@@ -14,7 +14,7 @@ The ACME URL for our [ACME v2 staging environment](https://community.letsencrypt
 
 `https://acme-staging-v02.api.letsencrypt.org/directory`
 
-If you're using Certbot, you can use our staging environment with the `--dry-run` flag. For other ACME clients, please read their instructions for information on testing with our staging environment. Please note the v2 staging environment requires a v2 compatible ACME client.
+If you're using Certbot, you can use our staging environment with the `--test-cert` flag. For other ACME clients, please read their instructions for information on testing with our staging environment. Please note the v2 staging environment requires a v2 compatible ACME client.
 
 # Rate Limits
 


### PR DESCRIPTION
See the [Certbot documentation](https://certbot.eff.org/docs/using.html#certbot-command-line-options) for the explanation:

> --test-cert       Obtain a test certificate from a staging server
> --dry-run         Test "renew" or "certonly" **without saving any certificates to disk**