### PR TITLE
ACMEv1 client cleanup

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -38,8 +38,7 @@
 		"Perl",
 		"PHP",
 		"Python",
-		"Ruby",
-		"Rust"
+		"Ruby"
 	],
 	"projects": [
 		{
@@ -155,14 +154,12 @@
 		{
 			"name": "GetSSL",
 			"url": "https://github.com/srvrco/getssl",
-			"acme_v2": "true",
 			"category": "Bash",
 			"comments": "(bash, also automates certs on remote hosts via ssh)"
 		},
 		{
 			"name": "acme.sh",
 			"url": "https://github.com/Neilpang/acme.sh",
-			"acme_v2": "true",
 			"category": "Bash",
 			"comments": "(Compatible to bash, dash and sh)",
 			"challenges": {
@@ -172,7 +169,6 @@
 		{
 			"name": "dehydrated",
 			"url": "https://github.com/lukas2511/dehydrated",
-			"acme_v2": "true",
 			"category": "Bash",
 			"comments": "(Compatible to bash and zsh)",
 			"challenges": {
@@ -182,7 +178,6 @@
 		{
 			"name": "acme",
 			"url": "https://git.rapsys.eu/acme",
-			"acme_v2": "acme >= 2.0.0",
 			"category": "Perl",
 			"comments": "(Simple json config, autogen keys, issue cert, refresh cert, apache/nginx integration)",
 			"library": "Perl",
@@ -196,49 +191,37 @@
 		{
 			"name": "OpenBSD acme-client",
 			"url": "https://man.openbsd.org/acme-client.1",
-			"acme_v2": "OpenBSD >= 6.6",
 			"category": "C"
 		},
 		{
 			"name": "acme-lw",
 			"url": "https://github.com/jmccl/acme-lw",
 			"category": "C++",
-			"acme_v2": "acme-lw >= v0.2",
 			"library": "C++"
 		},
 		{
 			"name": "certificaat",
 			"url": "https://github.com/danielsz/certificaat",
-			"acme_v2": "true",
 			"category": "Clojure"
-		},
-		{
-			"name": "tls_certificate_generation",
-			"url": "https://github.com/leandromoreira/tls_certificate_generation",
-			"category": "Docker"
 		},
 		{
 			"name": "Crypt::LE",
 			"url": "https://hub.docker.com/r/zerossl/client/",
-			"acme_v2": "true",
 			"category": "Docker"
 		},
 		{
 			"name": "acme.sh",
 			"url": "https://hub.docker.com/r/neilpang/acme.sh",
-			"acme_v2": "true",
 			"category": "Docker"
 		},
 	        {
 			"name": "letsproxy",
 			"url": "https://hub.docker.com/r/neilpang/letsproxy",
-			"acme_v2": "true",
 			"category": "Docker"
 		},
 		{
 			"name": "Caddy",
 			"url": "https://caddyserver.com",
-			"acme_v2": "Caddy >= 0.10.12",
 			"category": "Go",
 			"challenges": {
 				"HTTP-01": "true",
@@ -251,84 +234,54 @@
 			"url": "https://go-acme.github.io/lego/",
 			"category": "Go",
 			"library": "Go",
-			"acme_v2": "Lego >= v1.0.0",
 			"challenges": {
 				"TLS-ALPN-01": "true"
 			}
-		},
-		{
-			"name": "GoACME",
-			"url": "https://github.com/google/goacme",
-			"category": "Go"
 		},
 		{
 			"name": "acmetool",
 			"url": "https://github.com/hlandau/acmetool",
 			"category": "Go",
 			"library": "Go",
-			"library_url": "https://github.com/hlandau/acmeapi",
-			"acme_v2": "acmetool >= v0.2.1"
+			"library_url": "https://github.com/hlandau/acmeapi"
 		},
 		{
 			"name": "Lets-proxy2",
 			"url": "https://github.com/rekby/lets-proxy2",
 			"category": "Go",
-			"comments": "(Reverse proxy to handle https/tls)",
-			"acme_v2": "Lets-proxy2 >= v0.21.0"
+			"comments": "(Reverse proxy to handle https/tls)"
 		},
 		{
 			"name": "autocert",
 			"url": "https://godoc.org/golang.org/x/crypto/acme/autocert",
-			"acme_v2": "true",
 			"category": "Go",
 			"challenges": {
 				"TLS-ALPN-01": "true"
 			}
 		},
 		{
-			"name": "Ponzu CMS",
-			"url": "https://ponzu-cms.org/",
-			"category": "Go"
-		},
-		{
 			"name": "Traefik",
 			"url": "https://traefik.io/",
-			"acme_v2": "true",
 			"category": "Go"
-		},
-		{
-			"name": "HAProxy ACME validation plugin",
-			"url": "https://github.com/janeczku/haproxy-acme-validation-plugin",
-			"category": "HAProxy"
 		},
 		{
 			"name": "HAProxy client",
 			"url": "https://github.com/haproxytech/haproxy-lua-acme",
-			"acme_v2": "true",
 			"category": "HAProxy"
 		},
 		{
 			"name": "PJAC",
 			"url": "https://github.com/porunov/acme_client",
-			"acme_v2": "PJAC >= 3.0.0",
 			"category": "Java"
 		},
 		{
 			"name": "ManageEngine Key Manager Plus",
 			"url": "https://www.manageengine.com/key-manager/",
-			"acme_v2": "Version >= 5650",
 			"category": "Java"
-		},
-		{
-			"name": "GetSSL - Azure Automation",
-			"url": "https://www.powershellgallery.com/packages/GetSSL-LetsEncrypt/",
-			"category": "Microsoft Azure",
-			"comments": "(Compatible with any App Service)"
 		},
 		{
 			"name": "njs-acme",
 			"url": "https://github.com/nginx/njs-acme",
-			"acme_v2": "true",
 			"category": "nginx",
 			"comments": "JavaScript library compatible with the 'ngx_http_js_module' runtime (NJS), allows for the automatic issue of TLS/SSL certificates for NGINX without restarts",
 			"challenges": {
@@ -338,87 +291,42 @@
 		{
 			"name": "lua-resty-auto-ssl",
 			"url": "https://github.com/GUI/lua-resty-auto-ssl",
-			"acme_v2": "lua-resty-auto-ssl >= 0.13.0",
 			"category": "nginx"
 		},
 		{
 			"name": "Nginx ACME",
 			"url": "https://github.com/kshcherban/acme-nginx",
-			"acme_v2": "true",
 			"category": "nginx"
-		},
-		{
-			"name": "ngxpkg",
-			"url": "https://github.com/webpkg/ngxpkg",
-			"category": "nginx"
-		},
-		{
-			"name": "acme_proxy.php",
-			"url": "https://github.com/jpawlowski/acme_proxy.php",
-			"category": "nginx",
-			"comments": "(Reverse proxy to serve multiple internal servers based on internal DNS)"
-		},
-		{
-			"name": "Greenlock for Commandline",
-			"url": "https://git.coolaj86.com/coolaj86/greenlock-cli.js",
-			"category": "Node.js"
 		},
 		{
 			"name": "Greenlock for Express.js",
 			"url": "https://git.coolaj86.com/coolaj86/greenlock-express.js",
-			"acme_v2": "true",
 			"category": "Node.js"
 		},
 		{
 			"name": "Greenlock for node.js",
 			"url": "https://git.coolaj86.com/coolaj86/greenlock.js",
-			"acme_v2": "true",
 			"library": "Node.js"
-		},
-		{
-			"name": "Cloudron/acme",
-			"url": "https://git.cloudron.io/cloudron/box/blob/master/src/cert/acme2.js",
-			"category": "Node.js"
 		},
 		{
 			"name": "openshift-acme",
 			"url": "https://github.com/tnozicka/openshift-acme",
-			"acme_v2": "true",
 			"category": "OpenShift"
 		},
 		{
 			"name": "Crypt::LE (previously ZeroSSL project)",
 			"url": "https://github.com/do-know/Crypt-LE",
-			"acme_v2": "true",
 			"category": "Windows / IIS"
 		},
 		{
 			"name": "Crypt::LE",
 			"url": "https://metacpan.org/pod/Crypt::LE",
-			"acme_v2": "true",
 			"category": "Perl",
 			"library": "Perl"
-		},
-		{
-			"name": "Net::ACME",
-			"url": "https://metacpan.org/pod/Net::ACME",
-			"category": "Perl",
-			"library": "Perl"
-		},
-		{
-			"name": "Protocol::ACME",
-			"url": "https://metacpan.org/pod/Protocol::ACME",
-			"category": "Perl"
 		},
 		{
 			"name": "kelunik/acme-client",
 			"url": "https://github.com/kelunik/acme-client",
-			"acme_v2": "true",
-			"category": "PHP"
-		},
-		{
-			"name": "CertLE",
-			"url": "https://github.com/skoerfgen/CertLE",
 			"category": "PHP"
 		},
 		{
@@ -427,189 +335,81 @@
 			"category": "PHP"
 		},
 		{
-			"name": "LE Manager",
-			"url": "https://github.com/analogic/lemanager",
-			"category": "PHP"
-		},
-		{
 			"name": "FreeSSL.tech Auto",
 			"url": "https://freessl.tech",
-			"acme_v2": "true",
 			"category": "PHP"
 		},
 		{
 			"name": "Yet another ACME client",
-			"acme_v2": "true",
 			"url": "https://github.com/afosto/yaac",
 			"category": "PHP"
 		},
 		{
 			"name": "ACME Tiny",
 			"url": "https://github.com/diafygi/acme-tiny",
-			"acme_v2": "true",
 			"category": "Python"
 		},
 		{
 			"name": "simp_le",
 			"url": "https://github.com/zenhack/simp_le",
-			"acme_v2": "true",
-			"category": "Python"
-		},
-		{
-			"name": "mail-in-a-box/free_tls_certificates",
-			"url": "https://github.com/mail-in-a-box/free_tls_certificates",
-			"category": "Python",
-			"library": "Python",
-			"comments": "(Python 3)"
-		},
-		{
-			"name": "ManuaLE",
-			"url": "https://github.com/veeti/manuale",
-			"category": "Python",
-			"comments": "(Python 3)"
-		},
-		{
-			"name": "Let’s ACME",
-			"url": "https://github.com/neurobin/letsacme",
-			"category": "Python"
-		},
-		{
-			"name": "acmeshell",
-			"url": "https://mojzis.com/software/acmeshell",
-			"category": "Python"
-		},
-		{
-			"name": "wile",
-			"url": "https://github.com/costela/wile",
 			"category": "Python"
 		},
 		{
 			"name": "acmebot",
 			"url": "https://github.com/plinss/acmebot",
-			"acme_v2": "true",
 			"category": "Python"
 		},
 		{
 			"name": "sewer",
 			"url": "https://github.com/komuw/sewer",
-			"acme_v2": "true",
-			"category": "Python"
-		},
-		{
-			"name": "acme-powerdns",
-			"url": "https://github.com/adfinis-sygroup/acme-powerdns",
-			"category": "Python"
-		},
-		{
-			"name": "ACMEproxy",
-			"url": "https://github.com/catalyst/acmeproxy",
 			"category": "Python"
 		},
 		{
 			"name": "acme-dns-tiny",
 			"url": "https://acme-dns-tiny.adorsaz.ch",
-			"acme_v2": "v2.0 onwards",
 			"category": "Python",
 			"comments": "(Python 3)"
 		},
 		{
-			"name": "acme-nosudo",
-			"url": "https://github.com/diafygi/acme-nosudo",
-			"category": "Python"
-		},
-		{
 			"name": "Automatoes",
 			"url": "https://github.com/candango/automatoes",
-			"acme_v2": "true",
 			"category": "Python",
 			"comments": "ACME V2 ManuaLE replacement with new features"
 		},
 		{
 			"name": "unixcharles/acme-client",
 			"url": "https://github.com/unixcharles/acme-client",
-			"acme_v2": "true",
 			"category": "Ruby",
 			"library": "Ruby"
 		},
 		{
-			"name": "Multi-Server ACME Cert Management Dashboard",
-			"url": "https://github.com/myfreeweb/freshcerts",
-			"category": "Ruby"
-		},
-		{
-			"name": "Acmesmith, An effective ACME client: Manage keys on the cloud (AWS and more)",
-			"url": "https://github.com/sorah/acmesmith",
-			"category": "Ruby"
-		},
-		{
-			"name": "schubergphilis/chef-acme",
-			"url": "https://github.com/schubergphilis/chef-acme",
-			"category": "Ruby"
-		},
-		{
 			"name": "acme-distributed",
 			"url": "https://github.com/jannfis/acme-distributed",
-			"acme_v2": "true",
 			"category": "Ruby"
 		},
 		{
 			"name": "Combine-acme: Generate and upload crt to CloudFlare(enterprise) and GCP.",
 			"url": "https://gitlab.com/6318613/combine-acme",
-			"acme_v2": "true",
 			"category": "Ruby"
-		},
-		{
-			"name": "acme-client",
-			"url": "https://github.com/onur/acme-client",
-			"category": "Rust"
-		},
-		{
-			"name": "ACMESharp",
-			"url": "https://github.com/ebekker/ACMESharp",
-			"library": ".NET",
-			"category": "Windows / IIS",
-			"comments": "(ACMEv1 PowerShell client, .NET Framework library)",
-			"library_comments": "(Windows only)"
 		},
 		{
 			"name": "win-acme",
 			"url": "https://www.win-acme.com",
 			"category": "Windows / IIS",
-			"acme_v2": "true",
 			"comments": "(.NET)",
 			"challenges": {
 				"TLS-ALPN-01": "true"
 			}
 		},
 		{
-			"name": "Certify The Web",
-			"url": "https://github.com/webprofusion/certify",
-			"category": "Windows / IIS",
-			"comments": "GUI (.NET, WPF)"
-		},
-		{
-			"name": "oocx/acme.net",
-			"url": "https://github.com/oocx/acme.net",
-			"category": "Windows / IIS",
-			"comments": "(.NET)"
-		},
-		{
-			"name": "AutoACME",
-			"url": "https://www.autoacme.net/",
-			"category": "Windows / IIS",
-			"comments": "(.NET)"
-		},
-		{
 			"name": "Posh-ACME",
 			"url": "https://github.com/rmbolger/Posh-ACME",
-			"acme_v2": "true",
 			"category": "Windows / IIS",
 			"category_comments": "(PowerShell)"
 		},
 		{
 			"name": "Certes",
 			"url": "https://github.com/fszlin/certes",
-			"acme_v2": "true",
 			"category": "Windows / IIS",
 			"library": ".NET",
 			"library_comments": "(.NET Standard)"
@@ -617,66 +417,48 @@
 		{
 			"name": "ACME-PS",
 			"url": "https://github.com/PKISharp/ACMESharpCore-PowerShell",
-			"acme_v2": "true",
 			"category": "Windows / IIS",
 			"category_comments": "(PowerShell)"
 		},
 		{
 			"name": "PKISharp/ACMESharpCore",
 			"url": "https://github.com/PKISharp/acmesharpcore",
-			"acme_v2": "true",
 			"library": ".NET",
 			"library_comments": "(.NET Standard)"
 		},
 		{
 			"name": "DelphiACME",
 			"url": "https://github.com/tothpaul/DelphiACME",
-			"acme_v2": "true",
 			"library": "Delphi",
 			"comments": "(Embarcadero Delphi)"
 		},
 		{
 			"name": "eggsampler/acme",
 			"url": "https://github.com/eggsampler/acme",
-			"acme_v2": "true",
 			"library": "Go"
-		},
-		{
-			"name": "zero11it/acme-client",
-			"url": "https://github.com/zero11it/acme-client",
-			"library": "Java"
 		},
 		{
 			"name": "ACME4J",
 			"url": "https://github.com/shred/acme4j",
-			"acme_v2": "acme4j >= 2.0",
 			"library": "Java",
 			"challenges": {
 				"TLS-ALPN-01": "true"
 			}
 		},
 		{
-			"name": "sludin/Protocol-ACME",
-			"url": "https://github.com/sludin/Protocol-ACME",
-			"library": "Perl"
-		},
-		{
 			"name": "kelunik/acme",
 			"url": "https://github.com/kelunik/acme",
-			"acme_v2": "true",
 			"library": "PHP"
 		},
 		{
 			"name": "kelunik/acme-client",
 			"url": "https://github.com/kelunik/acme-client",
-			"acme_v2": "true",
 			"category": "Windows / IIS",
 			"comments": "(PHP)"
 		},
 		{
 			"name": "ACMECert PHP library",
 			"url": "https://github.com/skoerfgen/ACMECert",
-			"acme_v2": "true",
 			"library": "PHP"
 		},
 		{
@@ -688,57 +470,44 @@
 		{
 			"name": "publishlab/node-acme-client",
 			"url": "https://github.com/publishlab/node-acme-client",
-			"acme_v2": "true",
 			"library": "Node.js"
 		},
 		{
 			"name": "Net::ACME2",
 			"url": "https://metacpan.org/pod/Net::ACME2",
-			"acme_v2": "true",
 			"library": "Perl",
 			"challenges": {
 				"TLS-ALPN-01": "true"
 			}
 		},
 		{
-			"name": "acme-client",
-			"url": "https://crates.io/crates/acme-client",
-			"library": "Rust"
-		},
-		{
 			"name": "LEClient PHP library",
 			"url": "https://github.com/yourivw/LEClient",
-			"acme_v2": "true",
 			"library": "PHP"
 		},
 		{
 			"name": "le-acme2-php library",
 			"url": "https://github.com/fbett/le-acme2-php",
-			"acme_v2": "true",
 			"library": "PHP"
 		},
 		{
 			"name": "stonemax/acme2 PHP client",
 			"url": "https://github.com/stonemax/acme2",
-			"acme_v2": "true",
 			"library": "PHP"
 		},
 		{
 			"name": "itr-acme-client PHP library",
 			"url": "https://github.com/ITronic/itr-acme-client",
-			"acme_v2": "true",
 			"category": "PHP"
 		},
 		{
 			"name": "Certify The Web (Windows)",
 			"url": "https://certifytheweb.com",
-			"acme_v2": "v4 onwards",
 			"category": "Windows / IIS"
 		},
 		{
 			"name": "Ansible acme_certificate module",
 			"url": "https://docs.ansible.com/ansible/latest/collections/community/crypto/acme_certificate_module.html",
-			"acme_v2": "ansible >= 2.6",
 			"challenges": {
 				"TLS-ALPN-01": "ansible >= 2.7"
 			},
@@ -747,26 +516,17 @@
 		{
 			"name": "WinCertes Windows client",
 			"url": "https://github.com/aloopkin/WinCertes",
-			"acme_v2": "true",
 			"category": "Windows / IIS"
 		},
 		{
 			"name": "uacme",
 			"url": "https://github.com/ndilieto/uacme/",
-			"acme_v2": "true",
 			"category": "C"
 		},
 		{
 			"name": "ACMEd",
 			"url": "https://github.com/breard-r/acmed",
-			"acme_v2": "true",
 			"category": "Rust"
-		},
-		{
-			"name": "le-opensrs",
-			"url": "https://github.com/mhmd3bdo/le-opensrs",
-			"category": "Rust",
-			"comments": "(Python 3)"
 		},
 		{
 			"name": "certman-operator",
@@ -774,83 +534,66 @@
 			"category": "OpenShift"
 		},
 		{
-			"name": "GetCert",
-			"url": "https://github.com/GeorgeSchiro/GetCert2",
-			"category": "Windows / IIS",
-			"comments": "(simple GUI - .Net, C#, WPF, WCF)"
-		},
-		{
 			"name": "acme-lw-d",
 			"url": "https://github.com/cschlote/acme-lw-d",
 			"category": "D",
-			"library": "D",
-			"acme_v2": "true"
+			"library": "D"
 		},
 		{
 			"name": "acme-client-portable",
 			"url": "https://sr.ht/~graywolf/acme-client-portable/",
-			"category": "C",
-			"acme_v2": "true"
+			"category": "C"
 		},
 		{
 			"name": "Mako Server's ACME Plugin",
 			"url": "https://makoserver.net/articles/Lets-Encrypt",
 			"category": "Lua",
-			"comments": "The plugin's main objective is to provide certificates for servers on private networks.",
-			"acme_v2": "true"
+			"comments": "The plugin's main objective is to provide certificates for servers on private networks."
 		},
 		{
 			"name": "Apache httpd",
 			"url": "https://httpd.apache.org",
 			"comments": "Support via the module mod_md.",
-			"acme_v2": "Apache >= 2.4.41",
 			"category": "C"
 		},
 		{
 			"name": "mod_md",
 			"url": "https://github.com/icing/mod_md",
 			"comments": "Separate, more frequent releases of the Apache module.",
-			"acme_v2": "v2.0.x onwards",
 			"category": "C"
 		},
 		{
 			"name": "Azure WebApp SSL Manager",
 			"url": "https://github.com/n3wt0n/AzureWebAppSSLManager",
 			"category": "Microsoft Azure",
-			"comments": "(Serverless, Compatible with any App Service, requires Azure DNS)",
-			"acme_v2": "true"
+			"comments": "(Serverless, Compatible with any App Service, requires Azure DNS)"
 		},
 		{
 			"name": "App Service Acmebot",
 			"url": "https://github.com/shibayan/appservice-acmebot",
 			"category": "Microsoft Azure",
-			"comments": "(Compatible to Azure Web Apps / Functions / Web App for Containers)",
-			"acme_v2": "true"
+			"comments": "(Compatible to Azure Web Apps / Functions / Web App for Containers)"
 		},
 		{
 			"name": "Key Vault Acmebot",
 			"url": "https://github.com/shibayan/keyvault-acmebot",
 			"category": "Microsoft Azure",
-			"comments": "(Work with Azure Key Vault Certificates)",
-			"acme_v2": "true"
+			"comments": "(Work with Azure Key Vault Certificates)"
 		},
 		{
 			"name": "Acme PHP",
 			"url": "https://github.com/acmephp/acmephp",
-			"category": "PHP",
-			"acme_v2": "true"
+			"category": "PHP"
 		},
 		{
 			"name": "Acme PHP Library",
 			"url": "https://github.com/acmephp/core",
-			"library": "PHP",
-			"acme_v2": "true"
+			"library": "PHP"
 		},
 		{
 			"name": "lua-resty-acme",
 			"url": "https://github.com/fffonion/lua-resty-acme",
 			"category": "nginx",
-			"acme_v2": "true",
 			"challenges": {
 				"TLS-ALPN-01": "true"
 			}
@@ -858,55 +601,47 @@
 		{
 			"name": "acertmgr",
 			"url": "https://github.com/moepman/acertmgr",
-			"category": "Python",
-			"acme_v2": "true"
+			"category": "Python"
 		},
 		{
 			"name": "acme-cert-tool",
 			"url": "https://github.com/mk-fg/acme-cert-tool",
-			"category": "Python",
-			"acme_v2": "true"
+			"category": "Python"
 		},
 		{
 			"name": "ght-acme.sh",
 			"url": "https://github.com/bruncsak/ght-acme.sh",
 			"category": "Bash",
-			"comments": "(batch update of http-01 and dns-01 challenges is available)",
-			"acme_v2": "true"
+			"comments": "(batch update of http-01 and dns-01 challenges is available)"
 		},
 		{
 			"name": "GetCert2",
 			"url": "https://github.com/GeorgeSchiro/GetCert2",
 			"category": "Windows / IIS",
-			"comments": "(simple GUI - .Net, C#, WPF, WCF)",
-			"acme_v2": "true"
+			"comments": "(simple GUI - .Net, C#, WPF, WCF)"
 		},
 		{
 			"name": "esp32-acme-client",
 			"url": "https://esp32-acme-client.sourceforge.io",
 			"category": "C++",
 			"comments": "allows IoT devices to get certificates",
-			"acme_v2": "true",
 			"library": "C++"
 		},
 		{
 			"name": "bacme",
 			"url": "https://gitlab.com/sinclair2/bacme",
 			"category": "Bash",
-			"comments": "(simple yet complete scripting of certificate generation)",
-			"acme_v2": "true"
+			"comments": "(simple yet complete scripting of certificate generation)"
 		},
 		{
 			"name": "CertMatica",
 			"url": "https://www.rhpconsult.com/products.html",
 			"category": "Domino",
-			"comments": "(ACME certificate installation and renewals for HCL Domino™ servers)",
-			"acme_v2": "true"
+			"comments": "(ACME certificate installation and renewals for HCL Domino™ servers)"
 		},
 		{
 			"name": "acme component",
 			"url": "https://github.com/blegay/acme_component",
-			"acme_v2": "true",
 			"comments": "ACME Client v2 for 4D v18+",
 			"library": "4D",
 			"challenges": {
@@ -919,8 +654,7 @@
 		{
 			"name": "RW ACME client",
 			"url": "https://github.com/RogierW/rw-acme-client",
-			"category": "PHP",
-			"acme_v2": "true"
+			"category": "PHP"
 		},
 		{
 			"name": "cert-manager",
@@ -934,7 +668,6 @@
 		{
 			"name": "Certera",
 			"url": "https://certera.io",
-			"acme_v2": "true",
 			"comments": "(Crossplatform PKI to centrally manage keys and certificates)",
 			"category": "Server"
 		},
@@ -942,13 +675,11 @@
 			"name": "TekCERT",
 			"url": "https://www.kaplansoft.com/tekcert/",
 			"category": "Windows / IIS",
-			"comments": "(GUI, CLI)",
-			"acme_v2": "true"
+			"comments": "(GUI, CLI)"
 		},
 		{
 			"name": "serverPKI",
 			"url": "https://github.com/mc3/serverPKI",
-			"acme_v2": "true",
 			"category": "Python",
 			"challenges": {
 				"HTTP-01": "false",
@@ -961,7 +692,6 @@
 		{
 			"name": "acmetk",
 			"url": "https://github.com/noahkw/acmetk",
-			"acme_v2": "true",
 			"category": "Python",
 			"challenges": {
 				"DNS-01": "true"
@@ -972,27 +702,23 @@
 			"name": "ACMEz",
 			"url": "https://github.com/mholt/acmez",
 			"category": "Go",
-			"library": "Go",
-			"acme_v2": "true"
+			"library": "Go"
 		},
 		{
 			"name": "Step CLI",
 			"url": "https://smallstep.com/cli/",
-			"acme_v2": "true",
 			"category": "Go"
 		},
 		{
 			"name": "J8a",
 			"url": "https://github.com/simonmittag/j8a",
 			"category": "Go",
-			"comments": "(Reverse proxy for JSON APIs with auto-renewing TLS 1.3)",
-			"acme_v2": "true"
+			"comments": "(Reverse proxy for JSON APIs with auto-renewing TLS 1.3)"
 		},
 		{
 			"name": "CycloneACME",
 			"url": "https://oryx-embedded.com/products/CycloneACME",
 			"category": "C",
-			"acme_v2": "true",
 			"comments": "(client implementation of ACME dedicated to microcontrollers)",
 			"challenges": {
 				"HTTP-01": "true",
@@ -1003,13 +729,11 @@
 		{
 			"name": "acme-redirect",
 			"url": "https://github.com/kpcyrd/acme-redirect",
-			"acme_v2": "true",
 			"category": "Rust"
 		},
 		{
 			"name": "acme-http-01-azure-key-vault-middleware",
 			"url": "https://github.com/compulim/acme-http-01-azure-key-vault-middleware",
-			"acme_v2": "true",
 			"category": "Node.js",
 			"challenges": {
 				"HTTP-01": "true",
@@ -1022,7 +746,6 @@
 		{
 			"name": "Terraform ACME Provider",
 			"url": "https://registry.terraform.io/providers/vancluever/acme/latest",
-			"acme_v2": "terraform-provider-acme >= 1.0.0",
 			"challenges": {
 				"HTTP-01": "terraform-provider-acme >= 2.4.0",
 				"DNS-01": "terraform-provider-acme >= 1.0.0",
@@ -1033,7 +756,6 @@
 		{
 			"name": "wdfcert.sh",
 			"url": "https://github.com/WolfWings/wdfcert.sh",
-			"acme_v2": "true",
 			"category": "Bash",
 			"comments": "(Only supports DNS-01 challenges and ECDSA-384 bit keys for both accounts and certificates, native Joker DNS support including wildcard plus root domain support for single-TXT-record DNS providers)",
 			"library": "Perl",
@@ -1050,7 +772,6 @@
 			"url": "https://help.hcltechsw.com/domino/12.0.0/admin/secu_le_using_certificate_manager.html",
 			"category": "Domino",
 			"comments": "(Full ACME V2 flow integration for HCL Domino™ servers)",
-			"acme_v2": "true",
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true",
@@ -1063,7 +784,6 @@
 			"url": "https://github.com/T-Systems-MMS/ansible-collection-acme",
 			"category": "Configuration management tools",
 			"comments": "(ACME V2 integration with acme_certificate module. Supports multiple providers for challenges)",
-			"acme_v2": "true",
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true",
@@ -1077,14 +797,12 @@
 			"category": "Go",
 			"comments": "(Supports certificate sharing across instances/pods and split-horizon DNS with acme-proxy)",
 			"library": "Go",
-			"library_url": "https://github.com/Cloud-Foundations/golib/blob/master/pkg/crypto/certmanager",
-			"acme_v2": "true"
+			"library_url": "https://github.com/Cloud-Foundations/golib/blob/master/pkg/crypto/certmanager"
 		},
 		{
 			"name": "KCert",
 			"url": "https://github.com/nabsul/kcert",
 			"category": "Kubernetes",
-			"acme_v2": "true",
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "false",
@@ -1097,7 +815,6 @@
 			"url": "https://github.com/az-acme/az-acme-cli",
 			"category": "Microsoft Azure",
 			"comments": "(The simplest ACME Issuer for Azure Key Vault)",
-			"acme_v2": "true",
 			"challenges": {
 				"HTTP-01": "false",
 				"DNS-01": "true",

--- a/layouts/shortcodes/clients.html
+++ b/layouts/shortcodes/clients.html
@@ -7,7 +7,7 @@
     {{ $category := . }}
     <ul>
     {{ range $.Site.Data.clients.list }}
-        {{ if and .acme_v2 (eq $category .category) }}
+        {{ if (eq $category .category) }}
         <li>
             <a href="{{ .url }}">{{ .name }}</a>
             {{ if .category_comments }}
@@ -33,7 +33,7 @@
         <li dir="{{ $LanguageDirection }}">{{ $certbot | markdownify }}</li>
     {{ end }}
     {{ range $.Site.Data.clients.list }}
-        {{ if and .acme_v2 (eq $library .library) }}
+        {{ if (eq $library .library) }}
         <li>
             <a href="{{ if .library_url }}{{ .library_url }}{{ else }}{{ .url }}{{ end }}">{{ .name }}</a>
             {{ if .library_comments }}


### PR DESCRIPTION
Get rid of any clients that aren't ACMEv2 compatible, remove ACMEv2 labels from client list since we no longer need to differentiate.