### PR TITLE
Update certificates.md

### DIFF
--- a/content/en/certificates.md
+++ b/content/en/certificates.md
@@ -2,7 +2,7 @@
 title: Chains of Trust
 linkTitle: Chains of Trust (Root and Intermediate Certificates)
 slug: certificates
-lastmod: 2024-06-11
+lastmod: 2024-09-16
 show_lastmod: 1
 ---
 
@@ -19,7 +19,7 @@ Note that Root CAs don't have expiration dates in quite the same way that other 
 * **ISRG Root X1**
   * Subject: `O = Internet Security Research Group, CN = ISRG Root X1`
   * Key type: `RSA 4096`
-  * Validity: until 2030-06-04 (generated 2015-06-04)
+  * Validity: until 2035-06-04 (generated 2015-06-04)
   * CA details: [crt.sh](https://crt.sh/?caid=7394), [issued certs](https://crt.sh/?Identity=%25&iCAID=7394)
   * Certificate details (self-signed): [crt.sh](https://crt.sh/?id=9314791), [der](/certs/isrgrootx1.der), [pem](/certs/isrgrootx1.pem), [txt](/certs/isrgrootx1.txt)
   * Certificate details (cross-signed by DST Root CA X3): [crt.sh](https://crt.sh/?id=3958242236), [der](/certs/isrg-root-x1-cross-signed.der), [pem](/certs/isrg-root-x1-cross-signed.pem), [txt](/certs/isrg-root-x1-cross-signed.txt) (retired)


### PR DESCRIPTION
Corrected expiry year of ISRG Root X1 on Certificates page to 2035.

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
