### PR TITLE
Avoid double-rendering of link .Text

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -8,7 +8,7 @@
 	{{- else if not $page.RelPermalink }}{{ errorf "Missing page %q in %q" $pagename .Position -}}
 	{{- else -}}
 	<a href="{{ $page.RelPermalink }}{{ with $anchor }}#{{ . }}{{ end }}" hreflang="{{ $page.Language.Params.languageCode }}"{{ with .Title}} title="{{ . }}"{{ end }}>
-		{{- .Text | markdownify -}}
+		{{- .Text | safeHTML -}}
     </a>
 	{{- end -}}
 {{- else -}}


### PR DESCRIPTION
This is a common source of infinite recursion (stack overflow) when the `linkify` option is enabled.

In the upcoming Hugo 0.94.0 building will fail without this patch:

```bash
Error: Error building site: "/Users/bep/dev/sites/website/layouts/_default/_markup/render-link.html:11:14": execute of template failed: template: _default/_markup/render-link.html:11:14: executing "_default/_markup/render-link.html" at <markdownify>:
error calling markdownify: text is already rendered, repeating it may cause infinite recursion
```


