### PR TITLE
Update links to the boulder repo to link to the main branch

### DIFF
--- a/content/da/docs/acme-protocol-updates.md
+++ b/content/da/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ Den [IETF-standardiserede](https://letsencrypt.org/2019/03/11/acme-protocol-ietf
 
 # API Endpoints
 
-Vi har i øjeblikket følgende API-endepunkter. Se venligst [vores dokumentation af forskelle](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) for at sammenligne deres implementering med ACME-specifikationen.
+Vi har i øjeblikket følgende API-endepunkter. Se venligst [vores dokumentation af forskelle](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) for at sammenligne deres implementering med ACME-specifikationen.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/da/docs/revoking.md
+++ b/content/da/docs/revoking.md
@@ -12,7 +12,7 @@ Når et certifikats tilhørende private nøgle ikke længere er sikker, bør du 
 
 Når du tilbagekalder et Let's Encrypt certifikat, vil Let's Encrypt vil offentliggøre denne tilbagekaldelse information via [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol), og nogle browsere vil tjekke OCSP, for at se, om de skal have tillid til et certifikat. Bemærk, at OCSP [har nogle grundlæggende problemer](https://www.imperialviolet.org/2011/03/18/revocation.html), så ikke alle browsere udfører denne kontrol. Alligevel er tilbagekaldelse af certifikater, der tilhører kompromitterede private nøgler en vigtig praksis og er påkrævet af Let's Encrypts [Abonnentaftale](/repository).
 
-For at tilbagekalde et certifikat via Let's Encrypt, skal du bruge [ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), sandsynligvis gennem en ACME-klient som [Certbot](https://certbot.eff.org/). Du bliver nødt til at bevise overfor Let's Encrypt, at du er autoriseret til at tilbagekalde certifikatet. Der er tre måder at gøre dette:
+For at tilbagekalde et certifikat via Let's Encrypt, skal du bruge [ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), sandsynligvis gennem en ACME-klient som [Certbot](https://certbot.eff.org/). Du bliver nødt til at bevise overfor Let's Encrypt, at du er autoriseret til at tilbagekalde certifikatet. Der er tre måder at gøre dette:
 
 # Fra den konto, der har udstedt certifikatet
 

--- a/content/da/getinvolved.md
+++ b/content/da/getinvolved.md
@@ -25,7 +25,7 @@ Vi kan også bruge hjælp til softwareudvikling. Al vores kode er på [GitHub](h
 
 ### CA-software på Serversiden
 
-[Boulder](https://github.com/letsencrypt/boulder) er Let's Encrypt CA implementering. Den er baseret på [ACME](https://tools.ietf.org/html/rfc8555) -protokollen, og er primært skrevet i Go. Et godt sted at starte er med listen over ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) og [bidragsydere guiden](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) er Let's Encrypt CA implementering. Den er baseret på [ACME](https://tools.ietf.org/html/rfc8555) -protokollen, og er primært skrevet i Go. Et godt sted at starte er med listen over ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) og [bidragsydere guiden](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/de/docs/acme-protocol-updates.md
+++ b/content/de/docs/acme-protocol-updates.md
@@ -11,7 +11,7 @@ Das [IETF-standardisierte](https://letsencrypt.org/2019/03/11/acme-protocol-ietf
 
 # API-Endpunkte
 
-Momentan haben wir folgende API-Endpunkte. Bitte verwenden Sie [unser Diagramm der Unterschiede](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) zum Vergleich der Implementierung mit der ACME-Spezifikation.
+Momentan haben wir folgende API-Endpunkte. Bitte verwenden Sie [unser Diagramm der Unterschiede](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) zum Vergleich der Implementierung mit der ACME-Spezifikation.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/de/docs/glossary.md
+++ b/content/de/docs/glossary.md
@@ -32,7 +32,7 @@ Note for translators:
 
 {{% def id="ACME-client" name="ACME Client" %}} Ein Programmm, dass fähig ist, mit einem ACME Server zu kommunizieren, und nach einem [Zertifikat](#def-leaf) zu fragen. {{% /def %}}
 
-{{% def id="ACME-server" name="ACME Server" %}} Ein ACME-kompatibler Server, der [Zertifikate](#def-leaf) generieren kann. Let's Encrypt's Software, [Boulder](#def-boulder), ist ACME-kompatibel, [mit einigen Abweichungen](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md). {{% /def %}}
+{{% def id="ACME-server" name="ACME Server" %}} Ein ACME-kompatibler Server, der [Zertifikate](#def-leaf) generieren kann. Let's Encrypt's Software, [Boulder](#def-boulder), ist ACME-kompatibel, [mit einigen Abweichungen](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md). {{% /def %}}
 
 {{% def id="boulder" name="Boulder" %}} Die Software implementiert ACME, entwickelt und benutzt von [Let's Encrypt](#def-LE). [GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}
 

--- a/content/de/docs/revoking.md
+++ b/content/de/docs/revoking.md
@@ -12,7 +12,7 @@ Wenn ein zu einem Zertifikat dazugehöriger privater Schlüssel nicht länger si
 
 Wenn Sie ein Let's Encrypt Zertifikat sperren, wird Let's Encrypt die Sperrinformationen durch das [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) veröffentlichen und einige Browser werden OCSP überprüfen, ob sie einem Zertifikat vertrauen sollten. Beachten Sie, dass OCSP [einige grundlegende Probleme hat](https://www.imperialviolet.org/2011/03/18/revocation.html), sodass nicht alle Browser diese Überprüfung machen werden. Trotzdem, Sperren von Zertifikaten, die einen kompromitierten privaten Schlüssel haben, ist eine wichtige Praxis und ist erforderlich vom Let's Encrypt's [Subscriber Agreement](/repository).
 
-Um ein Zertifikat mit Let's Encrypt zu sperren, werden Sie die [ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) benutzen, meist durch einen ACME Client wie [Certbot](https://certbot.eff.org/). Sie müssen gegenüber Let's Encrypt bestätigen, dass Sie die Berechtigung zum Sperren des Zertifikats haben. Es gibt drei Wege, das zu tun:
+Um ein Zertifikat mit Let's Encrypt zu sperren, werden Sie die [ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) benutzen, meist durch einen ACME Client wie [Certbot](https://certbot.eff.org/). Sie müssen gegenüber Let's Encrypt bestätigen, dass Sie die Berechtigung zum Sperren des Zertifikats haben. Es gibt drei Wege, das zu tun:
 
 # Vom Konto, dass das Zertifikat ausgestellt hat.
 

--- a/content/de/getinvolved.md
+++ b/content/de/getinvolved.md
@@ -25,7 +25,7 @@ Wir können auch Hilfe bei der Softwareentwicklung gebrauchen. Unser gesamter Co
 
 ### Serverseitige CA-Software
 
-[Boulder](https://github.com/letsencrypt/boulder) ist die Let's Encrypt CA-Implementierung. Sie basiert auf dem [ACME](https://tools.ietf.org/html/rfc8555)-Protokoll und ist hauptsächlich in Go geschrieben. Ein großartiger Platz zum Starten ist die Liste der ['help wanted'-Issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) und der [Leitfaden für Mitwirkende](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) ist die Let's Encrypt CA-Implementierung. Sie basiert auf dem [ACME](https://tools.ietf.org/html/rfc8555)-Protokoll und ist hauptsächlich in Go geschrieben. Ein großartiger Platz zum Starten ist die Liste der ['help wanted'-Issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) und der [Leitfaden für Mitwirkende](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/en/docs/acme-protocol-updates.md
+++ b/content/en/docs/acme-protocol-updates.md
@@ -11,7 +11,7 @@ The [IETF-standardized](https://letsencrypt.org/2019/03/11/acme-protocol-ietf-st
 
 # API Endpoints
 
-We currently have the following API endpoints. Please see [our divergences documentation](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) to compare their implementation to the ACME specification.
+We currently have the following API endpoints. Please see [our divergences documentation](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) to compare their implementation to the ACME specification.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/en/docs/glossary.md
+++ b/content/en/docs/glossary.md
@@ -31,7 +31,7 @@ Note for translators:
 
 {{% def id="ACME-client" name="ACME Client" %}} A program capable of communicating with an ACME server to ask for a [certificate](#def-leaf). {{% /def %}}
 
-{{% def id="ACME-server" name="ACME Server" %}} An ACME-compatible server that can generate [certificates](#def-leaf). Let's Encrypt's software, [Boulder](#def-boulder), is ACME-compatible, [with some divergences](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md). {{% /def %}}
+{{% def id="ACME-server" name="ACME Server" %}} An ACME-compatible server that can generate [certificates](#def-leaf). Let's Encrypt's software, [Boulder](#def-boulder), is ACME-compatible, [with some divergences](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md). {{% /def %}}
 
 {{% def id="boulder" name="Boulder" %}} The software implementing ACME, developed and used by [Let's Encrypt](#def-LE). [GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}
 

--- a/content/en/docs/revoking.md
+++ b/content/en/docs/revoking.md
@@ -12,7 +12,7 @@ When a certificate is no longer safe to use, you should revoke it. This can happ
 
 When you revoke a Let's Encrypt certificate, Let's Encrypt will publish that revocation information through the [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol), and some browsers will check OCSP to see whether they should trust a certificate. Note that OCSP [has some fundamental problems](https://www.imperialviolet.org/2011/03/18/revocation.html), so not all browsers will do this check. Still, revoking certificates that correspond to compromised private keys is an important practice, and is required by Let's Encrypt's [Subscriber Agreement](/repository).
 
-To revoke a certificate with Let's Encrypt, you will use the [ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), most likely through an ACME client like [Certbot](https://certbot.eff.org/). You will need to prove to Let’s Encrypt that you are authorized to revoke the certificate. There are three ways to do this: from the account that issued the certificate, using a different authorized account, or using the certificate private key.
+To revoke a certificate with Let's Encrypt, you will use the [ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), most likely through an ACME client like [Certbot](https://certbot.eff.org/). You will need to prove to Let’s Encrypt that you are authorized to revoke the certificate. There are three ways to do this: from the account that issued the certificate, using a different authorized account, or using the certificate private key.
 
 # Specifying a reason code
 

--- a/content/en/getinvolved.md
+++ b/content/en/getinvolved.md
@@ -25,7 +25,7 @@ We can also use help with software development. All of our code is on [GitHub](h
 
 ### Server-side CA Software
 
-[Boulder](https://github.com/letsencrypt/boulder) is the Let's Encrypt CA implementation. It's based on the [ACME](https://tools.ietf.org/html/rfc8555) protocol, and written primarily in Go. A great place to start is with the list of ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) and the [contributors guide](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) is the Let's Encrypt CA implementation. It's based on the [ACME](https://tools.ietf.org/html/rfc8555) protocol, and written primarily in Go. A great place to start is with the list of ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) and the [contributors guide](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/es/docs/acme-protocol-updates.md
+++ b/content/es/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ El protocolo [IETF estandarizado](https://letsencrypt. org/2019/03/11/acme-proto
 
 # API Endpoints
 
-Actualmente tenemos los siguientes puntos finales de la API. Consulte [nuestra documentación de divergencias](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) para comparar su implementación con la especificación ACME.
+Actualmente tenemos los siguientes puntos finales de la API. Consulte [nuestra documentación de divergencias](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) para comparar su implementación con la especificación ACME.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/es/docs/glossary.md
+++ b/content/es/docs/glossary.md
@@ -31,7 +31,7 @@ Note for translators:
 
 {{% def id="ACME-client" name="ACME Client" %}} Un programa capaz de comunicarse con un servidor ACME para solicitar un [certificate](#def-leaf). {{% /def %}}
 
-{{% def id="ACME-server" name="ACME Server" %}} Un servidor compatible con ACME que puede generar [certificates](#def-leaf). El software , [Boulder](#def-boulder), es compatible con ACME, [con algunas diferencias](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md). {{% /def %}}
+{{% def id="ACME-server" name="ACME Server" %}} Un servidor compatible con ACME que puede generar [certificates](#def-leaf). El software , [Boulder](#def-boulder), es compatible con ACME, [con algunas diferencias](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md). {{% /def %}}
 
 {{% def id="boulder" name="Boulder" %}} El software que implementa ACME, desarrollado y utilizado por [Let's Encrypt](#def-LE). [GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}
 

--- a/content/es/docs/revoking.md
+++ b/content/es/docs/revoking.md
@@ -12,7 +12,7 @@ Cuando la clave privada correspondiente de un certificado ya no es segura, debe 
 
 Cuando revoca un certificado emitido por Let's Encrypt, Let's Encrypt publicará esa información de revocación a través del Protocolo de estado del certificado en línea [Online Certificate Status Protocol(OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol), algunos navegadores verificarán en un servidor OCSP para ver si deben confiar en el certificado. Tenga en cuenta que OCSP [tiene algunos problemas fundamentales](https://www.imperialviolet.org/2011/03/18/revocation.html), por lo que NO todos los navegadores harán esta comprobación. Aún así, revocar certificados que corresponden a claves privadas comprometidas es una práctica importante y es requerido por el [Acuerdo de Suscriptor](/repository) de Let's Encrypt.
 
-Para revocar un certificado con Let's Encrypt, utilizará el [API ACME](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), probablemente a través de un cliente ACME como [Certbot](https://certbot.eff.org/). Deberá demostrar a Let's Encrypt que está autorizado para revocar el certificado. Hay tres maneras de hacer esto:
+Para revocar un certificado con Let's Encrypt, utilizará el [API ACME](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), probablemente a través de un cliente ACME como [Certbot](https://certbot.eff.org/). Deberá demostrar a Let's Encrypt que está autorizado para revocar el certificado. Hay tres maneras de hacer esto:
 
 # Desde la cuenta para la que se emitió el certificado
 

--- a/content/es/getinvolved.md
+++ b/content/es/getinvolved.md
@@ -25,7 +25,7 @@ Siempre podemos usar ayuda para el desarrollo de software. Todo nuestro código 
 
 ### Software AC del lado del servidor
 
-[Boulder](https://github.com/letsencrypt/boulder) es la implementación AC de Let's Encrypt. Está basado en el protocolo [ACME](https://tools.ietf.org/html/rfc8555), y escrito primariamente en Go. Un gran lugar para comenzar es con la lista de problemas ['help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) y la [guía de contribuyentes](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) es la implementación AC de Let's Encrypt. Está basado en el protocolo [ACME](https://tools.ietf.org/html/rfc8555), y escrito primariamente en Go. Un gran lugar para comenzar es con la lista de problemas ['help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) y la [guía de contribuyentes](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/fi/docs/revoking.md
+++ b/content/fi/docs/revoking.md
@@ -12,7 +12,7 @@ Kun varmenteen vastaava yksityinen avain ei ole enää turvassa, sinun pitäisi 
 
 Kun kumoat Let's Encrypt -varmenteen, Let's Encrypt julkaisee kumotustiedot [Online Certificate Status Protocol (OCSP)-protokollan](https://en.wikipedia.orgwiki/Online_Certificate_Status_Protocol) kautta, ja jotkin selaimet tarkistavat OCSP:n nähdäkseen, pitäisikö niiden luottaa varmenteeseen. Huomaa, että OCSP:llä [ on perustavanlaatuisia ongelmia](https://www.imperialviolet.org/2011/03/18/revocation.html), joten kaikki verkkoselaimet eivät suorita tätä tarkistusta. Silti, vaarantuneita yksityisiä avaimia vastaavien varmenteiden kumoaminen on tärkeä käytäntö ja Let's Encryptin [tilaajasopimus](/repository) edellyttää sitä.
 
-Kumottaaksesi varmenteen Let's Encryptillä, käytä [ACME-sovellusliittymää](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), todennäköisimmin ACME-asiakasohjelman kautta, kuten [Certbot](https://certbot.eff.org/). Sinun on todistettava Let's Encryptille, että sinulla on oikeus varmenteen kumoamiseen. On olemassa kolme tapaa tehdä tämä:
+Kumottaaksesi varmenteen Let's Encryptillä, käytä [ACME-sovellusliittymää](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), todennäköisimmin ACME-asiakasohjelman kautta, kuten [Certbot](https://certbot.eff.org/). Sinun on todistettava Let's Encryptille, että sinulla on oikeus varmenteen kumoamiseen. On olemassa kolme tapaa tehdä tämä:
 
 # Varmenteen myöntäneeltä tililtä
 

--- a/content/fi/getinvolved.md
+++ b/content/fi/getinvolved.md
@@ -25,7 +25,7 @@ Voit myös auttaa ohjelmistokehityksessä. Kaikki koodimme on [GitHubissa](https
 
 ### Palvelinpuoleinen varmentajaohjelmisto
 
-<a href="https://gi[Boulder](https://github.com/letsencrypt/boulder) on toteutus varmentajaa Let's Encrypt. Se perustuu [ACME](https://tools.ietf.org/html/rfc8555) protokollaan, ja on kirjoitettu ensisijaisesti Go:ksi. Hyvä paikka aloittaa on luettelo ["apua tarvitaan'-ongelmista](https://github.com/letsencrypt/boulder/labels/help%20wanted) ja [avustajien opas](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+<a href="https://gi[Boulder](https://github.com/letsencrypt/boulder) on toteutus varmentajaa Let's Encrypt. Se perustuu [ACME](https://tools.ietf.org/html/rfc8555) protokollaan, ja on kirjoitettu ensisijaisesti Go:ksi. Hyvä paikka aloittaa on luettelo ["apua tarvitaan'-ongelmista](https://github.com/letsencrypt/boulder/labels/help%20wanted) ja [avustajien opas](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/fr/docs/acme-protocol-updates.md
+++ b/content/fr/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ Le [protocole ACME](https://letsencrypt.org/2019/03/11/acme-protocol-ietf-standa
 
 # Points d'entré de l'API
 
-Nous avons actuellement les points d'entré d'API suivants. Veuillez consulter [notre documentation sur les divergences](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) pour comparer leur implémentation aux spécifications ACME.
+Nous avons actuellement les points d'entré d'API suivants. Veuillez consulter [notre documentation sur les divergences](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) pour comparer leur implémentation aux spécifications ACME.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/fr/docs/glossary.md
+++ b/content/fr/docs/glossary.md
@@ -31,7 +31,7 @@ Note for translators:
 
 {{% def id="ACME-client" name="ACME Client" %}} Un programme capable de communiquer avec un serveur ACME pour demander un [certificat](#def-leaf). {{% /def %}}
 
-{{% def id="ACME-server" name="ACME Server" %}} Un serveur compatible ACME qui peut générer des [certificats](#def-leaf). Le logiciel de Let's Encrypt, [Boulder](#def-boulder), est compatible ACME, [ avec quelques divergences](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md). {{% /def %}}
+{{% def id="ACME-server" name="ACME Server" %}} Un serveur compatible ACME qui peut générer des [certificats](#def-leaf). Le logiciel de Let's Encrypt, [Boulder](#def-boulder), est compatible ACME, [ avec quelques divergences](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md). {{% /def %}}
 
 {{% def id="boulder" name="Boulder" %}} Le logiciel mettant en œuvre ACME, développé et utilisé par [Let's Encrypt](#def-LE). [GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}
 

--- a/content/fr/docs/revoking.md
+++ b/content/fr/docs/revoking.md
@@ -12,7 +12,7 @@ Quand la clé privée correspondante d'un certificat n'est plus sûre, vous devr
 
 Lorsque vous révoquez un certificat Let's Encrypt, Let's Encrypt publiera cette information de révocation via le [protocole d'état du certificat en ligne (OCSP)](https://fr.wikipedia.org/wiki/Online_Certificate_Status_Protocol), et certains navigateurs utiliseront l'OCSP pour savoir s'ils doivent faire confiance à un certificat. Notez que l'OCSP [a quelques problèmes fondamentaux ](https://www.imperialviolet.org/2011/03/18/revocation.html), donc tous les navigateurs ne feront pas cette vérification. Néanmoins, révoquer les certificats qui correspondent à des clés privées compromises est important, et est requis par le [Contrat d'abonné](/repository) de Let's Encrypt.
 
-Pour révoquer un certificat avec Let's Encrypt, vous utiliserez l'API [ACME ](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), probablement par l'intermédiaire d'un client ACME comme [Certbot](https://certbot.eff.org/). Vous devrez prouver à Let's Encrypt que vous êtes autorisé à révoquer le certificat. Il y a deux manières de procéder :
+Pour révoquer un certificat avec Let's Encrypt, vous utiliserez l'API [ACME ](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), probablement par l'intermédiaire d'un client ACME comme [Certbot](https://certbot.eff.org/). Vous devrez prouver à Let's Encrypt que vous êtes autorisé à révoquer le certificat. Il y a deux manières de procéder :
 
 # A partir du compte qui a émis le certificat
 

--- a/content/fr/getinvolved.md
+++ b/content/fr/getinvolved.md
@@ -25,7 +25,7 @@ Nous pouvons également apporter notre aide pour le développement de logiciels.
 
 ### Logiciel d'AC côté serveur
 
-[Boulder](https://github.com/letsencrypt/boulder) est l'implémentation de l'AC "Let's Encrypt". Il est basé sur le protocole [ACME](https://tools.ietf.org/html/rfc8555) et écrit principalement en Go. Un bon point de départ est la liste des questions ["help wanted"](https://github.com/letsencrypt/boulder/labels/help%20wanted) et le [guide des contributeurs](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) est l'implémentation de l'AC "Let's Encrypt". Il est basé sur le protocole [ACME](https://tools.ietf.org/html/rfc8555) et écrit principalement en Go. Un bon point de départ est la liste des questions ["help wanted"](https://github.com/letsencrypt/boulder/labels/help%20wanted) et le [guide des contributeurs](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/he/docs/acme-protocol-updates.md
+++ b/content/he/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ show_lastmod: 1
 
 # נקודות גישה ל־API
 
-נכון לעכשיו אנחנו מציעים את נקודות הגישה הבאות ל־API. ניתן לעיין ב[מסמך סקירת השינויים שלנו](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) כדי להשוות בין המימושים שלהם למפרט של ACME.
+נכון לעכשיו אנחנו מציעים את נקודות הגישה הבאות ל־API. ניתן לעיין ב[מסמך סקירת השינויים שלנו](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) כדי להשוות בין המימושים שלהם למפרט של ACME.
 
 ## גרסה 2 של ACME ‏(RFC 8555)
 

--- a/content/he/docs/glossary.md
+++ b/content/he/docs/glossary.md
@@ -31,7 +31,7 @@ Note for translators:
 
 {{% def id="ACME-client" english="ACME Client" name="לקוח ACME‏" %}} תכנית שיכולה לתקשר עם שרת ACME כדי לבקש [אישור](#def-leaf). {{% /def %}}
 
-{{% def id="ACME-server" english="ACME Server" name="שרת ACME‏" %}} שרת תואם ACME שיכול לייצר [אישורים](#def-leaf). התכנית שלLet's Encrypt,‏ [Boulder](#def-boulder), היא תואמת ACME [עם מספר שינויים קלים](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md). {{% /def %}}
+{{% def id="ACME-server" english="ACME Server" name="שרת ACME‏" %}} שרת תואם ACME שיכול לייצר [אישורים](#def-leaf). התכנית שלLet's Encrypt,‏ [Boulder](#def-boulder), היא תואמת ACME [עם מספר שינויים קלים](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md). {{% /def %}}
 
 {{% def id="boulder" name="בולדר" english="Boulder" %}} התכנית שמממשת את ACME, בפיתוח ובשימוש של [Let's Encrypt](#def-LE). [GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}
 

--- a/content/he/docs/revoking.md
+++ b/content/he/docs/revoking.md
@@ -12,7 +12,7 @@ show_lastmod: 1
 
 בעת שלילת אישור של Let's Encrypt, פרטים על השלילה הזאת יפורסמו על ידיLet's Encrypt דרך [Online Certificate Status Protocol (פרוטוקול מצב אישור מקוון - OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol), וחלק מהדפדפנים יבדקו את OCSP כדי לבדוק האם עליהם לתת אמון באישור. נא לשים לב של־OCSP [יש כמה תקלות יסודיות](https://www.imperialviolet.org/2011/03/18/revocation.html), לכן לא כל הדפדפנים יבצעו את הבדיקה הזו. עם זאת, שלילת אישורים בתגובה למפתחות פרטיים שנפגעו היא דרך התנהלות חשובה והיא נדרשת על ידי [הסכם המנוי](/repository) של Let's Encrypt.
 
-כדי לשלול אישור עם Let's Encrypt, יהיה עליך להשתמש ב־[API של ACME](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), ככל הנראה דרך לקוח ACME כגון [Certbot](https://certbot.eff.org/). יהיה עליך להוכיח ל־Let's Encrypt שיש לך הרשאה לשלול את האישור. ישנן שלוש דרכים לעשות זאת:
+כדי לשלול אישור עם Let's Encrypt, יהיה עליך להשתמש ב־[API של ACME](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), ככל הנראה דרך לקוח ACME כגון [Certbot](https://certbot.eff.org/). יהיה עליך להוכיח ל־Let's Encrypt שיש לך הרשאה לשלול את האישור. ישנן שלוש דרכים לעשות זאת:
 
 # מהחשבון שהנפיק את האישור
 

--- a/content/he/getinvolved.md
+++ b/content/he/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### תכנית רשות אישורים מצד השרת
 
-[Boulder](https://github.com/letsencrypt/boulder) הוא המימוש של Let's Encrypt לרשות אישורים. הוא מבוסס על פרוטוקול [ACME](https://tools.ietf.org/html/rfc8555) וכתוב בעיקר ב־Go. מקום טוב להתחיל בו הוא רשימת [התקלות שמסומנות בתור ‚help wanted’ (דרושה עזרה)](https://github.com/letsencrypt/boulder/labels/help%20wanted) לצד [המדריך למתנדבים](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) הוא המימוש של Let's Encrypt לרשות אישורים. הוא מבוסס על פרוטוקול [ACME](https://tools.ietf.org/html/rfc8555) וכתוב בעיקר ב־Go. מקום טוב להתחיל בו הוא רשימת [התקלות שמסומנות בתור ‚help wanted’ (דרושה עזרה)](https://github.com/letsencrypt/boulder/labels/help%20wanted) לצד [המדריך למתנדבים](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/hu/docs/acme-protocol-updates.md
+++ b/content/hu/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ A Let's Encrypt működésének alapköve a [IETF-szabványosított](https://let
 
 # API endpointok
 
-Jelenleg a következő API endpointokkal rendelkezünk. Kérjük, tekintse meg [a különbözőségekről szóló dokumentációt](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), hogy összehasonlítsa a megvalósításukat az ACME specifikációval.
+Jelenleg a következő API endpointokkal rendelkezünk. Kérjük, tekintse meg [a különbözőségekről szóló dokumentációt](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), hogy összehasonlítsa a megvalósításukat az ACME specifikációval.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/hu/docs/glossary.md
+++ b/content/hu/docs/glossary.md
@@ -31,7 +31,7 @@ Note for translators:
 
 {{% def id="ACME-client" name="ACME Client" %}} Egy olyan program, amely képes kommunikálni egy ACME szerverrel, hogy [tanúsítványt](#def-leaf) kérjen. {{% /def %}}
 
-{{% def id="ACME-server" name="ACME Server" %}} Egy ACME-kompatibilis szerver, amely képes [tanúsítványokat](#def-leaf) generálni. A Let's Encrypt szoftvere, a [Boulder](#def-boulder) ACME-kompatibilis, [némi eltéréssel](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md). {{% /def %}}
+{{% def id="ACME-server" name="ACME Server" %}} Egy ACME-kompatibilis szerver, amely képes [tanúsítványokat](#def-leaf) generálni. A Let's Encrypt szoftvere, a [Boulder](#def-boulder) ACME-kompatibilis, [némi eltéréssel](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md). {{% /def %}}
 
 {{% def id="boulder" name="Boulder" %}} Az ACME-t alkalmazó szoftver, amelyet a [Let's Encrypt](#def-LE) fejlesztett ki és használ. [GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}
 

--- a/content/hu/docs/revoking.md
+++ b/content/hu/docs/revoking.md
@@ -12,7 +12,7 @@ Ha egy tanúsítványhoz tartozó privát kulcs már nem biztonságos, akkor a t
 
 Amikor Ön visszavonja a Let's Encrypt tanúsítványt, a Let's Encrypt közzéteszi a visszavonási információt az [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) protokollon keresztül, egyes böngészők pedig ellenőrzik az OCSP-t, hogy megállapítsák, meg kell-e bízniuk a tanúsítványban. Vegye figyelembe, hogy az OCSP-nek [van néhány alapvető problémája](https://www.imperialviolet.org/2011/03/18/revocation.html), ezért nem minden böngésző végzi el ezt az ellenőrzést. Ennek ellenére a veszélyeztetett privát kulcsokhoz tartozó tanúsítványok visszavonása fontos gyakorlat, és a Let's Encrypt [előfizetői megállapodása](/repository) előírja.
 
-A tanúsítvány visszavonásához a Let's Encrypt segítségével használja a [ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)-t, egy ACME kliensen keresztül, mint amilyen például [Certbot](https://certbot.eff.org/). Bizonyítania szükséges a Let's Encrypt számára, hogy jogosult a tanúsítvány visszavonására. Ennek háromféle módja van:
+A tanúsítvány visszavonásához a Let's Encrypt segítségével használja a [ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md)-t, egy ACME kliensen keresztül, mint amilyen például [Certbot](https://certbot.eff.org/). Bizonyítania szükséges a Let's Encrypt számára, hogy jogosult a tanúsítvány visszavonására. Ennek háromféle módja van:
 
 # A tanúsítványt kiállító fiókból
 

--- a/content/hu/getinvolved.md
+++ b/content/hu/getinvolved.md
@@ -25,7 +25,7 @@ A [Certbot](https://github.com/certbot/certbot) a webszerver mellett működő P
 
 ### Szerveroldali hitelesítés szolgáltató  (CE) szoftver
 
-[Boulder](https://github.com/letsencrypt/boulder) a Let's Encrypt CA implementációja. Az [ACME](https://tools.ietf.org/html/rfc8555) protokollon alapul, és nagyrészt Go nyelven íródott. Remek kiindulópont lehet a ['help wanted' taggel ellátott issue-k](https://github.com/letsencrypt/boulder/labels/help%20wanted) és a [közreműködők számára készült útmutató](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) a Let's Encrypt CA implementációja. Az [ACME](https://tools.ietf.org/html/rfc8555) protokollon alapul, és nagyrészt Go nyelven íródott. Remek kiindulópont lehet a ['help wanted' taggel ellátott issue-k](https://github.com/letsencrypt/boulder/labels/help%20wanted) és a [közreműködők számára készült útmutató](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/id/getinvolved.md
+++ b/content/id/getinvolved.md
@@ -25,7 +25,7 @@ Kita juga bisa menggunakan bantuan dengan pengembangan perangkat lunak. Semua ko
 
 ### Perangkat Lunak CA Sisi Peladen
 
-[Boulder](https://github.com/letsencrypt/boulder) adalah implementasi CA Let's Encrypt. Ini berdasarkan pada protokol [ACME](https://tools.ietf.org/html/rfc8555) dan ditulis terutama dalam Go. Sebuah tempat yang bagus untuk memulai adalah dengan daftar [masalah 'help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) dan [petunjuk kontributor](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) adalah implementasi CA Let's Encrypt. Ini berdasarkan pada protokol [ACME](https://tools.ietf.org/html/rfc8555) dan ditulis terutama dalam Go. Sebuah tempat yang bagus untuk memulai adalah dengan daftar [masalah 'help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) dan [petunjuk kontributor](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/it/docs/acme-protocol-updates.md
+++ b/content/it/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ Il protocollo [IETF-standardizzato](https://letsencrypt.org/2019/03/11/acme-prot
 
 # API Endpoints
 
-Al momento abbiamo i seguenti endpoint API. Si prega di consultare [la nostra documentazione sulle divergenze](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) per confrontare la loro implementazione con la specifica ACME.
+Al momento abbiamo i seguenti endpoint API. Si prega di consultare [la nostra documentazione sulle divergenze](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) per confrontare la loro implementazione con la specifica ACME.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/it/docs/revoking.md
+++ b/content/it/docs/revoking.md
@@ -12,7 +12,7 @@ Quando la chiave privata di un certificato non è più sicura, dovresti revocare
 
 Quando si revoca un certificato Let's Encrypt, Let's Encrypt pubblica le informazioni di revoca tramite il [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol), e alcuni browser controlleranno OCSP per vedere se possono fidarsi del certificato. Nota che OCSP [ha alcuni problemi fondamentali](https://www.imperialviolet.org/2011/03/18/revocation.html), quindi non tutti i browser eseguiranno questo controllo. Tuttavia, revocare i certificati che hanno le chiavi private compromesse è una pratica importante, ed è richiesto dal [contratto di Let's Encrypt](/repository).
 
-Per revocare un certificato Let's Encrypt, si utilizzerà l'API [ACME](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) o, più probabilmente, un client ACME come [Certbot](https://certbot.eff.org/). Dovrai dimostrare a Let's Encrypt di essere autorizzato a revocare il certificato. Si può procedere in due modi:
+Per revocare un certificato Let's Encrypt, si utilizzerà l'API [ACME](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) o, più probabilmente, un client ACME come [Certbot](https://certbot.eff.org/). Dovrai dimostrare a Let's Encrypt di essere autorizzato a revocare il certificato. Si può procedere in due modi:
 
 # Dall'account che ha emesso il certificato
 

--- a/content/it/getinvolved.md
+++ b/content/it/getinvolved.md
@@ -25,7 +25,7 @@ Possiamo anche dare una mano con lo sviluppo di software. Il nostro codice è su
 
 ### Software CA lato Server
 
-[Boulder](https://github.com/letsencrypt/boulder) è l'implementazione Let's Encrypt CA. Si basa sul protocollo [ACME](https://tools.ietf.org/html/rfc8555), e scritto principalmente in Go. Un ottimo posto in cui iniziare è l'elenco di [help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) e la [guida dei contributori](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) è l'implementazione Let's Encrypt CA. Si basa sul protocollo [ACME](https://tools.ietf.org/html/rfc8555), e scritto principalmente in Go. Un ottimo posto in cui iniziare è l'elenco di [help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) e la [guida dei contributori](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/ja/docs/acme-protocol-updates.md
+++ b/content/ja/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ show_lastmod: 1
 
 # API エンドポイント
 
-現在、以下の API エンドポイントを運用しています。 ACME 仕様と比較した実装の詳細については、[ divergences ドキュメント](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)を参照してください。
+現在、以下の API エンドポイントを運用しています。 ACME 仕様と比較した実装の詳細については、[ divergences ドキュメント](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md)を参照してください。
 
 ## ACME v2 (RFC 8555)
 

--- a/content/ja/docs/revoking.md
+++ b/content/ja/docs/revoking.md
@@ -12,7 +12,7 @@ show_lastmod: 1
 
 Let's Encrypt の証明書を失効すると、Let's Encrypt は失効情報を [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) を用いて公開します。一部のブラウザは OCSP をチェックして証明書が信頼するべきかどうか確認します。 ただし、OCSP には[いくつかの基礎的な問題](https://www.imperialviolet.org/2011/03/18/revocation.html)があるため、すべてのブラウザがチェックするわけではないことに注意してください。 それでも、侵害された秘密鍵に対応する証明書を失効することは重要です。また、Let's Encrypt の [Subscriber Agreement](/repository) でも義務づけられています。
 
-Let's Encrypt で証明書を失効するには、[ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) を使用しますが、通常は [Certbot](https://certbot.eff.org/) などのACME クライアントを使用します。 証明書の失効をするには、Let's Encrypt に対して失効の権限があることを証明しなければなりません。 証明の方法は３つあります。
+Let's Encrypt で証明書を失効するには、[ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) を使用しますが、通常は [Certbot](https://certbot.eff.org/) などのACME クライアントを使用します。 証明書の失効をするには、Let's Encrypt に対して失効の権限があることを証明しなければなりません。 証明の方法は３つあります。
 
 # 証明書を発行したアカウントから行う方法
 

--- a/content/ja/getinvolved.md
+++ b/content/ja/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### サーバーサイドの CA ソフトウェア
 
-[Boulder](https://github.com/letsencrypt/boulder) は、Let's Encrypt CA の実装です。 Boulder は [ACME](https://tools.ietf.org/html/rfc8555) プロトコルに基づいており、主に Go 言語で書かれています。 コントリビューションを行うには、['help wanted' のラベルがついた issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) から始めるのがおすすめです。コントリビューションを行う際には、[コントリビューター・ガイド](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md)も忘れずに読んでください。
+[Boulder](https://github.com/letsencrypt/boulder) は、Let's Encrypt CA の実装です。 Boulder は [ACME](https://tools.ietf.org/html/rfc8555) プロトコルに基づいており、主に Go 言語で書かれています。 コントリビューションを行うには、['help wanted' のラベルがついた issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) から始めるのがおすすめです。コントリビューションを行う際には、[コントリビューター・ガイド](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md)も忘れずに読んでください。
 
 ### letsencrypt.org
 

--- a/content/ko/docs/acme-protocol-updates.md
+++ b/content/ko/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ ACME 프로토콜은 Let's Encrypt가 작동하는 방식의 기초입니다. �
 
 # 현재 구현된 ACME 버전
 
-저희는 다음과 같은 API 엔드포인트를 가지고 있습니다. 이들은 프로토콜 문서 초안과 함께 발전하면서 하나로 고정된 ACME 사양의 초안을 구현하는 것은 아닙니다. 현재 구현된 ACME 초안과 비교하기 위해[각기 다른 문서](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)를 참조하십시오.
+저희는 다음과 같은 API 엔드포인트를 가지고 있습니다. 이들은 프로토콜 문서 초안과 함께 발전하면서 하나로 고정된 ACME 사양의 초안을 구현하는 것은 아닙니다. 현재 구현된 ACME 초안과 비교하기 위해[각기 다른 문서](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md)를 참조하십시오.
 
 ## ACME v2
 

--- a/content/ko/docs/glossary.md
+++ b/content/ko/docs/glossary.md
@@ -31,7 +31,7 @@ Note for translators:
 
 {{% def id="ACME-client" name="ACME Client" %}} ACME 서버와 통신하여 [인증서](#def-leaf)를 요청할 수 있는 프로그램입니다. {{% /def %}}
 
-{{% def id="ACME-server" name="ACME Server" %}} [인증서](#def-leaf)를 생성할 수 있는 ACME 호환 서버입니다. Let's Encrypt의 소프트웨어인 [Bolder](#def-boulder)는 ACME와 호환되며, [일부 차이점이 있습니다](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md). {{% /def %}}
+{{% def id="ACME-server" name="ACME Server" %}} [인증서](#def-leaf)를 생성할 수 있는 ACME 호환 서버입니다. Let's Encrypt의 소프트웨어인 [Bolder](#def-boulder)는 ACME와 호환되며, [일부 차이점이 있습니다](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md). {{% /def %}}
 
 {{% def id="boulder" name="Boulder" %}} [Let's Encrypt](#def-LE)에서 개발하고 사용하는 ACME를 구현하는 소프트웨어입니다. [GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}
 

--- a/content/ko/docs/revoking.md
+++ b/content/ko/docs/revoking.md
@@ -12,7 +12,7 @@ show_lastmod: 1
 
 Let's Encrypt 인증서를 취소하면 Let's Encrypt는 [OCSP (온라인 인증서 상태 프로토콜)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol)를 통해 해당 해지 정보를 게시하고, 일부 브라우저는 OCSP에서 인증서를 신뢰해야 하는지 여부를 확인합니다. OCSP에는 [근본적인 문제가 있으므로](https://www.imperialviolet.org/2011/03/18/revocation.html) 모든 브라우저가 이 검사를 수행하지는 않습니다. 이 작업에는 세 가지 방법이 있습니다. 그러나 손상된 개인 키에 대응하는 인증서를 해지하는 것은 중요한 실천이며 Let's Encrypt의 [구독자 계약](/repository)에 따라 필요합니다.
 
-Let's Encrypt로 인증서를 취소하려면 대부분 [Certbot](https://certbot.eff.org/)과 같은 ACME 클라이언트를 통해 [ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)를 사용하게 됩니다. 귀하에게 인증서를 철회할 수있는 권한이 있음을 Let's Encrypt에 증명해야 합니다. 이 작업에는 세 가지 방법이 있습니다.
+Let's Encrypt로 인증서를 취소하려면 대부분 [Certbot](https://certbot.eff.org/)과 같은 ACME 클라이언트를 통해 [ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md)를 사용하게 됩니다. 귀하에게 인증서를 철회할 수있는 권한이 있음을 Let's Encrypt에 증명해야 합니다. 이 작업에는 세 가지 방법이 있습니다.
 
 # 인증서를 발급한 계정에서 하는 경우
 

--- a/content/ko/getinvolved.md
+++ b/content/ko/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### 서버단 CA 소프트웨어
 
-[Boulder](https://github.com/letsencrypt/boulder)는 Let’s Encrypt CA를 구현하기 위한 도구입니다. [ACME](https://tools.ietf.org/html/rfc8555) 프로토콜 기반이고, 우선은 Go 프로그램 언어로 작성되었습니다. 시작하기에 좋은 곳은 ['도움을 원해요' 목록](https://github.com/letsencrypt/boulder/labels/help%20wanted)과 [공헌자 가이드](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md)입니다.
+[Boulder](https://github.com/letsencrypt/boulder)는 Let’s Encrypt CA를 구현하기 위한 도구입니다. [ACME](https://tools.ietf.org/html/rfc8555) 프로토콜 기반이고, 우선은 Go 프로그램 언어로 작성되었습니다. 시작하기에 좋은 곳은 ['도움을 원해요' 목록](https://github.com/letsencrypt/boulder/labels/help%20wanted)과 [공헌자 가이드](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md)입니다.
 
 ### letsencrypt.org
 

--- a/content/pt-br/docs/revoking.md
+++ b/content/pt-br/docs/revoking.md
@@ -12,7 +12,7 @@ Quando a chave privada correspondente a um certificado não é mais segura você
 
 Quando você revoga um certificado Let's Encrypt, a Let's Encrypt publicará esta informação de revogação através do [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) (Inglês) e alguns navegadores checam o OCSP para decidir se devem confiar ou não em um certificado. Note que o OCSP [tem alguns problemas fundamentais](https://www.imperialviolet.org/2011/03/18/revocation.html), então nem todos os navegadores farão essa checagem. Mesmo assim, revogar certificados que correspondem a chaves privadas comprometidas é uma prática importante, e isso é requerido no [Subscriber Agreement](/repository) da Let's Encrypt.
 
-Para revogar um certificado com a Let's Encrypt, você precisará usar a [API ACME](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) (Inglês), muito provavelmente através de um cliente ACME como o [Certbot](https://certbot.eff.org/). Você precisará provar para a Let's Encrypt que você está autorizado a revogar o certificado. Abaixo estão as três formas de fazer isso:
+Para revogar um certificado com a Let's Encrypt, você precisará usar a [API ACME](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) (Inglês), muito provavelmente através de um cliente ACME como o [Certbot](https://certbot.eff.org/). Você precisará provar para a Let's Encrypt que você está autorizado a revogar o certificado. Abaixo estão as três formas de fazer isso:
 
 # A partir da conta que emitiu o certificado
 

--- a/content/ru/docs/acme-protocol-updates.md
+++ b/content/ru/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ show_lastmod: 1
 
 # Версии API
 
-В настоящее время мы поддерживаем следущие версии API. Пожалуйста, ознакомьтесь с [отступлениями от протокола ACME](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) для сравнения реализаций.
+В настоящее время мы поддерживаем следущие версии API. Пожалуйста, ознакомьтесь с [отступлениями от протокола ACME](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) для сравнения реализаций.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/ru/docs/revoking.md
+++ b/content/ru/docs/revoking.md
@@ -12,7 +12,7 @@ show_lastmod: 1
 
 Когда вы аннулируете сертификат Let's Encrypt, информация об этом публикуется в [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol). Некоторые браузеры проверяют OCSP, чтобы определить, можно ли доверять сертификату. Обратите внимание, что OCSP [имеет несколько значительных проблем](https://www.imperialviolet.org/2011/03/18/revocation.html), поэтому не все браузеры проводят эту проверку. Но аннулирование сертификатов, соответствующих скомпрометированным закрытым ключам, все еще является важной практикой и необходима согласно [Клиентскому соглашению](/repository) Let's Encrypt.
 
-Чтобы аннулировать сертификат с помощью Let's Encrypt, следует использовать [ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), лучше всего через ACME-клиент, например, [Certbot](https://certbot.eff.org/). Нужно подтвердить Let's Encrypt, что вы имеете право на аннулирование сертификата. Есть три способа сделать это:
+Чтобы аннулировать сертификат с помощью Let's Encrypt, следует использовать [ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), лучше всего через ACME-клиент, например, [Certbot](https://certbot.eff.org/). Нужно подтвердить Let's Encrypt, что вы имеете право на аннулирование сертификата. Есть три способа сделать это:
 
 # С аккаунта, который выпустил сертификат
 

--- a/content/ru/getinvolved.md
+++ b/content/ru/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### Серверное программное обеспечение ЦС
 
-[Boulder](https://github.com/letsencrypt/boulder) — это реализация Центра сертификации (ЦС) Let's Encrypt. Он основан на протоколе [ACME](https://tools.ietf.org/html/rfc8555), и написан в основном на Go. Отличный способ начать — ознакомиться со списком [проблем 'help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) и [инструкцией для участников](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) — это реализация Центра сертификации (ЦС) Let's Encrypt. Он основан на протоколе [ACME](https://tools.ietf.org/html/rfc8555), и написан в основном на Go. Отличный способ начать — ознакомиться со списком [проблем 'help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) и [инструкцией для участников](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### Сайт letsencrypt.org
 

--- a/content/sr/docs/acme-protocol-updates.md
+++ b/content/sr/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ show_lastmod: 1
 
 # Krajnje tačke API-a
 
-Trenutno raspolažemo sa sledećim API okruženjem. Molimo Vas da pogledate [našu dokumentaciju o razlikama](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) kako bi ste bili u mogućnosti da izvršite poređenje implementacije u skladu sa ACME specifikacijom.
+Trenutno raspolažemo sa sledećim API okruženjem. Molimo Vas da pogledate [našu dokumentaciju o razlikama](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) kako bi ste bili u mogućnosti da izvršite poređenje implementacije u skladu sa ACME specifikacijom.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/sr/getinvolved.md
+++ b/content/sr/getinvolved.md
@@ -25,7 +25,7 @@ Takođe,često volimo da koristimo i pomoć oko razvoja softvera. Ceo naš izvor
 
 ### Server-side CA softver
 
-[Boulder](https://github.com/letsencrypt/boulder) je implementacija Let's Encrypt CA. Temelji se na protokolu [ACME](https://tools.ietf.org/html/rfc8555), a prvenstveno je napisan u programskom jeziku Go. Sjajno mesto za početak je popis [pitanja od ljudi koji traže pomoć](https://github.com/letsencrypt/boulder/labels/help%20wanted) i [vodič za doprinose](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) je implementacija Let's Encrypt CA. Temelji se na protokolu [ACME](https://tools.ietf.org/html/rfc8555), a prvenstveno je napisan u programskom jeziku Go. Sjajno mesto za početak je popis [pitanja od ljudi koji traže pomoć](https://github.com/letsencrypt/boulder/labels/help%20wanted) i [vodič za doprinose](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/sv/docs/acme-protocol-updates.md
+++ b/content/sv/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ show_lastmod: 1
 
 # API-slutpunkter
 
-Vi har för närvarande följande API-slutpunkter. Se [våran avvikelser dokumentation](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) för att jämföra deras genomförande med ACME-specifikationen.
+Vi har för närvarande följande API-slutpunkter. Se [våran avvikelser dokumentation](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) för att jämföra deras genomförande med ACME-specifikationen.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/sv/docs/revoking.md
+++ b/content/sv/docs/revoking.md
@@ -12,7 +12,7 @@ När ett certifikats privata nyckel inte längre är i säkert förvar ska du å
 
 När du återkallar ett Let's Encrypt-certifikat kommer Let's Encrypt att publicera information om återkallelsen genom [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) och vissa webbläsare kommer genom OCSP att kontrollera om de ska lita på certifikatet. Notera att OCSP [har några grundläggande problem (engelska)](https://www.imperialviolet.org/2011/03/18/revocation.html), så alla webbläsare kommer inte att utföra denna kontroll. Det är dock fortfarande en viktig rutin att återkalla certifikat vars privata nycklar har läckt och det krävs av Let's Encrypts [användaravtal](/repository).
 
-För att återkalla ett certifikat med Let's Encrypt använder du [ACME-API:et](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), mest troligt genom en ACME-klient som [Certbot](https://certbot.eff.org/). Du behöver bevisa för Let's Encrypt att du är auktoriserad att återkalla certifikatet. Det finns tre sätt att göra det:
+För att återkalla ett certifikat med Let's Encrypt använder du [ACME-API:et](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), mest troligt genom en ACME-klient som [Certbot](https://certbot.eff.org/). Du behöver bevisa för Let's Encrypt att du är auktoriserad att återkalla certifikatet. Det finns tre sätt att göra det:
 
 # Från kontot som utfärdade certifikatet
 

--- a/content/sv/getinvolved.md
+++ b/content/sv/getinvolved.md
@@ -25,7 +25,7 @@ Vi kan också behöva hjälp med mjukvaruutveckling. All vår kod finns på [Git
 
 ### Server-side CA Software
 
-[Boulder](https://github.com/letsencrypt/boulder) är Let's Encrypts CA-implementation. Den bygger på [ACME](https://tools.ietf.org/html/rfc8555)-protokollet och är i huvudsak skriven i Go. Ett bra ställe att börja är i ["hjälp sökes"-listan](https://github.com/letsencrypt/boulder/labels/help%20wanted) och [riktlinjerna för att bidra](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) är Let's Encrypts CA-implementation. Den bygger på [ACME](https://tools.ietf.org/html/rfc8555)-protokollet och är i huvudsak skriven i Go. Ett bra ställe att börja är i ["hjälp sökes"-listan](https://github.com/letsencrypt/boulder/labels/help%20wanted) och [riktlinjerna för att bidra](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/uk/docs/acme-protocol-updates.md
+++ b/content/uk/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ show_lastmod: 1
 
 # Кінцеві точки API
 
-Наразі ми підтримуємо такі кінцеві точки API. Будь ласка, ознайомтеся з [розбіжностями](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) для порівняння їхнього втілення.
+Наразі ми підтримуємо такі кінцеві точки API. Будь ласка, ознайомтеся з [розбіжностями](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) для порівняння їхнього втілення.
 
 ## ACME v2 (RFC 8555)
 

--- a/content/uk/docs/glossary.md
+++ b/content/uk/docs/glossary.md
@@ -31,7 +31,7 @@ Note for translators:
 
 {{% def id="ACME-client" name="ACME Client" %}} Програма зв‘язку з сервером ACME для запиту[ сертифікату](#def-leaf). {{% /def %}}
 
-{{% def id="ACME-server" name="ACME Server" %}} ACME-це сумісний сервер, що може генерувати[ сертифікати](#def-leaf). Програмне забезпечення, яке належить Let’s Encrypt [Boulder](#def-boulder), є ACME-сумісним, [ з деякими відхиленнями ](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md). {{% /def %}}
+{{% def id="ACME-server" name="ACME Server" %}} ACME-це сумісний сервер, що може генерувати[ сертифікати](#def-leaf). Програмне забезпечення, яке належить Let’s Encrypt [Boulder](#def-boulder), є ACME-сумісним, [ з деякими відхиленнями ](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md). {{% /def %}}
 
 {{% def id="boulder" name="Boulder" %}} Програмне забезпечення, що реалізує ACME, розроблене та використовується [Let's Encrypt](#def-LE). [GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}
 

--- a/content/uk/docs/revoking.md
+++ b/content/uk/docs/revoking.md
@@ -12,7 +12,7 @@ show_lastmod: 1
 
 Коли ви скасовуєте сертифікат Let's Encrypt, то Let's Encrypt опублікує цю інформацію про скасовування [ Протокол стану онлайн-сертифікату (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol), та деякі браузери будуть перевіряти OCSP, щоб побачити чи вони можуть довіряти сертифікату. Зверніть увагу, що OCSP [має деякі фундаментальні проблеми](https://www.imperialviolet.org/2011/03/18/revocation.html), тому не всі браузери будуть виконувати цю перевірку. Тим не менш, анулювання сертифікатів, які відповідають зламаним особистим ключам є важливою практикою, яка вимагається для Let's Encrypt [Угода передплати](/repository).
 
-Щоб скасувати сертифікат Let's Encrypt, ви будете використовувати [ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md), ймовірно через ACME клієнта, наприклад [Certbot](https://certbot.eff.org/). Вам потрібно буде довести Let's Encrypt, що ви уповноважені скасувати сертифікат. Існує три способи зробити це:
+Щоб скасувати сертифікат Let's Encrypt, ви будете використовувати [ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md), ймовірно через ACME клієнта, наприклад [Certbot](https://certbot.eff.org/). Вам потрібно буде довести Let's Encrypt, що ви уповноважені скасувати сертифікат. Існує три способи зробити це:
 
 # З облікового запису, який видав сертифікат
 

--- a/content/uk/getinvolved.md
+++ b/content/uk/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### Програмне забезпечення на сервері ЦС
 
-[Boulder](https://github.com/letsencrypt/boulder) - це реалізація Let's Encrypt Центром сертифікації. Вона заснована на [ACME](https://tools.ietf.org/html/rfc8555) протоколі і переважно написана у Go. Найкраще розпочати зі списку ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) та [contributors guide](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) - це реалізація Let's Encrypt Центром сертифікації. Вона заснована на [ACME](https://tools.ietf.org/html/rfc8555) протоколі і переважно написана у Go. Найкраще розпочати зі списку ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) та [contributors guide](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/vi/docs/acme-protocol-updates.md
+++ b/content/vi/docs/acme-protocol-updates.md
@@ -14,7 +14,7 @@ tiêu chuẩn hoá theo IETF, [RFC 8555](https://datatracker.ietf.org/doc/rfc855
 
 # API Endpoints
 
-Chúng tôi hiện có các API endpoint sau. Vui lòng xem [tài liệu phân kỳ của chúng tôi](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) Để so sánh việc triển khai chúng với tài liệu đặc tả ACME.
+Chúng tôi hiện có các API endpoint sau. Vui lòng xem [tài liệu phân kỳ của chúng tôi](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) Để so sánh việc triển khai chúng với tài liệu đặc tả ACME.
 
 
 

--- a/content/vi/getinvolved.md
+++ b/content/vi/getinvolved.md
@@ -25,7 +25,7 @@ Chúng ta cũng có thể sử dụng trợ giúp về phát triển phần mề
 
 ### Phần mềm CA phía máy chủ
 
-[Boulder](https://github.com/letsencrypt/boulder) là triển khai Let's Encrypt CA. Nó dựa trên giao thức [ACME](https://tools.ietf.org/html/rfc8555) và được viết chủ yếu bằng ngôn ngữ Go. Một nơi tuyệt vời để bắt đầu là với danh sách [các vấn đề 'cần trợ giúp'](https://github.com/letsencrypt/boulder/labels/help%20wanted) và [hướng dẫn dành cho cộng tác viên](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) là triển khai Let's Encrypt CA. Nó dựa trên giao thức [ACME](https://tools.ietf.org/html/rfc8555) và được viết chủ yếu bằng ngôn ngữ Go. Một nơi tuyệt vời để bắt đầu là với danh sách [các vấn đề 'cần trợ giúp'](https://github.com/letsencrypt/boulder/labels/help%20wanted) và [hướng dẫn dành cho cộng tác viên](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/zh-cn/docs/acme-protocol-updates.md
+++ b/content/zh-cn/docs/acme-protocol-updates.md
@@ -10,7 +10,7 @@ show_lastmod: 1
 
 # 目前使用的 API 端点
 
-我们目前有以下 API 端点。 请参阅[我们的分歧文档](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)，以比较其实现与当前的 ACME 标准。
+我们目前有以下 API 端点。 请参阅[我们的分歧文档](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md)，以比较其实现与当前的 ACME 标准。
 
 ## ACME v2 (RFC 8555)
 

--- a/content/zh-cn/docs/glossary.md
+++ b/content/zh-cn/docs/glossary.md
@@ -13,7 +13,7 @@ show_lastmod: 1
 
 {{% def id="ACME-client" name="ACME 客户端" english="ACME Client" %}} 能够与 ACME 服务器通信以获取[证书](#def-leaf)的程序。 {{% /def %}}
 
-{{% def id="ACME-server" name="ACME 服务器" english="ACME Server" %}} 与 ACME 协议兼容的能生成[证书](#def-leaf)的服务器。Let's Encrypt 开发的软件 [Boulder](#def-boulder) 与 ACME 协议兼容，但[有一些差异](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)。 {{% /def %}}
+{{% def id="ACME-server" name="ACME 服务器" english="ACME Server" %}} 与 ACME 协议兼容的能生成[证书](#def-leaf)的服务器。Let's Encrypt 开发的软件 [Boulder](#def-boulder) 与 ACME 协议兼容，但[有一些差异](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md)。 {{% /def %}}
 
 {{% def id="boulder" english="Boulder" %}} 由 [Let's Encrypt](#def-LE) 开发并使用的实现了 ACME 协议的软件。[GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}
 

--- a/content/zh-cn/docs/revoking.md
+++ b/content/zh-cn/docs/revoking.md
@@ -12,7 +12,7 @@ show_lastmod: 1
 
 当您在吊销 Let's Encrypt 证书时，Let's Encrypt 将使用[在线证书状态协议（OCSP）](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol)发布该吊销信息，有些浏览器会检查 OCSP 并决定是否信任该证书。 请注意，OCSP 有些[根本性问题](https://www.imperialviolet.org/2011/03/18/revocation.html)，所以不是所有浏览器都会检查 OCSP 信息。 但是，吊销私钥已经泄露的证书十分重要，并且也是 Let's Encrypt 的[用户协议](/repository)中强制要求的。
 
-若您要吊销 Let's Encrypt 颁发的证书，您需要通过 [Certbot](https://certbot.eff.org/) 之类的 ACME 客户端使用 [ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) 进行操作。 您需要向 Let's Encrypt 证明您有权吊销证书。 有三种方法可以吊销颁发的证书：
+若您要吊销 Let's Encrypt 颁发的证书，您需要通过 [Certbot](https://certbot.eff.org/) 之类的 ACME 客户端使用 [ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) 进行操作。 您需要向 Let's Encrypt 证明您有权吊销证书。 有三种方法可以吊销颁发的证书：
 
 # 用颁发证书的账户吊销证书
 

--- a/content/zh-cn/getinvolved.md
+++ b/content/zh-cn/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### 服务器端 CA 软件
 
-Let’s Encrypt CA 使用[Boulder](https://github.com/letsencrypt/boulder)签发证书。 该软件基于[ACME](https://tools.ietf.org/html/rfc8555)协议并主要使用Go语言编写。 [标注为“help wanted”的 issue 列表](https://github.com/letsencrypt/boulder/labels/help%20wanted)和[贡献者指南](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md)都是一个很好的起点。
+Let’s Encrypt CA 使用[Boulder](https://github.com/letsencrypt/boulder)签发证书。 该软件基于[ACME](https://tools.ietf.org/html/rfc8555)协议并主要使用Go语言编写。 [标注为“help wanted”的 issue 列表](https://github.com/letsencrypt/boulder/labels/help%20wanted)和[贡献者指南](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md)都是一个很好的起点。
 
 ### letsencrypt.org
 

--- a/content/zh-tw/docs/acme-protocol-updates.md
+++ b/content/zh-tw/docs/acme-protocol-updates.md
@@ -11,7 +11,7 @@ show_lastmod: 1
 
 # API Endpoints
 
-目前我們有以下的 API endpoint。請參閱我們的[文檔](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)，以比較實作與當前標準的差異。
+目前我們有以下的 API endpoint。請參閱我們的[文檔](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md)，以比較實作與當前標準的差異。
 
 ## ACME v2 (RFC 8555)
 

--- a/content/zh-tw/docs/glossary.md
+++ b/content/zh-tw/docs/glossary.md
@@ -31,7 +31,7 @@ Note for translators:
 
 {{% def id="ACME-client" name="ACME Client" %}} ACME 客戶端。能 ACME 伺服器溝通，以請求[憑證](#def-leaf)的軟體。{{% /def %}}
 
-{{% def id="ACME-server" name="ACME Server" %}} ACME 伺服器。相容 ACME 協定的伺服器。Let's Encrypt 的軟體 [Boulder](#def-boulder) 相容 ACME 協定，但是還[是有一些差異](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md)。 {{% /def %}}
+{{% def id="ACME-server" name="ACME Server" %}} ACME 伺服器。相容 ACME 協定的伺服器。Let's Encrypt 的軟體 [Boulder](#def-boulder) 相容 ACME 協定，但是還[是有一些差異](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md)。 {{% /def %}}
 
 
 {{% def id="boulder" name="Boulder" %}} 由 [Let's Encrypt](#def-LE) 開發和使用，以實作 ACME 協議的軟體。[GitHub](https://github.com/letsencrypt/boulder) {{% /def %}}

--- a/content/zh-tw/docs/revoking.md
+++ b/content/zh-tw/docs/revoking.md
@@ -12,7 +12,7 @@ show_lastmod: 1
 
 當你註銷 Let's Encrypt 憑證，Let's Encrypt 透過 [Online Certificate Status Protocol (OCSP)](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) 發布註銷憑證的訊息，有些瀏覽器會檢查 OCSP 來確定是否該信任這張憑證。 請注意，OCSP 有一些[根本上的問題](https://www.imperialviolet.org/2011/03/18/revocation.html)，因此不是所有瀏覽器都會檢查它。 將洩漏私鑰的憑證註銷非常重要，並且在 Let's Encrypt 的[使用者協議](/repository)中要求使用者執行。
 
-你需要使用 [ACME API](https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md) 來註銷憑證，通常使用者會使用 ACME 客戶端，例如：[Certbot](https://certbot.eff.org/)。 你必須向 Let's Encrypt 證明你有權限註銷憑證， 我們有三種方法讓你註銷憑證：
+你需要使用 [ACME API](https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md) 來註銷憑證，通常使用者會使用 ACME 客戶端，例如：[Certbot](https://certbot.eff.org/)。 你必須向 Let's Encrypt 證明你有權限註銷憑證， 我們有三種方法讓你註銷憑證：
 
 # 使用申請頒發憑證的帳號註銷憑證
 

--- a/content/zh-tw/getinvolved.md
+++ b/content/zh-tw/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### 伺服器端 CA 軟體
 
-Let's Encrypt CA 使用 [Boulder](https://github.com/letsencrypt/boulder) 簽發憑證。 該軟體基於 [ACME](https://tools.ietf.org/html/rfc8555) 協定並主要使用 Go 語言撰寫。 查看[“尋求幫助”問題](https://github.com/letsencrypt/boulder/labels/help%20wanted)列表，和閱讀[貢獻者指南](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md)是一個很不錯的開始。
+Let's Encrypt CA 使用 [Boulder](https://github.com/letsencrypt/boulder) 簽發憑證。 該軟體基於 [ACME](https://tools.ietf.org/html/rfc8555) 協定並主要使用 Go 語言撰寫。 查看[“尋求幫助”問題](https://github.com/letsencrypt/boulder/labels/help%20wanted)列表，和閱讀[貢獻者指南](https://github.com/letsencrypt/boulder/blob/main/CONTRIBUTING.md)是一個很不錯的開始。
 
 ### letsencrypt.org
 

--- a/layouts/shortcodes/docs_index.html
+++ b/layouts/shortcodes/docs_index.html
@@ -51,7 +51,7 @@
 <ul>
     <li>{{ template "link" (dict "context" . "page" "/docs/integration-guide") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/acme-protocol-updates") }}</li>
-    <li><a href="https://github.com/letsencrypt/boulder/blob/master/docs/acme-divergences.md">{{ i18n "acme_divergences_rfc" }}</a></li>
+    <li><a href="https://github.com/letsencrypt/boulder/blob/main/docs/acme-divergences.md">{{ i18n "acme_divergences_rfc" }}</a></li>
     <li>{{ template "link" (dict "context" . "page" "/docs/account-id") }}</li>
 </ul>
 


### PR DESCRIPTION
Stumbled upon some links to the boulder repo that linked to an outdated version, becasue it linked to the `master` branch, and not the `main` branch. Thought that I might as well just update all the links to the boulder repo at once.

I did not bump `lastmod` on purpose, as I also changed the translated versions, and did not want to to trigger unnecessary "this is outdated" messages, or hide the need for real updates. Just let me know if I should bump it.