### PR TITLE
Fixing the weight parameter to fix the order of the locales in the menu

### DIFF
--- a/config/_default/languages.ca.toml
+++ b/config/_default/languages.ca.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/ca"
 languageName = "Català"
 languageCode = "ca"
-weight = 10
+weight = 125
 
 [params]
 

--- a/config/_default/languages.cs.toml
+++ b/config/_default/languages.cs.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/cs"
 languageName = "Čeština"
 languageCode = "cs-CZ"
-weight = 10
+weight = 150
 
 [params]
 beforeColon = ""

--- a/config/_default/languages.da.toml
+++ b/config/_default/languages.da.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/da"
 languageName = "Dansk"
 languageCode = "da"
-weight = 10
+weight = 175
 
 [params]
 beforeColon = ""

--- a/config/_default/languages.el.toml
+++ b/config/_default/languages.el.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/el"
 languageName = "Greek"
 languageCode = "el"
-weight = 10
+weight = 225
 
 [params]
 

--- a/config/_default/languages.he.toml
+++ b/config/_default/languages.he.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/he"
 languageName = "עברית"
 languageCode = "he"
-weight = 10
+weight = 325
 
 [params]
 beforeColon = ""

--- a/config/_default/languages.pl.toml
+++ b/config/_default/languages.pl.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/pl"
 languageName = "Polish"
 languageCode = "pl"
-weight = 10
+weight = 475
 
 [params]
 

--- a/config/_default/languages.ru.toml
+++ b/config/_default/languages.ru.toml
@@ -2,7 +2,7 @@ title = "Что такое Let's Encrypt"
 contentDir = "content/ru"
 languageName = "Русский"
 languageCode = "ru-RU"
-weight = 10
+weight = 550
 
 [params]
 beforeColon = ""

--- a/config/_default/languages.ta.toml
+++ b/config/_default/languages.ta.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/ta"
 languageName = "Tamil"
 languageCode = "ta"
-weight = 10
+weight = 650
 
 [params]
 

--- a/config/_default/languages.th.toml
+++ b/config/_default/languages.th.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/th"
 languageName = "Thai"
 languageCode = "th"
-weight = 10
+weight = 700
 
 [params]
 

--- a/config/_default/languages.tr.toml
+++ b/config/_default/languages.tr.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/tr"
 languageName = "Türkçe"
 languageCode = "tr-TR"
-weight = 10
+weight = 750
 
 [params]
 beforeColon = ""

--- a/config/_default/languages.uk.toml
+++ b/config/_default/languages.uk.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt - Free SSL/TLS Certificates"
 contentDir = "content/uk"
 languageName = "Українська"
 languageCode = "uk-UA"
-weight = 670
+weight = 800
 [params]
 beforeColon = ""
 description = """

--- a/config/_default/languages.vi.toml
+++ b/config/_default/languages.vi.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt - Chứng Chỉ SSL/TLS Certificates Miễn Phí"
 contentDir = "content/vi"
 languageName = "Tiếng Việt"
 languageCode = "vi-VN"
-weight = 700
+weight = 850
 [params]
 beforeColon = ""
 description = """

--- a/config/_default/languages.zh-cn.toml
+++ b/config/_default/languages.zh-cn.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt"
 contentDir = "content/zh-cn"
 languageName = "简体中文"
 languageCode = "zh-Hans-CN"
-weight = 10
+weight = 900
 
 [params]
 beforeColon = ""

--- a/config/_default/languages.zh-tw.toml
+++ b/config/_default/languages.zh-tw.toml
@@ -2,7 +2,7 @@ title = "Let's Encrypt - 免費的 SSL/TLS 憑證"
 languageName = "繁體中文"
 contentDir = "content/zh-tw"
 languageCode = "zh-Hant-TW"
-weight = 800
+weight = 950
 [params]
 beforeColon = ""
 description = """


### PR DESCRIPTION
# Latest update from Crowdin

- The `weight` parameter in the recently added languages was not correct causing incorrect order in the language menu selector. 

