### PR TITLE
Fix Issue 1876

### DIFF
--- a/i18n/cs.toml
+++ b/i18n/cs.toml
@@ -395,7 +395,7 @@ other = "Nezisková organizace poskytující bezplatné TLS certifikáty pro ví
 other = "550 m"
 
 [home_hero_nonprofit_suffix]
-other = "webových stránek"
+other = "webových stránek."
 
 [projects_section_title]
 other = "Více způsobů, jak zlepšujeme bezpečnost a soukromí"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -414,7 +414,7 @@ other = "A nonprofit providing free TLS certificates to more than"
 other = "550M"
 
 [home_hero_nonprofit_suffix]
-other = "websites"
+other = "websites."
 
 [projects_section_title]
 other = "More ways we're improving security and privacy"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -405,7 +405,7 @@ other = "ISRG"
 
 # Home Hero - home_hero_nonprofit_sentence used if language does not follow English word order
 [home_hero_nonprofit_sentence]
-other = "A nonprofit providing free TLS certificates to more than ### websites"
+other = "A nonprofit providing free TLS certificates to more than ### websites."
 
 [home_hero_nonprofit_prefix]
 other = "A nonprofit providing free TLS certificates to more than"

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -392,7 +392,7 @@ other = "A nonprofit providing free TLS certificates to more than"
 other = "550M"
 
 [home_hero_nonprofit_suffix]
-other = "websites"
+other = "websites."
 
 [projects_section_title]
 other = "我们促进互联网安全与隐私的其他方式"

--- a/themes/le-2025/assets/css/le-2025-theme-output.css
+++ b/themes/le-2025/assets/css/le-2025-theme-output.css
@@ -1813,28 +1813,28 @@ div[data-netlify-deploy-id] {
   height: 400px;
 }
 
+.h-\[48px\] {
+  height: 48px;
+}
+
+.h-\[64px\] {
+  height: 64px;
+}
+
 .h-\[70px\] {
   height: 70px;
+}
+
+.h-\[80px\] {
+  height: 80px;
 }
 
 .h-full {
   height: 100%;
 }
 
-.max-h-\[48px\] {
-  max-height: 48px;
-}
-
-.max-h-\[64px\] {
-  max-height: 64px;
-}
-
 .max-h-\[80\%\] {
   max-height: 80%;
-}
-
-.max-h-\[80px\] {
-  max-height: 80px;
 }
 
 .min-h-full {

--- a/themes/le-2025/layouts/partials/components/sponsor-item.html
+++ b/themes/le-2025/layouts/partials/components/sponsor-item.html
@@ -2,8 +2,8 @@
    {{ with .id }}id="{{ . }}"{{ end }}
    {{ with .nofollow }}rel="nofollow"{{ end }}
    {{ with .sponsored }}rel="sponsored"{{ end }}
-   class="border bg-white border-gray-200 rounded-lg p-2 flex items-center h-[70px] justify-center hover:border-gray-300 transition group">
+   class="border bg-white border-gray-200 rounded-lg p-2 flex items-center h-[70px] justify-center hover:border-gray-300 transition group  {{ .class }}">
   <img src="/images/sponsors/small/{{ .image }}"
        alt="{{ .name }}"
-       class="w- max-w-[80%] max-h-[80%] transition-transform duration-200 ease-in-out group-hover:scale-105 {{ .class }}">
+       class=" max-w-[80%] max-h-[80%] transition-transform duration-200 ease-in-out group-hover:scale-105">
 </a>

--- a/themes/le-2025/layouts/partials/sections/home-hero.html
+++ b/themes/le-2025/layouts/partials/sections/home-hero.html
@@ -9,7 +9,7 @@
               {{ safeHTML (T "home_hero_heading") }}
             </h1>
             <h2 class="text-2xl md:text-3xl font-bold mb-6 text-balance">
-              {{ T "home_hero_nonprofit_prefix" }} <span class="relative inline-block"><span class="invisible text-4xl">{{ T "home_hero_certificate_count" }}</span><span id="certificate-count" class="text-4xl absolute left-0">{{ T "home_hero_certificate_count" }}</span></span> {{ T "home_hero_nonprofit_suffix" }}.
+              {{ T "home_hero_nonprofit_prefix" }} <span class="relative inline-block"><span class="invisible text-4xl">{{ T "home_hero_certificate_count" }}</span><span id="certificate-count" class="text-4xl absolute left-0">{{ T "home_hero_certificate_count" }}</span></span> {{ T "home_hero_nonprofit_suffix" }}
             </h2>
             <hr class="w-20 border-le-yellow border-2 mb-7">
             <div class="flex flex-wrap gap-4">

--- a/themes/le-2025/layouts/partials/sections/home-hero.html
+++ b/themes/le-2025/layouts/partials/sections/home-hero.html
@@ -9,7 +9,11 @@
               {{ safeHTML (T "home_hero_heading") }}
             </h1>
             <h2 class="text-2xl md:text-3xl font-bold mb-6 text-balance">
-              {{ T "home_hero_nonprofit_prefix" }} <span class="relative inline-block"><span class="invisible text-4xl">{{ T "home_hero_certificate_count" }}</span><span id="certificate-count" class="text-4xl absolute left-0">{{ T "home_hero_certificate_count" }}</span></span> {{ T "home_hero_nonprofit_suffix" }}
+              {{ if and (T "home_hero_nonprofit_prefix") (T "home_hero_certificate_count") (T "home_hero_nonprofit_suffix") }}
+                {{ T "home_hero_nonprofit_prefix" }} <span class="relative inline-block"><span class="invisible text-4xl">{{ T "home_hero_certificate_count" }}</span><span id="certificate-count" class="text-4xl absolute left-0">{{ T "home_hero_certificate_count" }}</span></span> {{ T "home_hero_nonprofit_suffix" }}
+              {{ else if and (T "home_hero_nonprofit_sentence") (T "home_hero_certificate_count") }}
+                {{ replace (T "home_hero_nonprofit_sentence") "###" (T "home_hero_certificate_count") }}
+              {{ end }}
             </h2>
             <hr class="w-20 border-le-yellow border-2 mb-7">
             <div class="flex flex-wrap gap-4">

--- a/themes/le-2025/layouts/partials/sections/home-hero.html
+++ b/themes/le-2025/layouts/partials/sections/home-hero.html
@@ -38,7 +38,7 @@
           <p class="mb-0 text-sm">{{ T "home_hero_annual_report_description" }}</p>
         </div>
         <div class="md:col-span-4 md:text-right">
-          <a href="/documents/annual-report-2024.pdf" class="text-sm btn btn-primary">
+          <a href="https://www.abetterinternet.org/documents/2024-ISRG-Annual-Report.pdf" class="text-sm btn btn-primary">
             {{ T "home_hero_annual_report_button" }} →
           </a>
         </div>

--- a/themes/le-2025/layouts/partials/sections/sponsors.html
+++ b/themes/le-2025/layouts/partials/sections/sponsors.html
@@ -10,7 +10,7 @@
       <h3 class="text-eyebrow mb-6">{{ i18n "sponsors_diamond" }}</h3>
       <div class="grid grid-cols-2 md:grid-cols-3 gap-1">
         {{ range $sponsor := . }}
-        {{ partial "components/sponsor-item" (dict "url" .url "id" .id "nofollow" .nofollow "sponsored" .sponsored "image" .image "name" .name "class" "max-h-[80px]") }}
+        {{ partial "components/sponsor-item" (dict "url" .url "id" .id "nofollow" .nofollow "sponsored" .sponsored "image" .image "name" .name "class" "h-[80px]") }}
         {{ end }}
       </div>
     </div>
@@ -21,7 +21,7 @@
       <h3 class="text-eyebrow mb-6">{{ i18n "sponsors_platinum" }}</h3>
       <div class="grid grid-cols-3 md:grid-cols-4 gap-1">
         {{ range $sponsor := . }}
-        {{ partial "components/sponsor-item" (dict "url" .url "id" .id "nofollow" .nofollow "sponsored" .sponsored "image" .image "name" .name "class" "max-h-[64px]") }}
+        {{ partial "components/sponsor-item" (dict "url" .url "id" .id "nofollow" .nofollow "sponsored" .sponsored "image" .image "name" .name "class" "h-[64px]") }}
         {{ end }}
       </div>
     </div>
@@ -32,7 +32,7 @@
       <h3 class="text-eyebrow mb-6">{{ i18n "sponsors_gold" }}</h3>
       <div class="grid grid-cols-4 md:grid-cols-6 gap-1">
         {{ range $sponsor := . }}
-        {{ partial "components/sponsor-item" (dict "url" .url "id" .id "nofollow" .nofollow "sponsored" .sponsored "image" .image "name" .name "class" "max-h-[48px]") }}
+        {{ partial "components/sponsor-item" (dict "url" .url "id" .id "nofollow" .nofollow "sponsored" .sponsored "image" .image "name" .name "class" "h-[48px]") }}
         {{ end }}
       </div>
     </div>
@@ -43,7 +43,7 @@
       <h3 class="text-eyebrow mb-6">{{ i18n "sponsors_silver" }}</h3>
       <div class="grid grid-cols-4 md:grid-cols-6 gap-1">
         {{ range $sponsor := . }}
-        {{ partial "components/sponsor-item" (dict "url" .url "id" .id "nofollow" .nofollow "sponsored" .sponsored "image" .image "name" .name "class" "max-h-[48px]") }}
+        {{ partial "components/sponsor-item" (dict "url" .url "id" .id "nofollow" .nofollow "sponsored" .sponsored "image" .image "name" .name "class" "h-[48px]") }}
         {{ end }}
       </div>
     </div>

--- a/themes/le-2025/layouts/partials/sections/support.html
+++ b/themes/le-2025/layouts/partials/sections/support.html
@@ -2,11 +2,16 @@
   <div class="relative z-10">
     <div class="container mx-auto">
       <h2 class="text-left text-3xl md:text-4xl font-bold mb-8">
-        {{ i18n "support_heading_base" }} <span class="text-le-blue rotate-words"
-          data-word1="{{ i18n "support_heading_word1" }}"
-          data-word2="{{ i18n "support_heading_word2" }}"
-          data-word3="{{ i18n "support_heading_word3" }}"
-          data-word4="{{ i18n "support_heading_word4" }}">{{ i18n "support_heading_word1" }}</span>
+        {{ if and (i18n "support_heading_base") (i18n "support_heading_word1") (i18n "support_heading_word2") (i18n "support_heading_word3") (i18n "support_heading_word4") }}
+          {{ i18n "support_heading_base" }}
+          <span class="text-le-blue rotate-words"
+            data-word1="{{ i18n "support_heading_word1" }}"
+            data-word2="{{ i18n "support_heading_word2" }}"
+            data-word3="{{ i18n "support_heading_word3" }}"
+            data-word4="{{ i18n "support_heading_word4" }}">{{ i18n "support_heading_word1" }}</span>
+        {{ else if i18n "support_heading_entire_sentence" }}
+          {{ i18n "support_heading_entire_sentence" }}
+        {{ end }}
       </h2>
 
       <script>


### PR DESCRIPTION
Per #1876:

1. Fixes the Annual Report PDF link
2. Sponsor logos now cannot extend outside their container
3. All fallback strings for the animated sentences on the homepage:  the hero, and the global impact section