### PR TITLE
Fix #2015 - Add type:page to donate page to ensure custom template is used

### DIFF
--- a/content/base-l10n/donate.html
+++ b/content/base-l10n/donate.html
@@ -1,4 +1,5 @@
 ---
 slug: donate
+type: page
 untranslated: 1
 ---

--- a/content/ca/donate.html
+++ b/content/ca/donate.html
@@ -1,4 +1,5 @@
 ---
 slug: donate
+type: page
 untranslated: 1
 ---

--- a/content/cs/donate.html
+++ b/content/cs/donate.html
@@ -2,6 +2,7 @@
 title: Podpora šifrování pro každého
 linkTitle: "Přispět"
 slug: donate
+type: page
 layout: donate
 no_donate_footer: true
 useContainer: false

--- a/content/da/donate.html
+++ b/content/da/donate.html
@@ -2,6 +2,7 @@
 title: Støt Let's Encrypt
 linkTitle: "Donér"
 slug: donate
+type: page
 layout: donate
 no_donate_footer: true
 useContainer: false

--- a/content/de/donate.html
+++ b/content/de/donate.html
@@ -2,6 +2,7 @@
 title: Spenden
 linkTitle: "Spenden"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/el/donate.html
+++ b/content/el/donate.html
@@ -1,4 +1,5 @@
 ---
 slug: donate
+type: page
 untranslated: 1
 ---

--- a/content/en/donate.html
+++ b/content/en/donate.html
@@ -2,6 +2,7 @@
 title: Support Encryption for Everyone
 linkTitle: "Donate"
 slug: donate
+type: page
 layout: donate
 no_donate_footer: true
 useContainer: false

--- a/content/es/donate.html
+++ b/content/es/donate.html
@@ -2,6 +2,7 @@
 title: Donar
 linkTitle: "Haz una donación"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/fa/donate.html
+++ b/content/fa/donate.html
@@ -1,4 +1,5 @@
 ---
 slug: donate
+type: page
 untranslated: 1
 ---

--- a/content/fi/donate.html
+++ b/content/fi/donate.html
@@ -2,6 +2,7 @@
 title: Lahjoita
 linkTitle: "Tee lahjoitus"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/fr/donate.html
+++ b/content/fr/donate.html
@@ -2,6 +2,7 @@
 title: Faire un don
 linkTitle: "Faire un don"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/he/donate.html
+++ b/content/he/donate.html
@@ -2,6 +2,7 @@
 title: תמיכה בהצפנה לכולם
 linkTitle: "תרומה"
 slug: donate
+type: page
 layout: donate
 no_donate_footer: true
 useContainer: false

--- a/content/hr/donate.html
+++ b/content/hr/donate.html
@@ -1,4 +1,5 @@
 ---
 slug: donate
+type: page
 untranslated: 1
 ---

--- a/content/hu/donate.html
+++ b/content/hu/donate.html
@@ -2,6 +2,7 @@
 title: Adományozz
 linkTitle: "Make a Donation"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/id/donate.html
+++ b/content/id/donate.html
@@ -2,6 +2,7 @@
 title: Donasi
 linkTitle: "Berdonasi"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/it/donate.html
+++ b/content/it/donate.html
@@ -2,6 +2,7 @@
 title: Dona
 linkTitle: "Fai una donazione"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/ja/donate.html
+++ b/content/ja/donate.html
@@ -2,6 +2,7 @@
 title: 寄付する
 linkTitle: "寄付する"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/ko/donate.html
+++ b/content/ko/donate.html
@@ -2,6 +2,7 @@
 title: 기부
 linkTitle: "기부하기"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/pl/donate.html
+++ b/content/pl/donate.html
@@ -2,6 +2,7 @@
 title: Darowizna
 linkTitle: "Przekaż darowiznę"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/pt-br/donate.html
+++ b/content/pt-br/donate.html
@@ -2,6 +2,7 @@
 title: Doar
 linkTitle: "Faça uma doação"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/ru/donate.html
+++ b/content/ru/donate.html
@@ -2,6 +2,7 @@
 title: Поддержать нас
 linkTitle: "Поддержать нас"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/si/donate.html
+++ b/content/si/donate.html
@@ -2,6 +2,7 @@
 title: සැමට සංකේතනයට සහාය වන්න
 linkTitle: "පරිත්‍යාග"
 slug: donate
+type: page
 layout: donate
 no_donate_footer: true
 useContainer: false

--- a/content/sr/donate.html
+++ b/content/sr/donate.html
@@ -2,6 +2,7 @@
 title: Donirajte
 linkTitle: "Donirajte"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/sv/donate.html
+++ b/content/sv/donate.html
@@ -2,6 +2,7 @@
 title: Donera
 linkTitle: "Gör en donation"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/ta/donate.html
+++ b/content/ta/donate.html
@@ -1,4 +1,5 @@
 ---
 slug: donate
+type: page
 untranslated: 1
 ---

--- a/content/th/donate.html
+++ b/content/th/donate.html
@@ -2,6 +2,7 @@
 title: บริจาค
 linkTitle: "ทำการบริจาค"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/tr/donate.html
+++ b/content/tr/donate.html
@@ -1,4 +1,5 @@
 ---
 slug: donate
+type: page
 untranslated: 1
 ---

--- a/content/uk/donate.html
+++ b/content/uk/donate.html
@@ -2,6 +2,7 @@
 title: Підтримати
 linkTitle: "Зробити пожертву"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/uz/donate.html
+++ b/content/uz/donate.html
@@ -2,6 +2,7 @@
 title: Xayriya
 linkTitle: "Xayriya qilish"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/vi/donate.html
+++ b/content/vi/donate.html
@@ -2,6 +2,7 @@
 title: Quyên Góp
 linkTitle: "Quyên góp"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03

--- a/content/zh-cn/donate.html
+++ b/content/zh-cn/donate.html
@@ -2,6 +2,7 @@
 title: 支持为所有人提供的数据加密服务
 linkTitle: "捐款"
 slug: donate
+type: page
 layout: donate
 no_donate_footer: true
 useContainer: false

--- a/content/zh-tw/donate.html
+++ b/content/zh-tw/donate.html
@@ -2,6 +2,7 @@
 title: 捐贈
 linkTitle: "捐贈"
 slug: donate
+type: page
 untranslated: 1
 layout: donate
 lastmod: 2025-05-03


### PR DESCRIPTION
The type: page parameter is needed to use the custom template. I believe this was not required by prior Hugo versions so this was caused by the recent update to the newest hugo version.

Fixes #2015 