### PR TITLE
Mention Certbot `show_account` subcommand on Account ID page

### DIFF
--- a/content/en/docs/account-id.md
+++ b/content/en/docs/account-id.md
@@ -3,7 +3,7 @@ title: Finding Account IDs
 slug: account-id
 top_graphic: 1
 date: 2016-08-10
-lastmod: 2019-07-30
+lastmod: 2021-12-27
 show_lastmod: 1
 ---
 
@@ -16,8 +16,10 @@ multiple accounts configured if you run ACME clients on multiple servers.
 Your account ID is a URL of the form
 `https://acme-v02.api.letsencrypt.org/acme/acct/12345678`.
 
-If you're using Certbot, you can find your account ID by looking at the "uri"
-field in
+If you're using [Certbot](https://certbot.eff.org/) and you're running version
+1.23.0 or newer, you can find your account ID by running the `certbot show_account`
+subcommand. If your Certbot is older than 1.23.0, then you can find the account ID
+by looking at the "uri" field in
 `/etc/letsencrypt/accounts/acme-v02.api.letsencrypt.org/directory/*/regr.json`.
 
 If you're using another ACME client, the instructions will be client-dependent.


### PR DESCRIPTION
Recently, a new subcommand was added to Certbot: [`show_account`](https://github.com/certbot/certbot/commit/93c2852fdba34f14b294b38dcd27a0a8d94fe053)

While it was mainly intended to show stuff like email contact info of the account, the account ID is added to the output too. Therefore, for users running certbot 1.23.0 or newer could use this simple subcommand to fetch their account ID instead of the requirement to open JSON files.

While adding this info I also added a link to the Certbot homepage on the first mention of Certbot. Can't hurt methinks.

<s>**Note**: Certbot 1.23.0 hasn't been released yet. Therefore, I suggest waiting with merging this PR, if accepted, until the next release of Certbot.</s>