### PR TITLE
Add docs for Registrations Per IP limit

### DIFF
--- a/content/base-l10n/docs/too-many-registrations-for-this-ip.md
+++ b/content/base-l10n/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/da/docs/too-many-registrations-for-this-ip.md
+++ b/content/da/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/de/docs/too-many-registrations-for-this-ip.md
+++ b/content/de/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/en/docs/rate-limits.md
+++ b/content/en/docs/rate-limits.md
@@ -75,7 +75,8 @@ directory & subdirectories have an Overall Requests limit of 40 requests per sec
 
 We have two other limits that you're very unlikely to run into.
 
-You can create a maximum of 10 <a id="accounts-per-ip-address"></a>**Accounts per IP Address** per 3 hours. You can
+You can create a maximum of 10 <a id="accounts-per-ip-address"></a>[**Accounts
+per IP Address**](/docs/too-many-registrations-for-this-ip) per 3 hours. You can
 create a maximum of 500 **Accounts per IP Range** within an IPv6 /48 per
 3 hours. Hitting either account rate limit is very rare, and we recommend that
 large integrators prefer a design [using one account for many customers](/docs/integration-guide).

--- a/content/en/docs/too-many-registrations-for-this-ip.md
+++ b/content/en/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,38 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+---
+
+
+# Description
+
+Subscribers may register up to 10 accounts per IP address every 3 hours. You should receive the following error message from your ACME client when you’ve exceeded the *Registrations Per IP* limit:
+
+```
+too many registrations for this IP: see https://letsencrypt.org/docs/too-many-registrations-for-this-ip/
+```
+
+The ‘registrations’ this error refers to are requests, sent from your IP address, to register a new account with the Let's Encrypt API. This error indicates that at least 10 accounts have already been registered from this IP address in the last 3 hours.
+
+# Common Causes
+
+Subscribers who hit the Registrations Per IP limit often do so due to a misconfiguration in their environment.
+
+## Repeat Deployments
+
+Encountering the Registrations Per IP limit as an individual subscriber is exceedingly rare. This is most likely to occur during repeat deployments of your system or application; either your ACME client is failing to store and reuse your account credentials or the filesystem where the credentials should be stored is being destroyed between deployments (containers, virtual machines, cloud instances). When testing the deployment of your system or application ensure you've configured your ACME client to use our staging environment. Rate limits for our staging environment are [significantly higher](/docs/staging-environment/#rate-limits).
+
+## Too Many Accounts
+
+Hosting providers and other large integrators typically hit the Registrations Per IP limit by attempting to request an account per customer. We recommend that large integrators prefer a design using [one account for many customers](/docs/integration-guide/#one-account-or-many). When testing ensure you've configured your ACME implementation to use our staging environment. Rate limits for our staging environment are [significantly higher](/docs/staging-environment/#rate-limits).
+
+# Requesting Help
+
+If you’re not sure how to configure your ACME client to use our staging environment or you need some help debugging, we encourage you to [request help on our community forum](https://community.letsencrypt.org/c/help/13).
+
+# Requesting an Override
+
+Overrides are **not** available for the Registrations Per IP limit.

--- a/content/es/docs/too-many-registrations-for-this-ip.md
+++ b/content/es/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/fi/docs/too-many-registrations-for-this-ip.md
+++ b/content/fi/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/fr/docs/too-many-registrations-for-this-ip.md
+++ b/content/fr/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/he/docs/too-many-registrations-for-this-ip.md
+++ b/content/he/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/hu/docs/too-many-registrations-for-this-ip.md
+++ b/content/hu/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/id/docs/too-many-registrations-for-this-ip.md
+++ b/content/id/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/it/docs/too-many-registrations-for-this-ip.md
+++ b/content/it/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/ja/docs/too-many-registrations-for-this-ip.md
+++ b/content/ja/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/ko/docs/too-many-registrations-for-this-ip.md
+++ b/content/ko/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/pt-br/docs/too-many-registrations-for-this-ip.md
+++ b/content/pt-br/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/ru/docs/too-many-registrations-for-this-ip.md
+++ b/content/ru/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/sr/docs/too-many-registrations-for-this-ip.md
+++ b/content/sr/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/sv/docs/too-many-registrations-for-this-ip.md
+++ b/content/sv/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/uk/docs/too-many-registrations-for-this-ip.md
+++ b/content/uk/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/vi/docs/too-many-registrations-for-this-ip.md
+++ b/content/vi/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/zh-cn/docs/too-many-registrations-for-this-ip.md
+++ b/content/zh-cn/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/content/zh-tw/docs/too-many-registrations-for-this-ip.md
+++ b/content/zh-tw/docs/too-many-registrations-for-this-ip.md
@@ -1,0 +1,9 @@
+---
+title: Registrations Per IP Limit
+slug: too-many-registrations-for-this-ip
+top_graphic: 1
+lastmod: 2022-08-15
+show_lastmod: false
+untranslated: 1
+---
+

--- a/layouts/shortcodes/docs_index.html
+++ b/layouts/shortcodes/docs_index.html
@@ -19,6 +19,9 @@
         <ul>
             <li>{{ template "link" (dict "context" . "page" "/docs/failed-validation-limit") }}</li>
         </ul>
+        <ul>
+            <li>{{ template "link" (dict "context" . "page" "/docs/too-many-registrations-for-this-ip") }}</li>
+        </ul>
     </li>
     <li>{{ template "link" (dict "context" . "page" "/docs/expiration-emails") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/dst-root-ca-x3-expiration-september-2021") }}</li>


### PR DESCRIPTION
- Add dedicated Registrations Per IP limit docs page
- Link new Registrations Per IP limit page in the `/docs/` index list
- Link to new Registrations Per IP limit page to `/docs/rate-limits/`