### PR TITLE
added missed services in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+services:
   server:
     image: klakegg/hugo:ext-alpine
     command: server


### PR DESCRIPTION
added missed services in docker-compose. Without this `docker compose` complains about file syntax. 

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
