### PR TITLE
Add Auto Encrypt to clients.json

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -849,6 +849,19 @@
 			"library": "Rust",
 			"library_url": "https://github.com/n0-computer/tokio-rustls-acme",
 			"comments": "is an easy-to-use, async ACME client library for rustls"
+		},
+		{
+			"name": "Auto Encrypt",
+			"url": "https://codeberg.org/small-tech/auto-encrypt",
+			"category": "Node.js",
+			"library": "Node.js",
+			"comments": "Automatically provisions and renews TLS certificates from Let’s Encrypt on Node.js https servers",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "false",
+				"TLS-SNI-01": "false",
+				"TLS-SNI-02": "false"
+			}
 		}
 	]
 }


### PR DESCRIPTION
Automatically provisions and renews Let’s Encrypt TLS certificates on Node.js https servers (including Kitten, Polka, Express.js, etc.)

Implements the subset of RFC 8555 – Automatic Certificate Management Environment (ACME) – necessary for a client to support TLS certificate provisioning from Let’s Encrypt using HTTP-01 challenges.