### PR TITLE
Update Oak log shard status

### DIFF
--- a/data/transparency.json
+++ b/data/transparency.json
@@ -1,5 +1,5 @@
 {
-    "lastmod": "2024-10-02",
+    "lastmod": "2025-01-17",
     "categories": [
         "production",
         "testing",

--- a/data/transparency.json
+++ b/data/transparency.json
@@ -59,7 +59,7 @@
         {
             "log": "oak",
             "shard": "2024h1",
-            "state": "Usable",
+            "state": "Rejected - Shard Expired",
             "role": "production",
             "publicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVkPXfnvUcre6qVG9NpO36bWSD+pet0Wjkv3JpTyArBog7yUvuOEg96g6LgeN5uuk4n0kY59Gv5RzUo2Wrqkm/Q==",
             "logID": "3B:53:77:75:3E:2D:B9:80:4E:8B:30:5B:06:FE:40:3B:67:D8:4F:C3:F4:C7:BD:00:0D:2D:72:6F:E1:FA:D4:17",
@@ -99,7 +99,7 @@
         {
             "log": "oak",
             "shard": "2026h1",
-            "state": "Pending",
+            "state": "Usable",
             "role": "production",
             "publicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmdRhcCL6d5MNs8eAliJRvyV5sQFC6UF7iwzHsmVaifT64gJG1IrHzBAHESdFSJAjQN56TYky+9cK616MovH2SQ==",
             "logID": "19:86:D4:C7:28:AA:6F:FE:BA:03:6F:78:2A:4D:01:91:AA:CE:2D:72:31:0F:AE:CE:5D:70:41:2D:25:4C:C7:D4",
@@ -109,7 +109,7 @@
         {
             "log": "oak",
             "shard": "2026h2",
-            "state": "Pending",
+            "state": "Usable",
             "role": "production",
             "publicKey": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEanCds5bj7IU2lcNPnIvZfMnVkSmu69aH3AS8O/Y0D/bbCPdSqYjvuz9Z1tT29PxcqYxf+w1g5CwPFuwqsm3rFQ==",
             "logID": "AC:AB:30:70:6C:EB:EC:84:31:F4:13:D2:F4:91:5F:11:1E:42:24:43:B1:F2:A6:8C:4F:3C:2B:3B:A7:1E:02:C3",


### PR DESCRIPTION
2026 shards are usable.  2024h1 is rejected.

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read https://github.com/letsencrypt/website/blob/master/TRANSLATION.md first.
