### PR TITLE
Bump version of Hugo used by Netlify to 0.130.0.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@ command = "hugo -d public"
 
 [build.environment]
 # same as .github/workflows/test.yaml
-HUGO_VERSION = "0.128.2"
+HUGO_VERSION = "0.130.0"
 
 # https://docs.netlify.com/routing/headers/#syntax-for-the-netlify-configuration-file
 # headers must be the same than in config/_default/server.toml (for Hugo)


### PR DESCRIPTION
Doing this to allow us to replace the deprecated resources.ToCSS function.