### PR TITLE
Fix 301 redirect for /ta/sponsors/ appearing in Google SERP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -233,6 +233,14 @@ to = "/sv/404.html"
 status = 404
 force = false
 
+# Fix for Google SERP issue: /ta/sponsors/ was showing in search results but leading to 404
+# This specific redirect must come before the catch-all /ta/* rule to be processed first
+[[redirects]]
+from = "/ta/sponsors"
+to = "https://www.abetterinternet.org/sponsors/"
+status = 301
+force = true
+
 [[redirects]]
 from = "/ta/*"
 to = "/ta/404.html"


### PR DESCRIPTION
Add specific redirect for /ta/sponsors/ to prevent 404 errors from Google search results.

When users search for "let's encrypt sponsors" on Google, one of the top results shows https://letsencrypt.org/ta/sponsors/ in the SERP. However, clicking this link currently takes users to a 404 error page instead of the intended sponsors page at https://www.abetterinternet.org/sponsors/.

While the netlify.toml already contains a working 301 redirect for /sponsors -> https://www.abetterinternet.org/sponsors/, the Tamil language path /ta/sponsors/ was being caught by the catch-all rule "/ta/* -> /ta/404.html" which appears earlier in the redirect list.

Since Netlify processes redirects in order and stops at the first match, this adds a specific 301 redirect for /ta/sponsors before the catch-all /ta/* rule, ensuring users from Google search results are properly redirected to the sponsors page instead of receiving a 404 error.

Fixes broken user experience where Google SERP clicks lead to 404 instead of the intended destination.

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read [TRANSLATION.md](./TRANSLATION.md) first.
