### PR TITLE
Add sentence about searching on ct log monitors

### DIFF
--- a/content/en/docs/expiration-emails.md
+++ b/content/en/docs/expiration-emails.md
@@ -3,7 +3,7 @@ title: Expiration Emails
 slug: expiration-emails
 top_graphic: 1
 date: 2016-07-02
-lastmod: 2021-09-25
+lastmod: 2022-08-31
 show_lastmod: 1
 ---
 
@@ -27,6 +27,9 @@ If you've issued a new certificate that adds or removes a name relative to your
 old certificate, you will get expiration email about your old certificate.
 If you check the certificate currently running on your website, and it
 shows the correct date, no further action is needed.
+To see a history of issued certificates for your domain, you could search for
+your domain on certificate transparancy log monitors such as
+[crt.sh](https://crt.sh/).
 
 # Unsubscribing
 


### PR DESCRIPTION
We frequently see users on the Community just copy/pasting the expiry email. Usually I redirect them to this documentation page. It's almost always necessary to explain what happens using crt.sh.
I believe it would be a good thing if the documentation page I link to, also includes the part about ct log monitors as explained on the Community threads. That way one could not say the documentation is incomplete with regard to what happens in the Community threads.

This relatively simple addition refers to the use of ct log monitors to see a history of your certificates. This complements the part above it about adding/removing hostnames. Users might not remember doing that, so seeing the history on crt.sh is quite helpful I think and thus helpful to include it here.

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
