### PR TITLE
fix: update boulder's CONTRIBUTING.md location

### DIFF
--- a/content/da/getinvolved.md
+++ b/content/da/getinvolved.md
@@ -25,7 +25,7 @@ Vi kan også bruge hjælp til softwareudvikling. Al vores kode er på [GitHub](h
 
 ### CA-software på Serversiden
 
-[Boulder](https://github.com/letsencrypt/boulder) er Let's Encrypt CA implementering. Den er baseret på [ACME](https://tools.ietf.org/html/rfc8555) -protokollen, og er primært skrevet i Go. Et godt sted at starte er med listen over ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) og [bidragsydere guiden](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) er Let's Encrypt CA implementering. Den er baseret på [ACME](https://tools.ietf.org/html/rfc8555) -protokollen, og er primært skrevet i Go. Et godt sted at starte er med listen over ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) og [bidragsydere guiden](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/de/getinvolved.md
+++ b/content/de/getinvolved.md
@@ -25,7 +25,7 @@ Wir können auch Hilfe bei der Softwareentwicklung gebrauchen. Unser gesamter Co
 
 ### Serverseitige CA-Software
 
-[Boulder](https://github.com/letsencrypt/boulder) ist die Let's Encrypt CA-Implementierung. Sie basiert auf dem [ACME](https://tools.ietf.org/html/rfc8555)-Protokoll und ist hauptsächlich in Go geschrieben. Ein großartiger Platz zum Starten ist die Liste der ['help wanted'-Issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) und der [Leitfaden für Mitwirkende](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) ist die Let's Encrypt CA-Implementierung. Sie basiert auf dem [ACME](https://tools.ietf.org/html/rfc8555)-Protokoll und ist hauptsächlich in Go geschrieben. Ein großartiger Platz zum Starten ist die Liste der ['help wanted'-Issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) und der [Leitfaden für Mitwirkende](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/en/getinvolved.md
+++ b/content/en/getinvolved.md
@@ -25,7 +25,7 @@ We can also use help with software development. All of our code is on [GitHub](h
 
 ### Server-side CA Software
 
-[Boulder](https://github.com/letsencrypt/boulder) is the Let's Encrypt CA implementation. It's based on the [ACME](https://tools.ietf.org/html/rfc8555) protocol, and written primarily in Go. A great place to start is with the list of ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) and the [contributors guide](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) is the Let's Encrypt CA implementation. It's based on the [ACME](https://tools.ietf.org/html/rfc8555) protocol, and written primarily in Go. A great place to start is with the list of ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) and the [contributors guide](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/es/getinvolved.md
+++ b/content/es/getinvolved.md
@@ -25,7 +25,7 @@ Siempre podemos usar ayuda para el desarrollo de software. Todo nuestro código 
 
 ### Software AC del lado del servidor
 
-[Boulder](https://github.com/letsencrypt/boulder) es la implementación AC de Let's Encrypt. Está basado en el protocolo [ACME](https://tools.ietf.org/html/rfc8555), y escrito primariamente en Go. Un gran lugar para comenzar es con la lista de problemas ['help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) y la [guía de contribuyentes](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) es la implementación AC de Let's Encrypt. Está basado en el protocolo [ACME](https://tools.ietf.org/html/rfc8555), y escrito primariamente en Go. Un gran lugar para comenzar es con la lista de problemas ['help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) y la [guía de contribuyentes](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/fi/getinvolved.md
+++ b/content/fi/getinvolved.md
@@ -25,7 +25,7 @@ Voit myös auttaa ohjelmistokehityksessä. Kaikki koodimme on [GitHubissa](https
 
 ### Palvelinpuoleinen varmentajaohjelmisto
 
-<a href="https://gi[Boulder](https://github.com/letsencrypt/boulder) on toteutus varmentajaa Let's Encrypt. Se perustuu [ACME](https://tools.ietf.org/html/rfc8555) protokollaan, ja on kirjoitettu ensisijaisesti Go:ksi. Hyvä paikka aloittaa on luettelo ["apua tarvitaan'-ongelmista](https://github.com/letsencrypt/boulder/labels/help%20wanted) ja [avustajien opas](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+<a href="https://gi[Boulder](https://github.com/letsencrypt/boulder) on toteutus varmentajaa Let's Encrypt. Se perustuu [ACME](https://tools.ietf.org/html/rfc8555) protokollaan, ja on kirjoitettu ensisijaisesti Go:ksi. Hyvä paikka aloittaa on luettelo ["apua tarvitaan'-ongelmista](https://github.com/letsencrypt/boulder/labels/help%20wanted) ja [avustajien opas](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/fr/getinvolved.md
+++ b/content/fr/getinvolved.md
@@ -25,7 +25,7 @@ Nous pouvons également apporter notre aide pour le développement de logiciels.
 
 ### Logiciel d'AC côté serveur
 
-[Boulder](https://github.com/letsencrypt/boulder) est l'implémentation de l'AC "Let's Encrypt". Il est basé sur le protocole [ACME](https://tools.ietf.org/html/rfc8555) et écrit principalement en Go. Un bon point de départ est la liste des questions ["help wanted"](https://github.com/letsencrypt/boulder/labels/help%20wanted) et le [guide des contributeurs](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) est l'implémentation de l'AC "Let's Encrypt". Il est basé sur le protocole [ACME](https://tools.ietf.org/html/rfc8555) et écrit principalement en Go. Un bon point de départ est la liste des questions ["help wanted"](https://github.com/letsencrypt/boulder/labels/help%20wanted) et le [guide des contributeurs](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/he/getinvolved.md
+++ b/content/he/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### תכנית רשות אישורים מצד השרת
 
-[Boulder](https://github.com/letsencrypt/boulder) הוא המימוש של Let's Encrypt לרשות אישורים. הוא מבוסס על פרוטוקול [ACME](https://tools.ietf.org/html/rfc8555) וכתוב בעיקר ב־Go. מקום טוב להתחיל בו הוא רשימת [התקלות שמסומנות בתור ‚help wanted’ (דרושה עזרה)](https://github.com/letsencrypt/boulder/labels/help%20wanted) לצד [המדריך למתנדבים](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) הוא המימוש של Let's Encrypt לרשות אישורים. הוא מבוסס על פרוטוקול [ACME](https://tools.ietf.org/html/rfc8555) וכתוב בעיקר ב־Go. מקום טוב להתחיל בו הוא רשימת [התקלות שמסומנות בתור ‚help wanted’ (דרושה עזרה)](https://github.com/letsencrypt/boulder/labels/help%20wanted) לצד [המדריך למתנדבים](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/hu/getinvolved.md
+++ b/content/hu/getinvolved.md
@@ -25,7 +25,7 @@ A [Certbot](https://github.com/certbot/certbot) a webszerver mellett működő P
 
 ### Szerveroldali hitelesítés szolgáltató  (CE) szoftver
 
-[Boulder](https://github.com/letsencrypt/boulder) a Let's Encrypt CA implementációja. Az [ACME](https://tools.ietf.org/html/rfc8555) protokollon alapul, és nagyrészt Go nyelven íródott. Remek kiindulópont lehet a ['help wanted' taggel ellátott issue-k](https://github.com/letsencrypt/boulder/labels/help%20wanted) és a [közreműködők számára készült útmutató](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) a Let's Encrypt CA implementációja. Az [ACME](https://tools.ietf.org/html/rfc8555) protokollon alapul, és nagyrészt Go nyelven íródott. Remek kiindulópont lehet a ['help wanted' taggel ellátott issue-k](https://github.com/letsencrypt/boulder/labels/help%20wanted) és a [közreműködők számára készült útmutató](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/id/getinvolved.md
+++ b/content/id/getinvolved.md
@@ -25,7 +25,7 @@ Kita juga bisa menggunakan bantuan dengan pengembangan perangkat lunak. Semua ko
 
 ### Perangkat Lunak CA Sisi Peladen
 
-[Boulder](https://github.com/letsencrypt/boulder) adalah implementasi CA Let's Encrypt. Ini berdasarkan pada protokol [ACME](https://tools.ietf.org/html/rfc8555) dan ditulis terutama dalam Go. Sebuah tempat yang bagus untuk memulai adalah dengan daftar [masalah 'help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) dan [petunjuk kontributor](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) adalah implementasi CA Let's Encrypt. Ini berdasarkan pada protokol [ACME](https://tools.ietf.org/html/rfc8555) dan ditulis terutama dalam Go. Sebuah tempat yang bagus untuk memulai adalah dengan daftar [masalah 'help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) dan [petunjuk kontributor](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/it/getinvolved.md
+++ b/content/it/getinvolved.md
@@ -25,7 +25,7 @@ Possiamo anche dare una mano con lo sviluppo di software. Il nostro codice è su
 
 ### Software CA lato Server
 
-[Boulder](https://github.com/letsencrypt/boulder) è l'implementazione Let's Encrypt CA. Si basa sul protocollo [ACME](https://tools.ietf.org/html/rfc8555), e scritto principalmente in Go. Un ottimo posto in cui iniziare è l'elenco di [help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) e la [guida dei contributori](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) è l'implementazione Let's Encrypt CA. Si basa sul protocollo [ACME](https://tools.ietf.org/html/rfc8555), e scritto principalmente in Go. Un ottimo posto in cui iniziare è l'elenco di [help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) e la [guida dei contributori](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/ja/getinvolved.md
+++ b/content/ja/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### サーバーサイドの CA ソフトウェア
 
-[Boulder](https://github.com/letsencrypt/boulder) は、Let's Encrypt CA の実装です。 Boulder は [ACME](https://tools.ietf.org/html/rfc8555) プロトコルに基づいており、主に Go 言語で書かれています。 コントリビューションを行うには、['help wanted' のラベルがついた issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) から始めるのがおすすめです。コントリビューションを行う際には、[コントリビューター・ガイド](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md)も忘れずに読んでください。
+[Boulder](https://github.com/letsencrypt/boulder) は、Let's Encrypt CA の実装です。 Boulder は [ACME](https://tools.ietf.org/html/rfc8555) プロトコルに基づいており、主に Go 言語で書かれています。 コントリビューションを行うには、['help wanted' のラベルがついた issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) から始めるのがおすすめです。コントリビューションを行う際には、[コントリビューター・ガイド](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md)も忘れずに読んでください。
 
 ### letsencrypt.org
 

--- a/content/ko/getinvolved.md
+++ b/content/ko/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### 서버단 CA 소프트웨어
 
-[Boulder](https://github.com/letsencrypt/boulder)는 Let’s Encrypt CA를 구현하기 위한 도구입니다. [ACME](https://tools.ietf.org/html/rfc8555) 프로토콜 기반이고, 우선은 Go 프로그램 언어로 작성되었습니다. 시작하기에 좋은 곳은 ['도움을 원해요' 목록](https://github.com/letsencrypt/boulder/labels/help%20wanted)과 [공헌자 가이드](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md)입니다.
+[Boulder](https://github.com/letsencrypt/boulder)는 Let’s Encrypt CA를 구현하기 위한 도구입니다. [ACME](https://tools.ietf.org/html/rfc8555) 프로토콜 기반이고, 우선은 Go 프로그램 언어로 작성되었습니다. 시작하기에 좋은 곳은 ['도움을 원해요' 목록](https://github.com/letsencrypt/boulder/labels/help%20wanted)과 [공헌자 가이드](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md)입니다.
 
 ### letsencrypt.org
 

--- a/content/ru/getinvolved.md
+++ b/content/ru/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### Серверное программное обеспечение ЦС
 
-[Boulder](https://github.com/letsencrypt/boulder) — это реализация Центра сертификации (ЦС) Let's Encrypt. Он основан на протоколе [ACME](https://tools.ietf.org/html/rfc8555), и написан в основном на Go. Отличный способ начать — ознакомиться со списком [проблем 'help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) и [инструкцией для участников](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) — это реализация Центра сертификации (ЦС) Let's Encrypt. Он основан на протоколе [ACME](https://tools.ietf.org/html/rfc8555), и написан в основном на Go. Отличный способ начать — ознакомиться со списком [проблем 'help wanted'](https://github.com/letsencrypt/boulder/labels/help%20wanted) и [инструкцией для участников](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### Сайт letsencrypt.org
 

--- a/content/si/getinvolved.md
+++ b/content/si/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### සේවාදායක පාදක ස.අධි. (CA) මෘදුකාංගය
 
-[බෝල්ඩර්](https://github.com/letsencrypt/boulder) යනු ලෙට්'ස් එන්ක්‍රිප්ට් ස.අධි. (CA) ක්‍රියාවට නැංවීමකි. එය [ACME](https://tools.ietf.org/html/rfc8555) කෙටුම්පත මත පදනම් වන අතර මූලිකව ගෝ භාවිතයෙන් ලියා ඇත. මූලාරම්භයට සුදුසු තැන් ලෙස ['උදව් අවශ්‍ය' ගැටළු](https://github.com/letsencrypt/boulder/labels/help%20wanted) සහ [දායකත්ව මාර්ගෝපදේශය](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md) දැක්වීමට හැකිය.
+[බෝල්ඩර්](https://github.com/letsencrypt/boulder) යනු ලෙට්'ස් එන්ක්‍රිප්ට් ස.අධි. (CA) ක්‍රියාවට නැංවීමකි. එය [ACME](https://tools.ietf.org/html/rfc8555) කෙටුම්පත මත පදනම් වන අතර මූලිකව ගෝ භාවිතයෙන් ලියා ඇත. මූලාරම්භයට සුදුසු තැන් ලෙස ['උදව් අවශ්‍ය' ගැටළු](https://github.com/letsencrypt/boulder/labels/help%20wanted) සහ [දායකත්ව මාර්ගෝපදේශය](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md) දැක්වීමට හැකිය.
 
 ### letsencrypt.org
 

--- a/content/sr/getinvolved.md
+++ b/content/sr/getinvolved.md
@@ -25,7 +25,7 @@ Takođe,često volimo da koristimo i pomoć oko razvoja softvera. Ceo naš izvor
 
 ### Server-side CA softver
 
-[Boulder](https://github.com/letsencrypt/boulder) je implementacija Let's Encrypt CA. Temelji se na protokolu [ACME](https://tools.ietf.org/html/rfc8555), a prvenstveno je napisan u programskom jeziku Go. Sjajno mesto za početak je popis [pitanja od ljudi koji traže pomoć](https://github.com/letsencrypt/boulder/labels/help%20wanted) i [vodič za doprinose](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) je implementacija Let's Encrypt CA. Temelji se na protokolu [ACME](https://tools.ietf.org/html/rfc8555), a prvenstveno je napisan u programskom jeziku Go. Sjajno mesto za početak je popis [pitanja od ljudi koji traže pomoć](https://github.com/letsencrypt/boulder/labels/help%20wanted) i [vodič za doprinose](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/sv/getinvolved.md
+++ b/content/sv/getinvolved.md
@@ -25,7 +25,7 @@ Vi kan också behöva hjälp med mjukvaruutveckling. All vår kod finns på [Git
 
 ### Server-side CA Software
 
-[Boulder](https://github.com/letsencrypt/boulder) är Let's Encrypts CA-implementation. Den bygger på [ACME](https://tools.ietf.org/html/rfc8555)-protokollet och är i huvudsak skriven i Go. Ett bra ställe att börja är i ["hjälp sökes"-listan](https://github.com/letsencrypt/boulder/labels/help%20wanted) och [riktlinjerna för att bidra](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) är Let's Encrypts CA-implementation. Den bygger på [ACME](https://tools.ietf.org/html/rfc8555)-protokollet och är i huvudsak skriven i Go. Ett bra ställe att börja är i ["hjälp sökes"-listan](https://github.com/letsencrypt/boulder/labels/help%20wanted) och [riktlinjerna för att bidra](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/uk/getinvolved.md
+++ b/content/uk/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### Програмне забезпечення на сервері ЦС
 
-[Boulder](https://github.com/letsencrypt/boulder) - це реалізація Let's Encrypt Центром сертифікації. Вона заснована на [ACME](https://tools.ietf.org/html/rfc8555) протоколі і переважно написана у Go. Найкраще розпочати зі списку ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) та [contributors guide](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) - це реалізація Let's Encrypt Центром сертифікації. Вона заснована на [ACME](https://tools.ietf.org/html/rfc8555) протоколі і переважно написана у Go. Найкраще розпочати зі списку ['help wanted' issues](https://github.com/letsencrypt/boulder/labels/help%20wanted) та [contributors guide](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/vi/getinvolved.md
+++ b/content/vi/getinvolved.md
@@ -25,7 +25,7 @@ Chúng ta cũng có thể sử dụng trợ giúp về phát triển phần mề
 
 ### Phần mềm CA phía máy chủ
 
-[Boulder](https://github.com/letsencrypt/boulder) là triển khai Let's Encrypt CA. Nó dựa trên giao thức [ACME](https://tools.ietf.org/html/rfc8555) và được viết chủ yếu bằng ngôn ngữ Go. Một nơi tuyệt vời để bắt đầu là với danh sách [các vấn đề 'cần trợ giúp'](https://github.com/letsencrypt/boulder/labels/help%20wanted) và [hướng dẫn dành cho cộng tác viên](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md).
+[Boulder](https://github.com/letsencrypt/boulder) là triển khai Let's Encrypt CA. Nó dựa trên giao thức [ACME](https://tools.ietf.org/html/rfc8555) và được viết chủ yếu bằng ngôn ngữ Go. Một nơi tuyệt vời để bắt đầu là với danh sách [các vấn đề 'cần trợ giúp'](https://github.com/letsencrypt/boulder/labels/help%20wanted) và [hướng dẫn dành cho cộng tác viên](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md).
 
 ### letsencrypt.org
 

--- a/content/zh-cn/getinvolved.md
+++ b/content/zh-cn/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### 服务器端证书签发软件
 
-Let's Encrypt 的证书签发过程由 [Boulder](https://github.com/letsencrypt/boulder) 实现。 该软件基于 [ACME](https://tools.ietf.org/html/rfc8555) 协议，主要使用 Go 语言编写。 [标注为“help wanted”的 issue 列表](https://github.com/letsencrypt/boulder/labels/help%20wanted)和[贡献者指南](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md)都是一个很好的起点。
+Let's Encrypt 的证书签发过程由 [Boulder](https://github.com/letsencrypt/boulder) 实现。 该软件基于 [ACME](https://tools.ietf.org/html/rfc8555) 协议，主要使用 Go 语言编写。 [标注为“help wanted”的 issue 列表](https://github.com/letsencrypt/boulder/labels/help%20wanted)和[贡献者指南](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md)都是一个很好的起点。
 
 ### letsencrypt.org
 

--- a/content/zh-tw/getinvolved.md
+++ b/content/zh-tw/getinvolved.md
@@ -25,7 +25,7 @@ show_lastmod: 1
 
 ### 伺服器端 CA 軟體
 
-Let's Encrypt CA 使用 [Boulder](https://github.com/letsencrypt/boulder) 簽發憑證。 該軟體基於 [ACME](https://tools.ietf.org/html/rfc8555) 協定並主要使用 Go 語言撰寫。 查看[“尋求幫助”問題](https://github.com/letsencrypt/boulder/labels/help%20wanted)列表，和閱讀[貢獻者指南](https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md)是一個很不錯的開始。
+Let's Encrypt CA 使用 [Boulder](https://github.com/letsencrypt/boulder) 簽發憑證。 該軟體基於 [ACME](https://tools.ietf.org/html/rfc8555) 協定並主要使用 Go 語言撰寫。 查看[“尋求幫助”問題](https://github.com/letsencrypt/boulder/labels/help%20wanted)列表，和閱讀[貢獻者指南](https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md)是一個很不錯的開始。
 
 ### letsencrypt.org
 


### PR DESCRIPTION
**PR Summary**:
The PR updates the location of the letsencrypt/boulder's `CONTRIBUTING.md` file which was moved from the root directory into `docs` directory. Also changed the branch from `master` to `main`.
- Previous location: https://github.com/letsencrypt/boulder/blob/master/CONTRIBUTING.md
- Current location: https://github.com/letsencrypt/boulder/blob/main/docs/CONTRIBUTING.md

Relevant docs page: https://letsencrypt.org/getinvolved