### PR TITLE
Sponsors page - improve consistency of logos, especially on mobile

### DIFF
--- a/layouts/shortcodes/sponsors.html
+++ b/layouts/shortcodes/sponsors.html
@@ -2,7 +2,7 @@
 <div class="sponsors">
   <div>
     <h2>{{ i18n "platinum" }}</h2>
-    <div class="text-center">
+    <div class="text-center sponsor-flex">
 {{ range $.Site.Data.sponsors.platinum }}
       <a href="{{ .url }}" {{ if .id }}id="{{ .id }}"{{ end }} {{ if .nofollow }}rel="nofollow"{{ end }}{{ if .sponsored }}rel="sponsored"{{ end }}><img src="/images/sponsors/{{ .image }}" alt="{{ .name }}" width="180" height="108" class="sponsor-logo-large"></a>
 {{ end }}
@@ -11,7 +11,7 @@
 
   <div>
     <h2>{{ i18n "gold" }}</h2>
-    <div class="text-center">
+    <div class="text-center sponsor-flex">
 {{ range $.Site.Data.sponsors.gold }}
       <a href="{{ .url }}" {{ if .id }}id="{{ .id }}"{{ end }} {{ if .nofollow }}rel="nofollow"{{ end }}{{ if .sponsored }}rel="sponsored"{{ end }}><img src="/images/sponsors/{{ .image }}" alt="{{ .name }}" width="180" height="108" class="sponsor-logo-large"></a>
 {{ end }}
@@ -20,7 +20,7 @@
 
   <div>
     <h2>{{ i18n "silver" }}</h2>
-    <div class="text-center">
+    <div class="text-center sponsor-flex">
 {{ range $.Site.Data.sponsors.silver }}
       <a href="{{ .url }}" {{ if .id }}id="{{ .id }}"{{ end }} {{ if .nofollow }}rel="nofollow"{{ end }}{{ if .sponsored }}rel="sponsored"{{ end }}><img src="/images/sponsors/{{ .image }}" alt="{{ .name }}" width="180" height="108" class="sponsor-logo-large"></a>
 {{ end }}

--- a/src/css/_layout.scss
+++ b/src/css/_layout.scss
@@ -200,6 +200,7 @@ html[dir="rtl"] .hero.slim div.container {
     img {
         @include media-query($on-palm) {
             max-height: 70px;
+            max-width: 180px;
             width: auto;
         }
     }
@@ -459,5 +460,35 @@ html[dir="rtl"] .social-media-list {
         max-width: 90%;
         border-radius: 0;
         padding: 10px 10px;
+    }
+}
+
+
+.sponsor-flex {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+
+    & > a {
+        display: block;
+        flex-basis: 25%;
+        box-sizing: border-box;
+        padding: 20px;
+
+        @include media-query($on-palm) {
+            flex-basis: 33.3%;
+        }
+        @include media-query($smallest) {
+            flex-basis: 50%;
+        }
+
+        img {
+            max-width: 100%;
+            max-height: 100%;
+            width: auto;
+            height: auto;
+            padding: 0;
+
+        }
     }
 }

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -16,6 +16,7 @@ $grey-color: #828282;
 $grey-color-light: lighten($grey-color, 40%);
 $grey-color-dark: darken($grey-color, 25%);
 
+$smallest: 599.9px;
 $on-palm: 730px;
 $on-laptop: 800px;
 


### PR DESCRIPTION
Some logos on the sponsors page were taking up the full width, due to inconsistent sizes of the logos provided. Use flexbox to enforce more consistent layouts.