### PR TITLE
Fix transparency-dev slack link

### DIFF
--- a/content/en/post/2024-03-14-introducing-sunlight.md
+++ b/content/en/post/2024-03-14-introducing-sunlight.md
@@ -66,6 +66,6 @@ Today's announcement of Sunlight is just the beginning. We've released [software
 
 We've gotten positive feedback so far, with comments such as "Google's TrustFabric team, maintainers of Trillian, are supportive of this direction and the Sunlight spec. We have been working towards the same goal of cacheable tile-based logs for other ecosystems with [serverless tooling](https://github.com/transparency-dev/serverless-log), and will be folding this into Trillian and ctfe, along with adding support for the Sunlight API."
 
-If you have feedback on the design, please join in the conversation on the [ct-policy mailing list](https://groups.google.com/a/chromium.org/g/ct-policy), or in the #sunlight channel on the [transparency-dev Slack](http://transparency.dev/slack/).
+If you have feedback on the design, please join in the conversation on the [ct-policy mailing list](https://groups.google.com/a/chromium.org/g/ct-policy), or in the #sunlight channel on the [transparency-dev Slack](https://transparency.dev/slack/).
 
 We'd like to thank Chrome for supporting the development of Sunlight, and Amazon Web Services for their ongoing support for our CT log operation. If your organization monitors or values CT, please consider a financial gift of support. Learn more at <https://www.abetterinternet.org/sponsor/> or contact us at: sponsor@abetterinternet.org.


### PR DESCRIPTION
The invite link isn't current and doesn't work.
The channel link also won't work if you're not already on the slack.

Instead, link to transparency.dev/slack which has an invite generator.

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read [TRANSLATION.md](./TRANSLATION.md) first.
