### PR TITLE
Bump GitHub actions to latest versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,21 +13,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup NodeJS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node_version: 16
+          node-version: 22
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+        uses: peaceiris/actions-hugo@v3
         with:
           # same as netlify.toml
           hugo-version: '0.128.2'
           extended: true
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.13
       - name: Setup html5validator
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This PR bumps GitHub actions to their latest versions. It also corrects incorrect attribute `node_version` on the way.