### PR TITLE
Add docker-nginx and docker-openresty ACME clients

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -235,6 +235,18 @@
 			"acme_v2": "true",
 			"category": "Docker"
 		},
+	        {
+			"name": "docker-nginx",
+			"url": "https://hub.docker.com/r/xiaojun207/nginx",
+			"acme_v2": "true",
+			"category": "Docker"
+		},
+	        {
+			"name": "docker-openresty",
+			"url": "https://hub.docker.com/r/xiaojun207/openresty",
+			"acme_v2": "true",
+			"category": "Docker"
+		},
 		{
 			"name": "Caddy",
 			"url": "https://caddyserver.com",


### PR DESCRIPTION
add acme client: Nginx with Auto SSL, Openresty with Auto SSL

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
