### PR TITLE
Restore Donate page title

### DIFF
--- a/content/en/donate.html
+++ b/content/en/donate.html
@@ -1,9 +1,9 @@
 ---
-title: Additional Donation Information
-linkTitle: "Additional Donation Information"
+title: Donate
+linkTitle: "Donate"
 slug: donate
 no_donate_footer: true
-lastmod: 2023-08-08
+lastmod: 2024-11-18
 menu:
 menu:
   main:


### PR DESCRIPTION
In Summer 2024, the donate page was temporarily renamed while another version of the page took over. That version is now gone, and this is the original title for this page.