### PR TITLE
Fix warning 'duplicate menu entry'

### DIFF
--- a/content/en/post/_index.md
+++ b/content/en/post/_index.md
@@ -1,8 +1,0 @@
----
-title: Blog
-url: "/blog/"
-menu:
-  main:
-    weight: 100
-    parent: about
----


### PR DESCRIPTION
When previewing the site with latest hugo version `0.148.2`, a warning is printed out:

```
WARN  "/home/xxx/lets-encrypt-website/content/en/post/_index.md:1:1": duplicate menu entry with identifier "Blog" in menu "main"
```

This PR fixes that issue.