### PR TITLE
Update rate limits doc for IP address identifiers

### DIFF
--- a/content/en/docs/rate-limits.md
+++ b/content/en/docs/rate-limits.md
@@ -2,20 +2,20 @@
 title: Rate Limits
 slug: rate-limits
 date: 2018-01-04
-lastmod: 2025-04-01
+lastmod: 2025-06-12
 show_lastmod: true
 ---
 
-Let’s Encrypt provides rate limits to ensure fair usage by as many people as
+Let's Encrypt provides rate limits to ensure fair usage by as many people as
 possible. We believe these rate limits are high enough to work for most people
-by default. We’ve also designed them so that renewing a certificate almost never
+by default. We've also designed them so that renewing a certificate almost never
 hits a rate limit, and so that large organizations can gradually increase the
-number of certificates they can issue without requiring intervention from Let’s
+number of certificates they can issue without requiring intervention from Let's
 Encrypt.
 
-If you’re actively developing or testing a Let’s Encrypt client, please utilize
+If you're actively developing or testing a Let's Encrypt client, please utilize
 our [staging environment](/docs/staging-environment) instead of the production
-API. If you’re working on integrating Let’s Encrypt as a provider or with a
+API. If you're working on integrating Let's Encrypt as a provider or with a
 large website please review our [Integration Guide](/docs/integration-guide).
 
 # How Our Rate Limits Work
@@ -26,7 +26,7 @@ approach provides flexibility in how you use your allotted requests. You can
 either make requests in bursts—up to the full limit—or space out your requests
 to avoid the risk of being limited.
 
-If you’ve hit a rate limit, we don’t have a way to temporarily reset it. Don't
+If you've hit a rate limit, we don't have a way to temporarily reset it. Don't
 worry, your capacity for that limit will gradually refill over time, allowing
 you to make more requests without any additional action on your part. Revoking
 certificates does **not** reset rate limits, because the resources used to issue
@@ -77,9 +77,10 @@ hostnames.
 
 ## New Orders per Account
 
-Each time you request a certificate from Let’s Encrypt, a new order is created.
-A single certificate can include up to 100 hostnames. For performance reasons,
-it's better to use fewer hostnames per certificate whenever you can.
+Each time you request a certificate from Let's Encrypt, a new order is created.
+A single certificate can include up to 100 identifiers (hostnames or IP
+addresses). For performance reasons, it's better to use fewer identifiers per
+certificate whenever you can.
 
 ### Limit
 
@@ -103,12 +104,17 @@ registered domain is `example.com`. In `new.blog.example.co.uk`, the registered
 domain is `example.co.uk`. We use the [Public Suffix
 List](https://publicsuffix.org/) to identify registered domains.
 
+If you're requesting a certificate for an IP address, this rate limit evaluates
+an IPv4 address as if it's a registered domain. For IPv6 addresses, it evaluates
+the /64 range that contains the address.
+
 ### Limit
 
-Up to 50 certificates can be issued per registered domain every 7 days. This is
-a global limit, and all new order requests, regardless of which account submits
-them, count towards this limit. The ability to issue new certificates for the
-same registered domain refills at a rate of 1 certificate every 202 minutes.
+Up to 50 certificates can be issued per registered domain (or IPv4 address, or
+IPv6 /64 range) every 7 days. This is a global limit, and all new order
+requests, regardless of which account submits them, count towards this limit.
+The ability to issue new certificates for the same registered domain refills at
+a rate of 1 certificate every 202 minutes.
 
 ### Overrides
 
@@ -119,20 +125,21 @@ the specific registered domain or an account.
 </div>
 <div class="boxed">
 
-## New Certificates per Exact Set of Hostnames
+## New Certificates per Exact Set of Identifiers
 
-If you request a certificate for `example.com` and `login.example.com`, the
-“exact set of hostnames” is `[example.com, login.example.com]`. If you request a
-certificate for only 1 hostname, such as `example.co.uk`, then the exact set of
-hostnames would be `[example.co.uk]`.
+If you request a certificate for `192.168.1.1`, `example.com` and
+`login.example.com`, the “exact set of identifiers” is `[192.168.1.1,
+example.com, login.example.com]`. If you request a certificate for only 1
+identifier, such as `example.co.uk`, then the exact set of identifiers would be
+`[example.co.uk]`.
 
 ### Limit
 
-Up to 5 certificates can be issued per exact same set of hostnames every 7 days.
-This is a global limit, and all new order requests, regardless of which account
-submits them, count towards this limit. The ability to request new certificates
-for the same exact set of hostnames refills at a rate of 1 certificate every 34
-hours.
+Up to 5 certificates can be issued per exact same set of identifiers every 7
+days. This is a global limit, and all new order requests, regardless of which
+account submits them, count towards this limit. The ability to request new
+certificates for the same exact set of identifiers refills at a rate of 1
+certificate every 34 hours.
 
 ### Common Causes
 
@@ -148,7 +155,7 @@ client to use our [staging environment](/docs/staging-environment), which has
 
 ### Workaround
 
-If you've hit this limit, you can change the set of hostnames by adding
+If you've hit this limit, you can change the set of identifiers by adding
 `blog.example.com`, to request additional certificates. Be aware that these new
 orders would not be considered renewals. Therefore, they would be subject to the
 [New Orders per Account](#new-orders-per-account) and [New Certificates per
@@ -161,21 +168,21 @@ We do **not** offer overrides for this limit.
 </div>
 <div class="boxed">
 
-## Authorization Failures per Hostname per Account
+## Authorization Failures per Identifier per Account
 
-An authorization is generated for each hostname included in an order. Before a
-certificate can be issued, all authorizations in the order must be successfully
-validated. A failed authorization means that, although the requests for
-validation were sent successfully, all attempts by Let’s Encrypt to validate
-control of the hostname have failed.
+An authorization is generated for each identifier (domain or IP address)
+included in an order. Before a certificate can be issued, all authorizations in
+the order must be successfully validated. A failed authorization means that,
+although the requests for validation were sent successfully, all of Let's
+Encrypt's attempts to validate control of the identifier have failed.
 
 ### Limit
 
-Up to 5 authorization failures per hostname can be incurred by one account every
-hour. The ability to incur authorization failures refills at a rate of 1 per
-hostname every 12 minutes. Once exceeded, this limit is enforced by preventing
-any new orders for the same hostname, by the same account until the limit
-resets.
+Up to 5 authorization failures per identifier can be incurred by one account
+every hour. The ability to incur authorization failures refills at a rate of 1
+per identifier every 12 minutes. Once exceeded, this limit is enforced by
+preventing any new orders for the same identifier, by the same account until the
+limit resets.
 
 ### Common Causes
 
@@ -200,23 +207,24 @@ We do **not** offer overrides for this limit.
 </div>
 <div class="boxed">
 
-## Consecutive Authorization Failures per Hostname per Account
+## Consecutive Authorization Failures per Identifier per Account
 
-Similar to [Authorization Failures per Hostname per
-Account](#authorization-failures-per-hostname-per-account) but only applies to
+Similar to [Authorization Failures per Identifier per
+Account](#authorization-failures-per-identifier-per-account) but only applies to
 consecutive failures. This limit is designed to prevent clients from getting
 stuck forever in a loop of failed validations.
 
 ### Limit
 
-Up to 3,600 consecutive authorization failures per hostname can be incurred by
+Up to 3,600 consecutive authorization failures per identifier can be incurred by
 one account. The ability to incur authorization failures refills at a rate of 1
-per hostname every day and resets to zero if an authorization for that hostname
-is successfully validated. Once exceeded, the account is prevented from
-requesting new certificates for that hostname. Each time the subscriber attempts
-to request a certificate they will receive an error containing a link to our
-Self-Service Portal where they can unpause issuance for the paused hostname and
-up to 49,999 additional paused hostnames associated with their account.
+per identifier every day and resets to zero if an authorization for that
+identifier is successfully validated. Once exceeded, the account is prevented
+from requesting new certificates for that identifier. Each time the subscriber
+attempts to request a certificate they will receive an error containing a link
+to our Self-Service Portal where they can unpause issuance for the paused
+identifier and up to 49,999 additional paused identifiers associated with their
+account.
 
 | Failures per Day             | Time to Pause           |
 |------------------------------|-------------------------|
@@ -278,36 +286,37 @@ HTTP response code. The response will include a `Retry-After` header.
 Let's Encrypt recognizes a new certificate order as a "renewal" in two ways: the
 preferred method is through ACME Renewal Info (ARI), which is exempt from all
 rate limits, and the other relies on older renewal detection logic that
-considers orders with the exact same set of hostnames as renewals but may still
-be subject to certain rate limits.
+considers orders with the exact same set of identifiers as renewals but may
+still be subject to certain rate limits.
 
 ## ARI Renewals
 
 Renewals coordinated by ARI offer the unique benefit of being exempt from all
-rate limits. Clients that support ARI periodically check with Let’s Encrypt
+rate limits. Clients that support ARI periodically check with Let's Encrypt
 servers to determine if your existing certificate should be renewed. When the
 optimal renewal window is reached the client requests a new order explicitly
 indicating the certificate it replaces. If the new order includes at least one
-hostname matching the certificate it intends to replace and the certificate has
-not been previously replaced using ARI, the order will not be subject to any
+identifier matching the certificate it intends to replace and the certificate
+has not been previously replaced using ARI, the order will not be subject to any
 rate limits.
 
 ## Non-ARI Renewals
 
 If your client or hosting provider has yet to add support for ARI, your order
 can still be considered a renewal of an earlier certificate if it contains the
-exact same set of hostnames, ignoring capitalization and the order of hostnames.
-For example, if you requested a certificate for the hostnames `[www.example.com,
-example.com]`, you could request four more certificates for `[www.example.com,
-example.com]` before hitting the [New Certificates per Exact Set of
-Hostnames](#new-certificates-per-exact-set-of-hostnames) rate limit. Each of
+exact same set of identifiers, ignoring capitalization and the order of
+identifiers. For example, if you requested a certificate for the identifiers
+`[192.168.1.1, www.example.com, example.com]`, you could request four more
+certificates for `[192.168.1.1, www.example.com, example.com]` before hitting
+the [New Certificates per Exact Set of
+Identifiers](#new-certificates-per-exact-set-of-identifiers) rate limit. Each of
 these new orders would be considered renewals and would be exempt from the [New
 Orders per Account](#new-orders-per-account) and [New Certificates per
 Registered Domain](#new-certificates-per-registered-domain) rate limits.
 However, unlike ARI renewals, these orders would still be subject to
-[Authorization Failures per Hostname per
-Account](#authorization-failures-per-hostname-per-account) and [New Certificates
-per Exact Set of Hostnames](#new-certificates-per-exact-set-of-hostnames).
+[Authorization Failures per Identifier per
+Account](#authorization-failures-per-identifier-per-account) and [New Certificates
+per Exact Set of Identifiers](#new-certificates-per-exact-set-of-identifiers).
 
 # Retrying After Hitting Rate Limits
 
@@ -335,7 +344,7 @@ Transparency](https://www.certificate-transparency.org/) logs.
 
 # Requesting an Override
 
-If you are a large hosting provider or organization working on a Let’s Encrypt
+If you are a large hosting provider or organization working on a Let's Encrypt
 integration, we have a [rate limiting
 form](https://isrg.formstack.com/forms/rate_limit_adjustment_request) that can
 be used to request higher rate limits. It takes a few weeks to process requests,


### PR DESCRIPTION
Update `docs/rate-limits.md` to replace most uses of the word "hostname" with "identifier," and clarify at relevant points that certificates may contain IP address identifiers.

This includes most rate limit names in the doc, since they already differ slightly from what's returned by the API. This does not yet include "registered domains," since that phrase closely tracks what the API uses and has not yet renamed.

Also, replace "smart apostrophes" with ASCII apostrophes, since their usage was already inconsistently mixed throughout the doc.