### PR TITLE
Add my project server-ssl.js to clients.json (ACMEv2, HTTP-01, DNS-01)

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -872,6 +872,6 @@
 				"TLS-SNI-02": "false"
 			},
 			"comments": "(Easy to configure SSL Web Server for development or production)"
-		},
+		}
 	]
 }

--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2024-11-12",
+	"lastmod": "2024-11-24",
 	"categories": [
 		"Bash",
 		"C",
@@ -860,6 +860,18 @@
 			"library": "Rust",
 			"library_url": "https://github.com/n0-computer/tokio-rustls-acme",
 			"comments": "is an easy-to-use, async ACME client library for rustls"
-		}
+		},
+		{
+			"name": "Server-SSL.js",
+			"url": "https://github.com/FirstTimeEZ/server-ssl",
+			"category": "Node.js",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "false",
+				"TLS-SNI-01": "false",
+				"TLS-SNI-02": "false"
+			},
+			"comments": "(Easy to configure SSL Web Server for development or production)"
+		},
 	]
 }


### PR DESCRIPTION
Adds [`server-ssl.js`](https://github.com/FirstTimeEZ/server-ssl) to clients.json, which is a `Node.js` server which implements and automates the `HTTP-01 Challenge` to automatically renew certificates using `Lets Encrypt`

Can use `DNS-01` with support providers.

`ACMEv2`
