### PR TITLE
Update TLS-ALPN-01 Incident Page

### DIFF
--- a/content/en/tlsalpnrevocation.md
+++ b/content/en/tlsalpnrevocation.md
@@ -3,12 +3,12 @@ title: Download affected certificate serials for 2022.01.25 TLS-ALPN-01 Incident
 slug: tlsalpnrevocation
 top_graphic: 4
 date: 2022-01-27
-lastmod: 2022-01-27
+lastmod: 2022-03-02
 english_is_canonical: 1
 show_lastmod: 1
 ---
 
-This page hosts the list of certificates affected by the TLS-ALPN-01 Incident. You can find details about this incident [in the community forum](https://community.letsencrypt.org/t/2022-01-25-issue-with-tls-alpn-01-validation-method/170450) and [on bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1751984).
+This page hosts the list of certificates affected by the TLS-ALPN-01 Incident. You can find details about this incident [in the community forum](https://community.letsencrypt.org/t/2022-01-25-issue-with-tls-alpn-01-validation-method/170450) and [on bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1751984). The list of affected certificates will be available until 25 April 2022. After that date, all affected certificates will be expired.
 
 We have sent notification emails to affected subscribers who have registered a valid email address; if you received an email, you have at least one affected certificate. You may not have received an email if you did not provide an email address when registering your ACME account, if you unsubscribed from Let's Encrypt [email notifications](https://letsencrypt.org/docs/expiration-emails/) previously, or if the email was caught by a spam filter.
 


### PR DESCRIPTION
Include final date that affected certificate data for the TLS-ALPN-01 Incident will be available/hosted by Let's Encrypt.
