### PR TITLE
Fix warning 'duplicate menu entry'

### DIFF
--- a/content/en/post/_index.md
+++ b/content/en/post/_index.md
@@ -1,8 +1,4 @@
 ---
 title: Blog
 url: "/blog/"
-menu:
-  main:
-    weight: 100
-    parent: about
 ---


### PR DESCRIPTION
This PR is a follow-up on #1983, which was reverted.
With this PR in place, the link in the main main menu to the [blog](https://deploy-preview-1994--letsencrypt.netlify.app/blog/) is now preserved.
