### PR TITLE
Update CAA documentation

### DIFF
--- a/content/en/docs/caa.md
+++ b/content/en/docs/caa.md
@@ -3,18 +3,19 @@ title: Certificate Authority Authorization (CAA)
 slug: caa
 top_graphic: 1
 date: 2017-07-27
-lastmod: 2017-07-27
+lastmod: 2023-08-16
 show_lastmod: 1
 ---
 
 
 CAA is a type of DNS record that allows site owners to specify which Certificate
-Authorities (CAs) are allowed to issue certificates containing their domain names. It
-was standardized in 2013 by [RFC 6844](https://tools.ietf.org/html/rfc6844) to
-allow a CA "reduce the risk of unintended certificate mis-issue." By default,
-every public CA is allowed to issue certificates for any domain name in the
-public DNS, provided they validate control of that domain name. That means that
-if there's a bug in any one of the many public CAs' validation processes, every
+Authorities (CAs) are allowed to issue certificates containing their domain
+names. It was first standardized in 2013, and the version we use today was
+standardized in 2019 by [RFC 8659](https://datatracker.ietf.org/doc/html/rfc8659)
+and [RFC 8657](https://datatracker.ietf.org/doc/html/rfc8657). By default, every
+public CA is allowed to issue certificates for any domain name in the public
+DNS, provided they validate control of that domain name. That means that if
+there's a bug in any one of the many public CAs' validation processes, every
 domain name is potentially affected. CAA provides a way for domain holders to
 reduce that risk.
 
@@ -29,35 +30,75 @@ provider is listed, you can use
 [SSLMate's CAA Record Generator](https://sslmate.com/caa/) to generate a
 set of CAA records listing the CAs that you would like to allow.
 
-Let's Encrypt's identifying domain name for CAA is `letsencrypt.org`. This is
-officially documented [in our Certification Practice Statement (CPS), section 4.2.1](/repository).
-
 ## Where to put the record
 
-You can set CAA records on your main domain, or at any depth of subdomain.
-For instance, if you had `www.community.example.com`, you could set CAA records
-for the full name, or for `community.example.com`, or for `example.com`. CAs
-will check each version, from left to right, and stop as soon as they see any
-CAA record. So for instance, a CAA record at `community.example.com` would take
-precedence over one at `example.com`. Most people who add CAA records will want
-to add them to their registered domain (`example.com`) so that they apply to all
-subdomains. Also note that CAA records for subdomains take precedence over their
-parent domains regardless of whether they are more permissive or more
-restrictive. So a subdomain can loosen a restriction put in place by a parent
-domain.
+Generally, you want to set CAA records on your registered domain (such as "example.org" or "mysite.co.uk"). This way they apply to both that domain and any subdomains you create under it, such as "community.example.org".
 
-CAA validation follows CNAMEs, like all other DNS requests. If
-`www.community.example.com` is a CNAME to `web1.example.net`, the CA will first
-request CAA records for `www.community.example.com`, then seeing that there is a
-CNAME for that domain name instead of CAA records, will request CAA records for
-`web1.example.net` instead. Note that if a domain name has a CNAME record, it is
-not allowed to have any other records according to the DNS standards.
+Note that the CA will always respect the CAA record *closest* to the domain name it is issuing a certificate for. So if you're requesting a cert for "www.community.example.org", the CA will check "www.community.example.org", then "community.example.org", then "example.org", stopping at the first CAA record it finds.
 
-The [CAA RFC](https://tools.ietf.org/html/rfc6844) specifies an additional
-behavior called "tree-climbing" that requires CAs to also check the parent
-domains of the result of CNAME resolution. This additional behavior was later
-removed by [an erratum](https://www.rfc-editor.org/errata/eid5065), so Let's
-Encrypt and other CAs do not implement it.
+This means that you can override CAA for subdomains. For example, suppose that you host "example.org" yourself, but have "api.example.org" on a cloud provider. You could use a CAA record on "example.org" to say that only Let's Encrypt can issue for that domain and all of its subdomains, but also use a CAA record on "api.example.org" to override that and allow the cloud provider to issue certificates for that one subdomain.
+
+Note also that CAA checking follows CNAME redirects, just like all other DNS requests. If "community.example.org" is a CNAME to "example.forum.com", the CA will respect any CAA records that are set on "example.forum.com". It is not allowed for a domain name with a CNAME record to have any other records, so there cannot be conflicts between CAA records on the original name and CAA records on the target of the redirect.
+
+## What to put in the record
+
+All CAA records follow the same basic format:
+
+```
+CAA <flags> <tag> <value>
+```
+
+The **flags** are just an integer, and should almost always just be the integer `0`, indicating that no flags have been set. If you like, you can set the flags to the integer `128`, indicating that the "critical bit" has been set, and that CAs should immediately halt and not issue a certificate if they don't recognize the contents of the tag field.
+
+The **tag** is a string indicating which kind of CAA record this is: either `issue` or `issuewild` in most cases. More on these below.
+
+Finally, the **value** is a string containing at most one CA identifier (such as "letsencrypt.org") and some optional semicolon-separated parameters, also discussed below.
+
+### The `issue` and `issuewild` properties
+
+Records with the `issue` tag simply control whether a CA can issue certificates for this domain and its subdomains. Generally this is the only record you need, as it controls both normal (e.g. "example.org") and wildcard (e.g. "*.example.org") issuance in the absence of any other records. You control which CA can issue for this domain by putting that CA's identifying domain name in the value portion of the CAA record.
+
+Records with the `issuewild` tag control whether a CA can issue *wildcard* certificates (e.g. "*.example.org"). You only need to use `issuewild` records if you want different permissions for wildcard and non-wildcard issuance.
+
+Note that you can have multiple records with the same property type and they are *additive*: if any one of those records allows the CA to issue, then it is allowed.
+
+Let's Encrypt's identifying domain name for CAA is `letsencrypt.org`. This is
+officially documented in [Section 4.2.1 of our CP/CPS](https://cps.letsencrypt.org/#4.2.1-performing-identification-and-authentication-functions).
+
+### The `validationmethods` parameter
+
+This parameter can be placed after the CA's identifying domain name to control which validation methods that CA can use to confirm control over the domain. This can be used to restrict validation to methods that you trust more. For example, if you want to restrict the CA to only using the TLS-ALPN-01 method, you could append `;validationmethods=tls-alpn-01` to your CAA record value.
+
+Let's Encrypt recognizes the following validation method strings:
+
+* `http-01`
+* `dns-01`
+* `tls-alpn-01`
+
+### The `accounturi` parameter
+
+This parameter can be placed after the CA's identifying domain name to control which ACME Accounts can request issuance for the domain. This can be used to ensure that someone who temporarily hijacks your domain, but doesn't have access to your ACME Account key, can't issue malicious certificates.
+
+Let's Encrypt's account URIs look like `https://acme-v02.api.letsencrypt.org/acme/acct/1234567890`, where the numbers at the end are your Account ID.
+
+### Examples
+
+A simple CAA record which allows Let's Encrypt to issue for "example.org" might look like this:
+
+```
+example.org         CAA 0 issue "letsencrypt.org"
+```
+
+A more complex CAA record set might look like this:
+
+```
+example.org         CAA 0 issue "myca.org;validationmethods=dns-01"
+example.org         CAA 0 issuewild "myca.org"
+example.org         CAA 128 issue "otherca.com;accounturi=https://otherca.com/acct/123456"
+```
+
+In this example, MyCA can issue for "example.org", but only using the DNS-01 validation method. It can also issue wildcard certificates, using any validation method. Finally, OtherCA can also issue certificates, but only if the request comes from account number `123456`, and only if OtherCA recognizes and knows how to correctly handle the `accounturi` restriction.
+
 
 # CAA errors
 
@@ -79,7 +120,7 @@ NOERROR response for unknown query types (including CAA). Returning other
 opcodes, including NOTIMP, for unrecognized qtypes is a violation of [RFC
 1035](https://tools.ietf.org/html/rfc1035), and needs to be fixed.
 
-# SERVFAIL
+## SERVFAIL
 
 One of the most common errors that people encounter is SERVFAIL. Most often this
 indicates a failure of DNSSEC validation. If you get a SERVFAIL error, your
@@ -98,7 +139,7 @@ Lastly, SERVFAILs may be caused by outages at your authoritative nameservers.
 Check the NS records for your nameservers and ensure that each server is
 available.
 
-# Timeout
+## Timeout
 
 Sometimes CAA queries time out. That is, the authoritative name server never
 replies with an answer at all, even after multiple retries. Most commonly this


### PR DESCRIPTION
Overhaul the CAA documentation page to remove references to outdated RFCs, streamline the guidance about where to put CAA records, introduce guidance about what to put in them, and describe the (relatively) new accounturi and validationmethods parameters.

Fixes https://github.com/letsencrypt/website/issues/1524