### PR TITLE
Separate the logic of outdated_translation vs lastmod

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -85,6 +85,8 @@
 		{{- if.Page.Params.show_lastmod -}}
 			{{- partial "lastmod" . -}}
 		{{- end -}}
+		
+		{{- partial "outdated_translation" . -}}
 
 		{{- $scratch := newScratch -}}
 		{{- $lang := .Page.Language.Lang -}}

--- a/layouts/partials/lastmod.html
+++ b/layouts/partials/lastmod.html
@@ -7,25 +7,4 @@
 
 {{ if eq .Page.Section "docs" }} | <a href="{{ "docs" | relLangURL }}">{{ i18n "see_all_doc" }}</a>{{ end }}
 </p>
-
-{{ $curpage := .Page }}
-{{ if and (ne $curpage.Language.Lang "en") (not .Page.Params.untranslated) }}
-{{/* If we are not in English we search for the English version */}}
-{{ range $curpage.Translations }}
-    {{ if eq "en" .Language.Lang }}
-        {{ if .Page.Lastmod }}
-            {{/* To compare the Lastmod with the current translation */}}   
-            {{ if ne $curpage.Lastmod .Page.Lastmod }}
-            <p>
-                <i>
-                    {{ i18n "old_version" }}
-                    (<time datetime="{{ .Page.Lastmod.Format "2006-01-02" }}">{{ .Page.Lastmod | time.Format $.Site.Params.time_format_default }}</time>)
-                    <a href="{{ .Page.RelPermalink }}">{{ i18n "view_in_english" }}</a>
-                </i>
-            </p>
-            {{ end }}
-        {{ end }}
-    {{ end }}
-{{ end }}
-{{ end }}
 <!--googleon: all-->

--- a/layouts/partials/outdated_translation.html
+++ b/layouts/partials/outdated_translation.html
@@ -1,0 +1,22 @@
+<!--googleoff: all-->
+{{ $curpage := .Page }}
+{{ if and (ne $curpage.Language.Lang "en") (not .Page.Params.untranslated) }}
+{{/* If we are not in English we search for the English version */}}
+{{ range $curpage.Translations }}
+    {{ if eq "en" .Language.Lang }}
+        {{ if .Page.Lastmod }}
+            {{/* To compare the Lastmod with the current translation */}}   
+            {{ if ne $curpage.Lastmod .Page.Lastmod }}
+            <p>
+                <i>
+                    {{ i18n "old_version" }}
+                    (<time datetime="{{ .Page.Lastmod.Format "2006-01-02" }}">{{ .Page.Lastmod | time.Format $.Site.Params.time_format_default }}</time>)
+                    <a href="{{ .Page.RelPermalink }}">{{ i18n "view_in_english" }}</a>
+                </i>
+            </p>
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
+{{ end }}
+<!--googleon: all-->


### PR DESCRIPTION
Fix #1576 : 

It will always display the "outdated translation" warning, even for pages without `show_lastmod`