### PR TITLE
Fix reported X2 debian compatibility

### DIFF
--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -1,7 +1,7 @@
 ---
 title: Certificate Compatibility
 slug: certificate-compatibility
-lastmod: 2024-05-07
+lastmod: 2024-07-04
 show_lastmod: 1
 ---
 
@@ -34,7 +34,7 @@ If your platform is not listed here, we appreciate [pull requests](https://githu
 * Android >= [14](https://android.googlesource.com/platform/system/ca-certificates/+/c8d7f51bbb3de2c40a0d868972be008070eb25d8)
 * Firefox >= [97](https://bugzilla.mozilla.org/show_bug.cgi?id=1701317)
 * Ubuntu >= [18.04 Bionic Beaver](https://launchpad.net/ubuntu/+source/ca-certificates/20230311) (with updates applied)
-* Debian >= [11 / Bullseye](https://tracker.debian.org/news/1426477/accepted-ca-certificates-20230311-source-into-unstable/) (with updates applied)
+* Debian >= [12 / Bookworm](https://tracker.debian.org/news/1426477/accepted-ca-certificates-20230311-source-into-unstable/)
 * Java >= [21.0.2](https://jdk.java.net/21/release-notes)
 * NSS >= [3.74](https://firefox-source-docs.mozilla.org/security/nss/releases/nss_3_74.html)
 * Chrome >= [105](https://chromium.googlesource.com/chromium/src/+/main/net/data/ssl/chrome_root_store/faq.md#when-are-these-changes-taking-place) (earlier versions use the operating system trust store)


### PR DESCRIPTION
Debian Bullseye (11 / old-stable) ships ca-certificates version 20210119 as it can be checked in https://packages.debian.org/bullseye/ca-certificates. ISRG X2 root certificate was included on version 20230311 that's shipped with Debian Bookworm (12 / stable) as showed in https://packages.debian.org/bookworm/ca-certificates
