### PR TITLE
Remove cross sign expiration post from the About menu

### DIFF
--- a/content/en/post/2023-07-10-cross-sign-expiration.md
+++ b/content/en/post/2023-07-10-cross-sign-expiration.md
@@ -4,10 +4,6 @@ date: 2023-07-10T00:00:00Z
 slug: cross-sign-expiration
 title: "Shortening the Let's Encrypt Chain of Trust"
 excerpt: "In late 2024, Let's Encrypt's cross-sign from IdenTrust will expire. Here's everything you need to know about the upcoming transition, and why it will be a non-event for most people."
-menu:
-  main:
-    weight: 30
-    parent: about
 lastmod: 2024-02-08
 ---
 


### PR DESCRIPTION
We don't need this any more.