### PR TITLE
Revert "Fix warning 'duplicate menu entry'"

### DIFF
--- a/content/en/post/_index.md
+++ b/content/en/post/_index.md
@@ -1,0 +1,8 @@
+---
+title: Blog
+url: "/blog/"
+menu:
+  main:
+    weight: 100
+    parent: about
+---


### PR DESCRIPTION
Reverts letsencrypt/website#1983

This broke the "Blog" link in top navigation.