### PR TITLE
Removing content/base-l10n/sponsors.html

### DIFF
--- a/content/base-l10n/sponsors.html
+++ b/content/base-l10n/sponsors.html
@@ -1,4 +1,0 @@
----
-slug: sponsors
-untranslated: 1
----


### PR DESCRIPTION
# Removing content/base-l10n/sponsors.html

- No longer needed due to https://github.com/letsencrypt/website/commit/cbbce229ac2cc321a9b1b0221822b9feca77a6e9 
