### PR TITLE
Allow trailing `.` in Terms of Service URL

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -293,5 +293,5 @@ force = true
 # It should be updated on ToS changes, but is not a compliance-critical path.
 from = "/documents/LE-SA-v1.4-April-3-2024.pdf."
 to = "/documents/LE-SA-v1.4-April-3-2024.pdf"
-status = 302
+status = 301
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -291,7 +291,7 @@ force = true
 # Certbot (and other) clients link to the Terms of Service with a `.` after them
 # This is a convenience to allow copying the URL with that `.`
 # It should be updated on ToS changes, but is not a compliance-critical path.
-from = "https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf."
-to = "https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf"
+from = "/documents/LE-SA-v1.4-April-3-2024.pdf."
+to = "/documents/LE-SA-v1.4-April-3-2024.pdf"
 status = 302
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -286,3 +286,12 @@ from = "https://www.letsencrypt.com/*"
 to = "https://letsencrypt.org/"
 status = 302
 force = true
+
+[[redirects]]
+# Certbot (and other) clients link to the Terms of Service with a `.` after them
+# This is a convenience to allow copying the URL with that `.`
+# It should be updated on ToS changes, but is not a compliance-critical path.
+from = "https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf."
+to = "https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf"
+status = 302
+force = true


### PR DESCRIPTION
Fixes #1702 

Because `certbot` includes a `.` right after the URL, it is easy for users to accidentally try to load a URL including the `.`.  This adds a redirect to make that less error-prone.