### PR TITLE
Add comments regarding weight, language and language codes to config/_default/languages.en.toml

### DIFF
--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -1,7 +1,12 @@
 title = "Let's Encrypt"
 contentDir = "content/en"
+#The name of the language, it that language is not English
 languageName = "English"
+#The language code. Usually two lower-case letters. It that language is spoken in more than one country, the country-code can be added, uppercase. To check it: https://r12a.github.io/app-subtags/?check=pt-BR
 languageCode = "en-US"
+# Weight used for sorting.
+# 10 for English
+# Other languages from 100 to 999, alphabetical order using languageCode
 weight = 10
 
 [params]


### PR DESCRIPTION
# Fix an issue caused by https://github.com/letsencrypt/website/pull/1746 

- I have added comments back to `config/_default/languages.en.toml` which is used as a source for translations and these comments are important so that people know how to create new such files. 
- Tested, the update does not cause a new warning. 
- If there is a problem, we may need to find a better way to keep these comments, either in this file or in the localisation instructions. 
