### PR TITLE
Restore previous RSS template

### DIFF
--- a/themes/le-2025/layouts/_default/rss.xml
+++ b/themes/le-2025/layouts/_default/rss.xml
@@ -1,0 +1,18 @@
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ .Site.Title | htmlUnescape }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ .Site.Params.description | htmlUnescape }}</description>
+    {{ with .Site.LanguageCode }}<language>{{.}}</language>{{ end }}
+    {{ if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    <generator>Hugo v{{ hugo.Version }}</generator>
+    {{ with .OutputFormats.Get "RSS" }}<atom:link href="{{ .Permalink }}" rel="self" type="application/rss+xml" />{{ end }}
+      {{ $posts := where .Site.RegularPages "Type" "in" (slice "post")  | first 10 }}{{ range $posts }}<item>
+        <title>{{ .Title | safeHTML }}</title>
+        <link>{{ .Permalink }}</link>
+        <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+        <description>{{ safeHTML "<![CDATA["}}{{ chomp .Content }}{{ safeHTML "]]>"}}</description>
+        <guid isPermaLink="true">{{ .Permalink }}</guid>
+      </item>{{ end }}
+  </channel>
+</rss>


### PR DESCRIPTION
Re: #1866 & #1867 restores previous RSS template to not include any site pages.