### PR TITLE
Certificate compatibility for Red Hat Enterprise Linux (and derivatives)

### DIFF
--- a/content/en/docs/cert-compat.md
+++ b/content/en/docs/cert-compat.md
@@ -1,7 +1,7 @@
 ---
 title: Certificate Compatibility
 slug: certificate-compatibility
-lastmod: 2024-07-04
+lastmod: 2024-08-25
 show_lastmod: 1
 ---
 
@@ -21,6 +21,7 @@ If your platform is not listed here, we appreciate [pull requests](https://githu
 * Firefox >= [50.0](https://bugzilla.mozilla.org/show_bug.cgi?id=1204656)
 * Ubuntu >= [12.04 Precise Pangolin](https://launchpad.net/ubuntu/+source/ca-certificates/20161102) (with updates applied)
 * Debian >= [8 / Jessie](https://tracker.debian.org/news/812114/accepted-ca-certificates-20161102-source-all-into-unstable/) (with updates applied)
+* RHEL >= 6.10, 7.4 ([with updates applied](https://src.fedoraproject.org/rpms/ca-certificates/c/02204a071d2effe7cdb840c1a2763bcdc396c4be)), 8+
 * Java >= [7u151](https://www.oracle.com/java/technologies/javase/7u151-relnotes.html), [8u141](https://www.oracle.com/java/technologies/javase/8u141-relnotes.html), [9+](https://www.oracle.com/java/technologies/javase/9-all-relnotes.html#JDK-8177539)
 * NSS >= [3.26](https://nss-crypto.org/reference/security/nss/legacy/nss_releases/nss_3.26_release_notes/index.html)
 * Chrome >= [105](https://chromium.googlesource.com/chromium/src/+/main/net/data/ssl/chrome_root_store/faq.md#when-are-these-changes-taking-place) (earlier versions use the operating system trust store)
@@ -35,6 +36,7 @@ If your platform is not listed here, we appreciate [pull requests](https://githu
 * Firefox >= [97](https://bugzilla.mozilla.org/show_bug.cgi?id=1701317)
 * Ubuntu >= [18.04 Bionic Beaver](https://launchpad.net/ubuntu/+source/ca-certificates/20230311) (with updates applied)
 * Debian >= [12 / Bookworm](https://tracker.debian.org/news/1426477/accepted-ca-certificates-20230311-source-into-unstable/)
+* RHEL >= 7.9, 8.6, 9.1 ([with updates applied](https://src.fedoraproject.org/rpms/ca-certificates/c/f6b8f45e836dfc9c69585bf7ef0250ad734b086a))
 * Java >= [21.0.2](https://jdk.java.net/21/release-notes)
 * NSS >= [3.74](https://firefox-source-docs.mozilla.org/security/nss/releases/nss_3_74.html)
 * Chrome >= [105](https://chromium.googlesource.com/chromium/src/+/main/net/data/ssl/chrome_root_store/faq.md#when-are-these-changes-taking-place) (earlier versions use the operating system trust store)


### PR DESCRIPTION
ISRG Root X1 from 6.10 (with ca-certificates >= 2016.2.9)
ISRG Root X2 from 7.9 (with ca-certificates >= 2022.2.54)