### PR TITLE
Adding watch my ssl

### DIFF
--- a/content/en/docs/monitoring-options.md
+++ b/content/en/docs/monitoring-options.md
@@ -16,6 +16,7 @@ There are a number of monitoring options out there, including:
 * [Datadog SSL Monitoring](https://www.datadoghq.com/monitoring/ssl-monitoring/)
 * [TrackSSL](https://trackssl.com/)
 * [Host-Tracker](https://www.host-tracker.com/)
+* [Watch My SSL](https://watchmyssl.com/)
 
 Please note that all of these services are unaffiliated with ISRG / Let's Encrypt.
 

--- a/content/en/docs/monitoring-options.md
+++ b/content/en/docs/monitoring-options.md
@@ -1,7 +1,7 @@
 ---
 title: Monitoring Service Options
 slug: monitoring-options
-lastmod: 2025-01-16
+lastmod: 2025-02-25
 show_lastmod: 1
 ---
 


### PR DESCRIPTION
This PR adds "Watch My SSL" to the list of SSL certificate monitoring options. Watch My SSL provides expiration monitoring via email, and it includes a free tier for basic usage.