### PR TITLE
Adds pomerium entry to clients.json

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2023-07-22",
+	"lastmod": "2023-10-16",
 	"categories": [
 		"Bash",
 		"C",
@@ -149,6 +149,10 @@
 		{
 			"name": "Proxmox Virtual Environment",
 			"url": "https://pve.proxmox.com/wiki/Certificate_Management#sysadmin_certs_get_trusted_acme_cert"
+		},
+		{
+			"name": "Pomerium",
+			"url": "https://www.pomerium.com/"
 		}
 	],
 	"list": [


### PR DESCRIPTION
This PR adds [Pomerium](https://www.pomerium.com/) to the `clients.json` file. Pomerium's Autocert setting uses an ACME client to manage certificate automation when enabled in an org's Pomerium configuration. Please see the [Autocert](https://www.pomerium.com/docs/reference/autocert) settings page for more information.
