### PR TITLE
Fix warn messages with latest hugo version 0.117.0

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -3,7 +3,7 @@ baseURL = "https://letsencrypt.org/"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy", "term"]
 
 enableRobotsTXT = true
 

--- a/config/_default/languages.da.toml
+++ b/config/_default/languages.da.toml
@@ -2,11 +2,12 @@ title = "Let's Encrypt"
 contentDir = "content/da"
 languageName = "Dansk"
 languageCode = "da"
-beforeColon = ""
 weight = 190
+[params]
+beforeColon = ""
 description = """
-  Let's Encrypt er en gratis, automatisk og åben certifikat 
- udsteeder bragt til dig af nonprofit organisationen <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>. 
+  Let's Encrypt er en gratis, automatisk og åben certifikat
+ udsteeder bragt til dig af nonprofit organisationen <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"
 paypalCountry = "DK"

--- a/config/_default/languages.de.toml
+++ b/config/_default/languages.de.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - Freie SSL/TLS Zertifikate"
 contentDir = "content/de"
 languageName = "Deutsch"
 languageCode = "de-DE"
-beforeColon = ""
 weight = 200
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt ist eine freie, automatisierte und offene Zertifizierungsstelle,
   herausgebracht für Sie durch <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.

--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -4,12 +4,13 @@ contentDir = "content/en"
 languageName = "English"
 #The language code. Usually two lower-case letters. It that language is spoken in more than one country, the country-code can be added, uppercase. To check it: https://r12a.github.io/app-subtags/?check=pt-BR
 languageCode = "en-US"
-#if colon ":" must be prefixed with a space : "&nbsp;" (example in [fr])
-beforeColon = ""
 # Weight used for sorting.
 # 10 for English
 # Other languages from 100 to 999, alphabetical order using languageCode.
 weight = 10
+[params]
+#if colon ":" must be prefixed with a space : "&nbsp;" (example in [fr])
+beforeColon = ""
 description = """
   Let's Encrypt is a free, automated, and open certificate
   authority brought to you by the nonprofit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.

--- a/config/_default/languages.es.toml
+++ b/config/_default/languages.es.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - Certificados SSL/TLS Gratuitos"
 contentDir = "content/es"
 languageName = "Español"
 languageCode = "es-US"
-beforeColon = "&nbsp;"
 weight = 250
+[params]
+beforeColon = "&nbsp;"
 description = """
   Let's Encrypt es una autoridad de certificación gratuita, automatizada, y abierta traida a ustedes por la organización sin ánimos de lucro <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """

--- a/config/_default/languages.fi.toml
+++ b/config/_default/languages.fi.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt"
 contentDir = "content/fi"
 languageName = "Suomi"
 languageCode = "fi"
-beforeColon = ""
 weight = 275
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt on ilmainen, automatisoitu, ja avoin varmenteita myöntävä organisaatio, jonka on perustanut voittoa tavoittelematon organisaatio <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.
 """

--- a/config/_default/languages.fr.toml
+++ b/config/_default/languages.fr.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - Certificats SSL/TLS gratuits"
 languageName = "Français"
 contentDir = "content/fr"
 languageCode = "fr-FR"
-beforeColon = "&nbsp;"
 weight = 300
+[params]
+beforeColon = "&nbsp;"
 description = """
   Let's Encrypt est une autorité de certification gratuite, automatisée et ouverte
   mise à votre disposition par la société d'utilité publique <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.

--- a/config/_default/languages.he.toml
+++ b/config/_default/languages.he.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt"
 contentDir = "content/he"
 languageName = "עברית"
 languageCode = "he"
-beforeColon = ""
 weight = 325
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt היא רשות אישורים חופשית, אוטומטית ופתוחה
   שמוגשת לך באדיבות <a href="https://www.abetterinternet.org/">קבוצת מחקר אבטחת האינטרנט (ISRG)</a>.

--- a/config/_default/languages.hu.toml
+++ b/config/_default/languages.hu.toml
@@ -4,12 +4,13 @@ contentDir = "content/hu"
 languageName = "Hungarian"
 #The language code. Usually two lower-case letters. It that language is spoken in more than one country, the country-code can be added, uppercase. To check it: https://r12a.github.io/app-subtags/?check=pt-BR
 languageCode = "hu"
-#if colon ":" must be prefixed with a space : "&nbsp;" (example in [fr])
-beforeColon = ""
 # Weight used for sorting.
 # 10 for English
 # Other languages from 100 to 999, alphabetical order using languageCode.
 weight = 330
+[params]
+#if colon ":" must be prefixed with a space : "&nbsp;" (example in [fr])
+beforeColon = ""
 description = """
   A Let's Encrypt egy ingyenes, automatizált és nyílt tanúsító hatóság,
   melyet a nonprofit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a> szervezet tesz elérhetővé.

--- a/config/_default/languages.id.toml
+++ b/config/_default/languages.id.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - Sertifikat SSL/TLS Gratis"
 contentDir = "content/id"
 languageName = "Bahasa Indonesia"
 languageCode = "id-ID"
-beforeColon = ""
 weight = 350
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt adalah otoritas sertifikasi terbuka yang gratis dan terotomatisasi,
   dipersembahkan oleh organisasi non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.

--- a/config/_default/languages.it.toml
+++ b/config/_default/languages.it.toml
@@ -4,12 +4,13 @@ contentDir = "content/it"
 languageName = "Italiano"
 #The language code. Usually two lower-case letters. It that language is spoken in more than one country, the country-code can be added, uppercase. To check it: https://r12a.github.io/app-subtags/?check=pt-BR
 languageCode = "it-IT"
-#if colon ":" must be prefixed with a space : "&nbsp;" (example in [fr])
-beforeColon = ""
 # Weight used for sorting.
 # 10 for English
 # Other languages from 100 to 999, alphabetical order using languageCode.
 weight = 375
+[params]
+#if colon ":" must be prefixed with a space : "&nbsp;" (example in [fr])
+beforeColon = ""
 description = """
   Let's Encrypt è un'autorità di certificazione gratuita, automatica
   ed open source messa a disposizione dall'organizzazione non-profit <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.

--- a/config/_default/languages.ja.toml
+++ b/config/_default/languages.ja.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - フリーな SSL/TLS 証明書"
 contentDir = "content/ja"
 languageName = "日本語"
 languageCode = "ja"
-beforeColon = ""
 weight = 400
+[params]
+beforeColon = ""
 description = """
   Let's Encryptは、非営利団体の <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a> が提供する自動化されたフリーでオープンな認証局です。
 """

--- a/config/_default/languages.ko.toml
+++ b/config/_default/languages.ko.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - 무료 SSL/TLS 인증서"
 contentDir = "content/ko"
 languageName = "한국어"
 languageCode = "ko-KR"
-beforeColon = ""
 weight = 450
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt는 <a href="https://www.abetterinternet.org/"> 비영리 인터넷 보안 연구 그룹 (ISRG)</a>에서 가져온 무료, 자동 및 공개 인증 기관입니다.
 """

--- a/config/_default/languages.pt-br.toml
+++ b/config/_default/languages.pt-br.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - Certificados SSL/TLS Gratuitos"
 contentDir = "content/pt-br"
 languageName = "Português do Brasil"
 languageCode = "pt-BR"
-beforeColon = ""
 weight = 500
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt é uma autoridade certificadora gratuita, automatizada e aberta
   que se tornou possível graças à organização sem fins lucrativos <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>

--- a/config/_default/languages.ru.toml
+++ b/config/_default/languages.ru.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt"
 contentDir = "content/ru"
 languageName = "Русский"
 languageCode = "ru-RU"
-beforeColon = ""
 weight = 550
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt - это бесплатный, автоматизированный и открытый Центр Сертификации, созданный для вас
   некоммерческой организацией <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.

--- a/config/_default/languages.si.toml
+++ b/config/_default/languages.si.toml
@@ -1,10 +1,10 @@
-
 title = "Let's Encrypt"
 contentDir = "content/si"
 languageName = "සිංහල"
 languageCode = "si"
-beforeColon = ""
 weight = 590
+[params]
+beforeColon = ""
 description = """
 Let's Encrypt යනු නොමිලේ, ස්වයංක්‍රීය සහ විවෘත සහතික අධිකාරියකි. ලාභ නොලබන අන්තර්ජාල ආරක්‍ෂණ පර්යේෂණ සමූහය (අයි.එස්.ආර්.ජී.) විසින් මෙහෙයවයි.
 """

--- a/config/_default/languages.sr.toml
+++ b/config/_default/languages.sr.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - Besplatni SSL/TLS Sertifikati"
 contentDir = "content/sr"
 languageName = "Srpski"
 languageCode = "sr"
-beforeColon = ""
 weight = 600
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt je besplatno, automatizovano, i otvoreno sertifikaciono
   telo omogućeno od strane ne profitne <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a> grupe.

--- a/config/_default/languages.sv.toml
+++ b/config/_default/languages.sv.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - Gratis SSL/TLS-certifikat"
 contentDir = "content/sv"
 languageName = "Svenska"
 languageCode = "sv"
-beforeColon = ""
 weight = 650
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt är en gratis, automatiserad och öppen certifikatutgivare
   skapad av icke-vinstdrivande <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.

--- a/config/_default/languages.uk.toml
+++ b/config/_default/languages.uk.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - Free SSL/TLS Certificates"
 contentDir = "content/uk"
 languageName = "Українська"
 languageCode = "uk-UA"
-beforeColon = ""
 weight = 670
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt - це безкоштовний, автоматизований і відкритий Центр Сертифікації, створений для вас
   некомерційною організацією <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.

--- a/config/_default/languages.vi.toml
+++ b/config/_default/languages.vi.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - Chứng Chỉ SSL/TLS Certificates Miễn Phí"
 contentDir = "content/vi"
 languageName = "Tiếng Việt"
 languageCode = "vi-VN"
-beforeColon = ""
 weight = 700
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt là một chứng nhận mở, miễn phí và tự động
   được cung cấp bởi tổ chức phi lợi nhuận <a href="https://www.abetterinternet.org/">Internet Security Research Group (ISRG)</a>.

--- a/config/_default/languages.zh-cn.toml
+++ b/config/_default/languages.zh-cn.toml
@@ -2,8 +2,9 @@ title = "Let's Encrypt - 免费的SSL/TLS证书"
 contentDir = "content/zh-cn"
 languageName = "简体中文"
 languageCode = "zh-Hans-CN"
-beforeColon = ""
 weight = 750
+[params]
+beforeColon = ""
 description = """
   Let's Encrypt 是免费、开放和自动化的证书颁发机构。由非盈利组织<a href="https://www.abetterinternet.org/"
   style="white-space:nowrap;">互联网安全研究小组（ISRG）</a>运营。

--- a/config/_default/languages.zh-tw.toml
+++ b/config/_default/languages.zh-tw.toml
@@ -2,9 +2,10 @@ title = "Let's Encrypt - 免費的 SSL/TLS 憑證"
 languageName = "繁體中文"
 contentDir = "content/zh-tw"
 languageCode = "zh-Hant-TW"
-beforeColon = ""
 weight = 800
-description = """  
+[params]
+beforeColon = ""
+description = """
   Let's Encrypt 是免費、自動化和開放的憑證頒發機構，由非營利組織<a href="https://www.abetterinternet.org/">網路安全研究小組 (Internet Security Research Group, ISRG)</a> 營運。
   """
 paypalDonateImage = "https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif"


### PR DESCRIPTION
When running this site with latest hugo version 0.117.0, there are a lot of warning thrown. This PR fixes all these warnings.
The site runs still fine with hugo v0.89.x, though.