### PR TITLE
Add docs for duplicate certificate rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,35 @@ To help with translation, please see [TRANSLATION.md].
 [http://localhost:1313/]: http://localhost:1313/
 [TRANSLATION.md]: https://github.com/letsencrypt/website/blob/master/TRANSLATION.md
 [netlify.toml]: https://github.com/letsencrypt/website/blob/master/netlify.toml
+
+# Creating new pages
+
+When creating new pages you'll need to add a translation stub for each language.
+You can use the `new-page.sh` script to create these automatically:
+```sh
+Usage: ./new-page.sh <page-path> <page title>
+Examples:
+./new-page.sh my-page "My Page Title"
+./new-page.sh post/my-post "My Post Title"
+```
+```sh
+$ ./new-page.sh docs/new-page "My New Page"
+Created page: ./content/vi/docs/new-page.md
+Created page: ./content/sv/docs/new-page.md
+Created page: ./content/he/docs/new-page.md
+Created page: ./content/ja/docs/new-page.md
+Created page: ./content/base-l10n/docs/new-page.md
+Created page: ./content/it/docs/new-page.md
+Created page: ./content/ru/docs/new-page.md
+Created page: ./content/zh-cn/docs/new-page.md
+Created page: ./content/uk/docs/new-page.md
+Created page: ./content/sr/docs/new-page.md
+Created page: ./content/zh-tw/docs/new-page.md
+Created page: ./content/pt-br/docs/new-page.md
+Created page: ./content/de/docs/new-page.md
+Created page: ./content/ko/docs/new-page.md
+Created page: ./content/id/docs/new-page.md
+Created page: ./content/fr/docs/new-page.md
+Created page: ./content/es/docs/new-page.md
+Created page: ./content/en/docs/new-page.md
+```

--- a/content/base-l10n/docs/duplicate-certificate-limit.md
+++ b/content/base-l10n/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/de/docs/duplicate-certificate-limit.md
+++ b/content/de/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/en/docs/duplicate-certificate-limit.md
+++ b/content/en/docs/duplicate-certificate-limit.md
@@ -10,18 +10,17 @@ show_lastmod: 1
 
 # Description
 All issuance requests are subject to a *Duplicate Certificate* limit of 5 per
-week. You should receive the following error message from your ACME client when
-you’ve exceeded the Duplicate Certificate limit:
+week. You should receive an error message like the following from your ACME
+client when you’ve exceeded the Duplicate Certificate limit:
 ```
 too many certificates (5) already issued for this exact set of domains in the
-last 168 hours: example.com login.example.com: see
-https://letsencrypt.org/docs/duplicate-certificate-limit
+last 168 hours: example.com login.example.com: see https://letsencrypt.org/docs/duplicate-certificate-limit
 ```
 The "exact set" that this error refers to is the set of hostnames requested for
-this certificate: in this example, example.com and login.example.com. If your
-certificate is issued for only 1 name, such as example.com, then the "exact set"
-of hostnames for your certificate would be `[example.com]`. This rate limit is
-exceeded when a subscriber requests a certificate for the same "exact set" of
+this certificate: in this example, `example.com` and `login.example.com`. If
+your certificate is issued for only 1 name, such as example.com, then the "exact
+set" of hostnames for your certificate would be `[example.com]`. This rate limit
+is exceeded when a subscriber requests a certificate for the same "exact set" of
 hostnames more than 5 times in a single week.
 
 # Common Causes
@@ -41,9 +40,8 @@ need to.
 
 When troubleshooting or testing the deployment of your applications we encourage
 you to configure your ACME client to use our [staging
-environment](/docs/staging-environment/). Rate limits for
-our staging environment are[ significantly
-higher](/docs/staging-environment/#rate-limits).
+environment](/docs/staging-environment/). Rate limits for our staging
+environment are[ significantly higher](/docs/staging-environment/#rate-limits).
 
 # Requesting Help
 
@@ -57,15 +55,15 @@ Overrides are **not** available for the Duplicate Certificate limit.
 
 # Workaround
 
-Unfortunately, revoking the previously issued certificates will not reset the
-Duplicate Certificate limit. However, if you find that you’ve exceeded the limit
-and you still require another certificate for the same hostnames you can always
-request a certificate for a different “exact set” of hostnames. For example, if
-you’ve exceeded the Duplicate Certificate limit for `[example.com]` then
-requesting a certificate for `[example.com, login.example.com]` will succeed.
-Similarly, if you’ve exceeded the Duplicate Certificate limit for `[example.com,
-login.example.com]` then requesting a separate certificate for `[example.com]` and
-another for `[login.example.com]` will succeed.
+Revoking the previously issued certificates will not reset the Duplicate
+Certificate limit. However, if you find that you’ve exceeded the limit and you
+still require another certificate for the same hostnames you can always request
+a certificate for a different “exact set” of hostnames. For example, if you’ve
+exceeded the Duplicate Certificate limit for `[example.com]` then requesting a
+certificate for `[example.com, login.example.com]` will succeed. Similarly, if
+you’ve exceeded the Duplicate Certificate limit for `[example.com,
+login.example.com]` then requesting a separate certificate for `[example.com]`
+and another for `[login.example.com]` will succeed.
 
 # Monitoring Rate Limits
 

--- a/content/en/docs/duplicate-certificate-limit.md
+++ b/content/en/docs/duplicate-certificate-limit.md
@@ -1,0 +1,72 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+date: 2022-06-16
+lastmod: 2022-06-16
+show_lastmod: 1
+---
+
+
+# Description
+All issuance requests are subject to a *Duplicate Certificate* limit of 5 per
+week. You should receive the following error message from your ACME client when
+you’ve exceeded the Duplicate Certificate limit:
+```
+too many certificates (5) already issued for this exact set of domains in the
+last 168 hours: example.com login.example.com: see
+https://letsencrypt.org/docs/duplicate-certificate-limit
+```
+The "exact set" that this error refers to is the set of hostnames requested for
+this certificate: in this example, example.com and login.example.com. If your
+certificate is issued for only 1 name, such as example.com, then the "exact set"
+of hostnames for your certificate would be `[example.com]`. This rate limit is
+exceeded when a subscriber requests a certificate for the same "exact set" of
+hostnames more than 5 times in a single week.
+
+# Common Causes
+
+Subscribers who hit the Duplicate Certificate limit often do so while attempting
+to troubleshoot the deployment of an application or service. Some examples:
+
+If you encounter an error from your ACME client that you do not recognize and
+attempt to remove and reinstall your ACME client multiple times in the process
+of troubleshooting the error, you may exceed the Duplicate Certificate limit.
+
+If you delete the configuration data for your ACME client after each failed
+attempt at installing a certificate, you will hit this rate limit after five
+failed attempts. It's best to make a copy of configuration data before deleting
+it, so you can access previously issued certificates and private keys if you
+need to.
+
+When troubleshooting or testing the deployment of your applications we encourage
+you to configure your ACME client to use our [staging
+environment](/docs/staging-environment/). Rate limits for
+our staging environment are[ significantly
+higher](/docs/staging-environment/#rate-limits).
+
+# Requesting Help
+
+If you’re not sure how to configure your ACME client to use our staging
+environment or you need some help debugging, we encourage you to [request help
+on our community forum](https://community.letsencrypt.org/c/help/13).
+
+# Requesting an Override
+
+Overrides are **not** available for the Duplicate Certificate limit.
+
+# Workaround
+
+Unfortunately, revoking the previously issued certificates will not reset the
+Duplicate Certificate limit. However, if you find that you’ve exceeded the limit
+and you still require another certificate for the same hostnames you can always
+request a certificate for a different “exact set” of hostnames. For example, if
+you’ve exceeded the Duplicate Certificate limit for `[example.com]` then
+requesting a certificate for `[example.com, login.example.com]` will succeed.
+Similarly, if you’ve exceeded the Duplicate Certificate limit for `[example.com,
+login.example.com]` then requesting a separate certificate for `[example.com]` and
+another for `[login.example.com]` will succeed.
+
+# Monitoring Rate Limits
+
+We do not offer a way to monitor subscriber rate limits at this time.

--- a/content/es/docs/duplicate-certificate-limit.md
+++ b/content/es/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/fr/docs/duplicate-certificate-limit.md
+++ b/content/fr/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/he/docs/duplicate-certificate-limit.md
+++ b/content/he/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/id/docs/duplicate-certificate-limit.md
+++ b/content/id/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/it/docs/duplicate-certificate-limit.md
+++ b/content/it/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/ja/docs/duplicate-certificate-limit.md
+++ b/content/ja/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/ko/docs/duplicate-certificate-limit.md
+++ b/content/ko/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/pt-br/docs/duplicate-certificate-limit.md
+++ b/content/pt-br/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/ru/docs/duplicate-certificate-limit.md
+++ b/content/ru/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/sr/docs/duplicate-certificate-limit.md
+++ b/content/sr/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/sv/docs/duplicate-certificate-limit.md
+++ b/content/sv/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/uk/docs/duplicate-certificate-limit.md
+++ b/content/uk/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/vi/docs/duplicate-certificate-limit.md
+++ b/content/vi/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/zh-cn/docs/duplicate-certificate-limit.md
+++ b/content/zh-cn/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/zh-tw/docs/duplicate-certificate-limit.md
+++ b/content/zh-tw/docs/duplicate-certificate-limit.md
@@ -1,0 +1,9 @@
+---
+title: Duplicate Certificate Limit
+slug: duplicate-certificate-limit
+top_graphic: 1
+lastmod: 2022-06-16
+show_lastmod: false
+untranslated: 1
+---
+

--- a/layouts/shortcodes/docs_index.html
+++ b/layouts/shortcodes/docs_index.html
@@ -13,9 +13,9 @@
 <ul>
     <li>{{ template "link" (dict "context" . "page" "/docs/client-options") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/rate-limits") }}
-    <ul>
-        <li>{{ template "link" (dict "context" . "page" "/docs/duplicate-certificate-limit") }}</li>
-    </ul>
+        <ul>
+            <li>{{ template "link" (dict "context" . "page" "/docs/duplicate-certificate-limit") }}</li>
+        </ul>
     </li>
     <li>{{ template "link" (dict "context" . "page" "/docs/expiration-emails") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/dst-root-ca-x3-expiration-september-2021") }}</li>

--- a/layouts/shortcodes/docs_index.html
+++ b/layouts/shortcodes/docs_index.html
@@ -12,7 +12,11 @@
 
 <ul>
     <li>{{ template "link" (dict "context" . "page" "/docs/client-options") }}</li>
-    <li>{{ template "link" (dict "context" . "page" "/docs/rate-limits") }}</li>
+    <li>{{ template "link" (dict "context" . "page" "/docs/rate-limits") }}
+    <ul>
+        <li>{{ template "link" (dict "context" . "page" "/docs/duplicate-certificate-limit") }}</li>
+    </ul>
+    </li>
     <li>{{ template "link" (dict "context" . "page" "/docs/expiration-emails") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/dst-root-ca-x3-expiration-september-2021") }}</li>
 </ul>

--- a/new-page.sh
+++ b/new-page.sh
@@ -14,7 +14,7 @@ filename="${slug}.md"
 title="${2}"
 date=$(date +%Y-%m-%d)
 
-for i in $(find . -type d -path './content/*' ! -path '*/documents' ! -path '*/docs' ! -path '*/post')
+for i in $(find . -type d -path './content/*' -maxdepth 2)
 do
     # If the directory doesn't exist, create it.
     if ! [ -d "${i}/${path}" ] && ! [ "${path}" = post ]
@@ -29,7 +29,7 @@ do
         # Create the new page.
         if ! [ -f "${i}/${path}/${filename}" ]
         then
-        tee "${i}/${path}/${filename}" << EOF
+            cat > "${i}/${path}/${filename}" << EOF
 ---
 title: ${title}
 slug: ${slug}
@@ -53,7 +53,7 @@ EOF
         # Create the stub (untranslated) page.
         if ! [ -f "${i}/${path}/${filename}" ]
         then
-            tee "${i}/${path}/${filename}"  << EOF
+            cat > "${i}/${path}/${filename}"  << EOF
 ---
 title: ${title}
 slug: ${slug}

--- a/new-page.sh
+++ b/new-page.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-if [ -z "$1" ] || [ -z "$2" ] || [ $1 = "-help" ] || [ $1 = "--help" ]; then
-  echo "Usage: $0 <page-path> <page title>"
+if [ -z "${1}" ] || [ -z "${2}" ] || [ "${1}" = "-h" ] || [ "${1}" = "-help" ] || [ "${1}" = "--help" ]
+then
+  echo "Usage: "${0}" <page-path> <page title>"
   echo "Examples:"
   echo "${0} my-page \"My Page Title\""
   echo "${0} post/my-post \"My Post Title\""
@@ -39,8 +40,8 @@ show_lastmod: false
 ---
 
 EOF
-    echo "Created page: ${i}/${path}/${filename}"
-    fi
+        echo "Created page: ${i}/${path}/${filename}"
+        fi
     else
         # Actions only for non-English (e.g. no-translation stubs, etc.)
 

--- a/new-page.sh
+++ b/new-page.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ] || [ -z "$2" ] || [ $1 = "-help" ] || [ $1 = "--help" ]; then
+  echo "Usage: $0 <page-path> <page title>"
+  echo "Examples:"
+  echo "${0} my-page \"My Page Title\""
+  echo "${0} post/my-post \"My Post Title\""
+  exit 1
+fi
+
+path=$(dirname "${1}")
+slug=$(basename "${1}")
+filename="${slug}.md"
+title="${2}"
+date=$(date +%Y-%m-%d)
+
+for i in $(find . -type d -path './content/*' ! -path '*/documents' ! -path '*/docs' ! -path '*/post')
+do
+    # If the directory doesn't exist, create it.
+    if ! [ -d "${i}/${path}" ] && ! [ "${path}" = post ]
+    then
+        mkdir -p "${i}/${path}"
+        echo "Created directory: ${i}/${path}"
+    fi
+
+    # Actions only for English (e.g. blog posts, etc.)
+    if [ ${i} = "./content/en" ]
+    then
+        # Create the new page.
+        if ! [ -f "${i}/${path}/${filename}" ]
+        then
+        tee "${i}/${path}/${filename}" << EOF
+---
+title: ${title}
+slug: ${slug}
+top_graphic: 1
+lastmod: ${date}
+show_lastmod: false
+---
+
+EOF
+    echo "Created page: ${i}/${path}/${filename}"
+    fi
+    else
+        # Actions only for non-English (e.g. no-translation stubs, etc.)
+
+        # Blog posts are only created for the "en" directory.
+        if [ "${path}" = post ]
+        then
+            continue
+        fi
+
+        # Create the stub (untranslated) page.
+        if ! [ -f "${i}/${path}/${filename}" ]
+        then
+            tee "${i}/${path}/${filename}"  << EOF
+---
+title: ${title}
+slug: ${slug}
+top_graphic: 1
+lastmod: ${date}
+show_lastmod: false
+untranslated: 1
+---
+
+EOF
+        echo "Created page: ${i}/${path}/${filename}"
+        fi
+    fi
+done

--- a/src/css/_base.scss
+++ b/src/css/_base.scss
@@ -70,6 +70,13 @@ figure,
 }
 
 /**
+ * Nested `unordered lists` should not have `margin-bottom`
+ */
+ul ul {
+  margin-bottom: 0;
+}
+
+/**
  * Images
  */
 img {


### PR DESCRIPTION
- Add docs page for the Duplicate Certificate Rate Limit
- Add list entry to the Documentation page
- Fix CSS `bottom` spacing for single-nested unordered-list (`<ul>`) entries
- Add small script `new-page.sh` which automates the creation of new pages in
  `content/en` and all stub no-translation documents for all other languages