### PR TITLE
Add new docs page for Failed Validation Limit

### DIFF
--- a/content/base-l10n/docs/failed-validation-limit.md
+++ b/content/base-l10n/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/de/docs/failed-validation-limit.md
+++ b/content/de/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/en/docs/failed-validation-limit.md
+++ b/content/en/docs/failed-validation-limit.md
@@ -1,0 +1,58 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+---
+
+
+# Description
+All issuance requests are subject to a *Failed Validation* limit of 5 failures
+per account, per hostname, per hour. You should receive the following error
+message from your ACME client when you’ve exceeded the Failed Validation limit:
+
+```
+too many failed authorizations recently: see https://letsencrypt.org/docs/failed-validation-limit/
+```
+
+The ‘authorizations’ that this error refers to are the result of authorization
+requests, sent by your ACME client, to validate control over a domain name
+before we can issue or renew a certificate. This error indicates that the
+multiple requests for validation were sent successfully but all attempts to
+validate have failed.
+
+# Common Causes
+
+Subscribers who hit the Failed Validation limit often do so due to a
+misconfiguration in their environment.
+
+# HTTP-01 or TLS-APLN-01
+
+For ACME clients requesting authorization via the HTTP-01 or TLS-APLN-01
+validation methods, the problem usually stems from a network or firewall
+configuration which makes it impossible for our validation servers to reach the
+server that the request was sent from.
+
+# DNS-01
+
+ACME clients requesting authorization via the DNS-01 validation method usually
+require that you create a CNAME record in your main DNS zone which allows the
+ACME client to set the required DNS records during the validation process.
+Failed DNS-01 validations are usually the result of missed steps or typos during
+this initial setup process.
+
+When troubleshooting or testing the deployment of your applications we encourage
+you to configure your ACME client to use our [staging
+environment](/docs/staging-environment/). Rate limits for our staging
+environment are [significantly higher](/docs/staging-environment/#rate-limits).
+
+# Requesting Help
+
+If you’re not sure how to configure your ACME client to use our staging
+environment or you need some help debugging, we encourage you to [request help
+on our community forum](https://community.letsencrypt.org/c/help/13).
+
+# Requesting an Override
+
+Overrides are **not** available for the Failed Validation limit.

--- a/content/en/docs/failed-validation-limit.md
+++ b/content/en/docs/failed-validation-limit.md
@@ -27,14 +27,14 @@ validate have failed.
 Subscribers who hit the Failed Validation limit often do so due to a
 misconfiguration in their environment.
 
-# HTTP-01 or TLS-APLN-01
+## HTTP-01 or TLS-APLN-01
 
 For ACME clients requesting authorization via the HTTP-01 or TLS-APLN-01
 validation methods, the problem usually stems from a network or firewall
 configuration which makes it impossible for our validation servers to reach the
 server that the request was sent from.
 
-# DNS-01
+## DNS-01
 
 ACME clients requesting authorization via the DNS-01 validation method usually
 require that you create a CNAME record in your main DNS zone which allows the

--- a/content/en/docs/rate-limits.md
+++ b/content/en/docs/rate-limits.md
@@ -62,11 +62,11 @@ can be considered a renewal even if you are using a new key.
 **Revoking certificates does not reset rate limits**, because the resources used to
 issue those certificates have already been consumed.
 
-There is a <a id="failed-validations"></a>**Failed Validation** limit of 5 failures
-per account, per hostname, per hour. This limit is higher on our
-[staging environment](/docs/staging-environment), so you
-can use that environment to debug connectivity problems. Exceeding the Failed
-Validations limit is reported with the error message `too many failed authorizations recently`.
+There is a <a id="failed-validations"></a>[**Failed Validation**](/docs/failed-validation-limit) 
+limit of 5 failures per account, per hostname, per hour. This limit is higher on our
+[staging environment](/docs/staging-environment), so you can use that environment to debug connectivity
+problems. Exceeding the Failed Validations limit is reported with the error message `too many failed
+authorizations recently`.
 
 The "new-nonce", "new-account", "new-order", and "revoke-cert" endpoints on the API have an <a
 id="overall-requests"></a>**Overall

--- a/content/es/docs/failed-validation-limit.md
+++ b/content/es/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/fr/docs/failed-validation-limit.md
+++ b/content/fr/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/he/docs/failed-validation-limit.md
+++ b/content/he/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/id/docs/failed-validation-limit.md
+++ b/content/id/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/it/docs/failed-validation-limit.md
+++ b/content/it/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/ja/docs/failed-validation-limit.md
+++ b/content/ja/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/ko/docs/failed-validation-limit.md
+++ b/content/ko/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/pt-br/docs/failed-validation-limit.md
+++ b/content/pt-br/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/ru/docs/failed-validation-limit.md
+++ b/content/ru/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/sr/docs/failed-validation-limit.md
+++ b/content/sr/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/sv/docs/failed-validation-limit.md
+++ b/content/sv/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/uk/docs/failed-validation-limit.md
+++ b/content/uk/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/vi/docs/failed-validation-limit.md
+++ b/content/vi/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/zh-cn/docs/failed-validation-limit.md
+++ b/content/zh-cn/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/zh-tw/docs/failed-validation-limit.md
+++ b/content/zh-tw/docs/failed-validation-limit.md
@@ -1,0 +1,9 @@
+---
+title: Failed Validation Limit
+slug: failed-validation-limit
+top_graphic: 1
+lastmod: 2022-06-30
+show_lastmod: false
+untranslated: 1
+---
+

--- a/layouts/shortcodes/docs_index.html
+++ b/layouts/shortcodes/docs_index.html
@@ -16,6 +16,9 @@
         <ul>
             <li>{{ template "link" (dict "context" . "page" "/docs/duplicate-certificate-limit") }}</li>
         </ul>
+        <ul>
+            <li>{{ template "link" (dict "context" . "page" "/docs/failed-validation-limit") }}</li>
+        </ul>
     </li>
     <li>{{ template "link" (dict "context" . "page" "/docs/expiration-emails") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/dst-root-ca-x3-expiration-september-2021") }}</li>


### PR DESCRIPTION
- Add dedicated Failed Validation Limit docs page
- Add new Failed Validation Limit page to the `/docs/` index list
- Link to new Failed Validation Limit page to `/docs/rate-limits/`