### PR TITLE
Remove unmaintained HAProxy ACME implementation

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2024-11-12",
+	"lastmod": "2025-02-11",
 	"categories": [
 		"Bash",
 		"C",
@@ -10,7 +10,6 @@
 		"Domino",
 		"Docker",
 		"Go",
-		"HAProxy",
 		"Java",
 		"Kubernetes",
 		"Lua",
@@ -264,11 +263,6 @@
 			"name": "Traefik",
 			"url": "https://traefik.io/",
 			"category": "Go"
-		},
-		{
-			"name": "HAProxy client",
-			"url": "https://github.com/haproxytech/haproxy-lua-acme",
-			"category": "HAProxy"
 		},
 		{
 			"name": "PJAC",


### PR DESCRIPTION
See https://github.com/haproxytech/haproxy-lua-acme?tab=readme-ov-file#deprecated

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read [TRANSLATION.md](./TRANSLATION.md) first.
