### PR TITLE
Remove unused "date:" front matter

### DIFF
--- a/content/en/docs/a-warm-welcome-to-asn1-and-der.md
+++ b/content/en/docs/a-warm-welcome-to-asn1-and-der.md
@@ -1,7 +1,6 @@
 ---
 title: A Warm Welcome to ASN.1 and DER
 slug: a-warm-welcome-to-asn1-and-der
-date: 2020-04-23
 lastmod: 2021-03-21
 ---
 This document provides a gentle introduction to the data structures and

--- a/content/en/docs/account-id.md
+++ b/content/en/docs/account-id.md
@@ -1,7 +1,6 @@
 ---
 title: Finding Account IDs
 slug: account-id
-date: 2016-08-10
 lastmod: 2021-12-27
 show_lastmod: 1
 ---

--- a/content/en/docs/allow-port-80.md
+++ b/content/en/docs/allow-port-80.md
@@ -1,7 +1,6 @@
 ---
 title: Best Practice - Keep Port 80 Open
 slug: allow-port-80
-date: 2019-01-24
 lastmod: 2019-01-24
 show_lastmod: 1
 ---

--- a/content/en/docs/caa.md
+++ b/content/en/docs/caa.md
@@ -1,7 +1,6 @@
 ---
 title: Certificate Authority Authorization (CAA)
 slug: caa
-date: 2017-07-27
 lastmod: 2023-08-16
 show_lastmod: 1
 ---

--- a/content/en/docs/challenge-types.md
+++ b/content/en/docs/challenge-types.md
@@ -1,7 +1,6 @@
 ---
 title: Challenge Types
 slug: challenge-types
-date: 2019-02-25
 lastmod: 2025-01-07
 show_lastmod: 1
 ---

--- a/content/en/docs/integration-guide.md
+++ b/content/en/docs/integration-guide.md
@@ -2,7 +2,6 @@
 title: Integration Guide
 linkTitle: Client and Large Provider Integration Guide
 slug: integration-guide
-date: 2016-08-08
 lastmod: 2025-06-23
 show_lastmod: 1
 ---

--- a/content/en/docs/ipv6.md
+++ b/content/en/docs/ipv6.md
@@ -1,7 +1,6 @@
 ---
 title: IPv6 Support
 slug: ipv6-support
-date: 2020-02-07
 lastmod: 2020-02-07
 show_lastmod: 1
 ---

--- a/content/en/docs/rate-limits.md
+++ b/content/en/docs/rate-limits.md
@@ -1,7 +1,6 @@
 ---
 title: Rate Limits
 slug: rate-limits
-date: 2018-01-04
 lastmod: 2025-06-12
 show_lastmod: true
 ---

--- a/content/en/docs/staging-environment.md
+++ b/content/en/docs/staging-environment.md
@@ -1,7 +1,6 @@
 ---
 title: Staging Environment
 slug: staging-environment
-date: 2018-01-05
 lastmod: 2025-05-12
 show_lastmod: 1
 ---

--- a/content/en/opt-in.html
+++ b/content/en/opt-in.html
@@ -1,7 +1,6 @@
 ---
 title: Sign up for emails
 slug: opt-in
-date: 2025-01-21
 display_inline_newsletter_embed: true
 ---
 

--- a/content/en/osn-event.html
+++ b/content/en/osn-event.html
@@ -1,7 +1,6 @@
 ---
 title: Newsletter Signup
 slug: osn-event
-date: 2023-05-18
 do_not_translate: 1
 ---
 

--- a/content/en/stats-dashboard.html
+++ b/content/en/stats-dashboard.html
@@ -2,7 +2,7 @@
 layout: blank
 title: Let's Encrypt Stats
 slug: stats-dashboard
-date: 2018-04-12
+lastmod: 2018-04-12
 ---
 <!-- This is used as a full-screen display by various parties, including
      (minimally) Mozilla. Please check with the committers before removing. -->

--- a/content/en/thankyou.md
+++ b/content/en/thankyou.md
@@ -1,7 +1,7 @@
 ---
 title: Thank you
 slug: thankyou
-date: 2022-12-02
+lastmod: 2022-12-02
 ---
 
 

--- a/content/en/tlsalpnrevocation.md
+++ b/content/en/tlsalpnrevocation.md
@@ -1,7 +1,6 @@
 ---
 title: Download affected certificate serials for 2022.01.25 TLS-ALPN-01 Incident
 slug: tlsalpnrevocation
-date: 2022-01-26
 lastmod: 2022-08-02
 english_is_canonical: 1
 show_lastmod: 1


### PR DESCRIPTION
Use lastmod instead if date is needed.

The old "date:" entries are a waste of space and confusing to website contributors.