### PR TITLE
Add to monitoring options list on monitoring-options page

### DIFF
--- a/content/en/docs/monitoring-options.md
+++ b/content/en/docs/monitoring-options.md
@@ -1,7 +1,7 @@
 ---
 title: Monitoring Service Options
 slug: monitoring-options
-lastmod: 2025-01-16
+lastmod: 2025-06-05
 show_lastmod: 1
 ---
 
@@ -16,6 +16,7 @@ There are a number of monitoring options out there, including:
 * [Datadog SSL Monitoring](https://www.datadoghq.com/monitoring/ssl-monitoring/)
 * [TrackSSL](https://trackssl.com/)
 * [Host-Tracker](https://www.host-tracker.com/)
+* [Chill SSL](https://www.chillssl.com/)
 
 Please note that all of these services are unaffiliated with ISRG / Let's Encrypt.
 


### PR DESCRIPTION
Added Chill SSL (https://www.chillssl.com/) to the list of TLS certificate monitoring services on the monitoring-options page.

Note: I’m the founder/owner of Chill SSL.

Chill SSL helps users track SSL certificate expiration dates and receive timely notifications, making certificate management easier.

This contribution aligns with the existing list of unaffiliated monitoring tools and provides users with an additional option for SSL monitoring.

