### PR TITLE
Add new redirects for CP and CPS links

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -155,16 +155,6 @@ to = "https://www.abetterinternet.org/sponsors/"
 status = 301
 force = true
 
-
-[[redirects]]
-# Certbot (and other) clients link to the Terms of Service with a `.` after them
-# This is a convenience to allow copying the URL with that `.`
-# It should be updated on ToS changes, but is not a compliance-critical path.
-from = "/documents/LE-SA-v1.4-April-3-2024.pdf."
-to = "/documents/LE-SA-v1.4-April-3-2024.pdf"
-status = 301
-force = true
-
 [[redirects]]
 from = "/sponsors"
 to = "https://www.abetterinternet.org/sponsors/"
@@ -320,3 +310,13 @@ from = "https://www.letsencrypt.com/*"
 to = "https://letsencrypt.org/"
 status = 302
 force = true
+
+[[redirects]]
+# Certbot (and other) clients link to the Terms of Service with a `.` after them
+# This is a convenience to allow copying the URL with that `.`
+# It should be updated on ToS changes, but is not a compliance-critical path.
+from = "/documents/LE-SA-v1.4-April-3-2024.pdf."
+to = "/documents/LE-SA-v1.4-April-3-2024.pdf"
+status = 301
+force = true
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -315,8 +315,14 @@ force = true
 # Certbot (and other) clients link to the Terms of Service with a `.` after them
 # This is a convenience to allow copying the URL with that `.`
 # It should be updated on ToS changes, but is not a compliance-critical path.
-from = "/documents/LE-SA-v1.4-April-3-2024.pdf."
-to = "/documents/LE-SA-v1.4-April-3-2024.pdf"
+from = "/documents/LE-SA-v1.5-February-24-2025.pdf."
+to = "/documents/LE-SA-v1.5-February-24-2025.pdf"
+status = 301
+force = true
+
+[[redirects]]
+from = "/documents/LE-SA-v1.6-August-18-2025.pdf."
+to = "/documents/LE-SA-v1.6-August-18-2025.pdf"
 status = 301
 force = true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -326,3 +326,10 @@ to = "/documents/LE-SA-v1.6-August-18-2025.pdf"
 status = 301
 force = true
 
+[[redirects]]
+from = "https://cp-test.letsencrypt.org/"
+to = "https://letsencrypt.org/documents/isrg-cp-cps-v5.8/"
+
+[[redirects]]
+from = "https://cps-test.letsencrypt.org/"
+to = "https://letsencrypt.org/documents/isrg-cp-cps-v5.8/"


### PR DESCRIPTION
This updates the stale subscriber agreement redirects, which exist as a convenience for anyone who clicks a link that includes a trailing period.

This adds new redirects from "https://cp-test.letsencrypt.org/" and "https://cps-test.letsencrypt.org/" to the current version of the CPS. Once we validate this works properly, we can stop using a standalone webserver that hosts those URLs, and update this to use the real domains.

DNS entries will be required for these to work, which will be handled independently.
