### PR TITLE
Adds renewc client to clients.json

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2024-11-12",
+	"lastmod": "2024-12-23",
 	"categories": [
 		"Bash",
 		"C",
@@ -860,6 +860,18 @@
 			"library": "Rust",
 			"library_url": "https://github.com/n0-computer/tokio-rustls-acme",
 			"comments": "is an easy-to-use, async ACME client library for rustls"
-		}
+		},
+		{
+			"name": "renewc",
+			"url": "https://github.com/dvdsk/renewc",
+			"category": "Rust",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "false",
+				"TLS-SNI-01": "false",
+				"TLS-SNI-02": "false"
+			},
+			"comments": "Easy certificate tool: helpful diagnostics, no requirements, no installation needed"
+    	}
 	]
 }


### PR DESCRIPTION
My client [`renewc`](https://github.com/dvdsk/renewc) has reached the point where I am quite happy with it, so I am releasing it to the world now. I think it fits on this list.

It uses InstantACME (rust lib, on the list already) internally. The client compiles to a fully static binary that can be deployed without install (it has zero runtime dependencies not even a libc minimum version). 

It provides an install command that copies the binary somewhere safe and sets up a systemd service and timer for renewal. 

Renewal is checked every day (without api call). When the certificate gets close to expiry it is renewed. The point at which it does renewal is slightly random as required by letsencrypt.

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
