### PR TITLE
Update dates for Oak EOL

### DIFF
--- a/content/en/post/2025-08-14-rfc-6962-logs-eol.md
+++ b/content/en/post/2025-08-14-rfc-6962-logs-eol.md
@@ -3,12 +3,12 @@ author: Josh Aas
 date: 2025-08-14T00:00:00Z
 slug: rfc-6962-logs-eol
 title: "End of Life Plan for RFC 6962 Certificate Transparency Logs"
-excerpt: "Our RFC 6962 CT logs will go read-only on November 3, 2025, and shut down entirely on February 9, 2026. Going forward we will use Static CT API logs instead."
+excerpt: "Our RFC 6962 CT logs will go read-only on November 30, 2025, and shut down entirely on February 28, 2026. Going forward we will use Static CT API logs instead."
 display_default_footer: true
 display_inline_newsletter_embed: false
 ---
 
-Let’s Encrypt operates two types of Certificate Transparency (“CT”) logs—some implement the original [RFC 6962 API](https://datatracker.ietf.org/doc/html/rfc6962), and some that implement the newer [Static CT API](https://github.com/C2SP/C2SP/blob/main/static-ct-api.md). Today we are announcing that on **November 3, 2025**, we will make our RFC 6962 logs read-only. Past that date, we will write only to our Static CT logs. On **February 9, 2026**, we will entirely shut down our RFC 6962 logs. 
+Let’s Encrypt operates two types of Certificate Transparency (“CT”) logs—some implement the original [RFC 6962 API](https://datatracker.ietf.org/doc/html/rfc6962), and some that implement the newer [Static CT API](https://github.com/C2SP/C2SP/blob/main/static-ct-api.md). Today we are announcing that on **November 30, 2025**, we will make our RFC 6962 logs read-only. Past that date, we will write only to our Static CT logs. On **February 28, 2026**, we will entirely shut down our RFC 6962 logs. 
 
 End users (consumers or relying parties) of Web PKI certificates do not need to take any action. The work that needs to be done to make this transition will be handled by Let’s Encrypt and the browsers.
 

--- a/content/en/post/2025-08-14-rfc-6962-logs-eol.md
+++ b/content/en/post/2025-08-14-rfc-6962-logs-eol.md
@@ -10,7 +10,7 @@ display_inline_newsletter_embed: false
 
 > **Update, August 18, 2025**
 > 
-> We have updated the read-only and shutdown dates to ensure that our new Static CT API logs are fully-trusted by browsers to avoid any disruption.
+> We have updated the read-only and shutdown dates to ensure that our new Static CT API logs are fully trusted by browsers before switching Oak to read-only in order to avoid any disruption.
 
 Let’s Encrypt operates two types of Certificate Transparency (“CT”) logs—some implement the original [RFC 6962 API](https://datatracker.ietf.org/doc/html/rfc6962), and some that implement the newer [Static CT API](https://github.com/C2SP/C2SP/blob/main/static-ct-api.md). Today we are announcing that on **November 30, 2025**, we will make our RFC 6962 logs read-only. Past that date, we will write only to our Static CT logs. On **February 28, 2026**, we will entirely shut down our RFC 6962 logs. 
 

--- a/content/en/post/2025-08-14-rfc-6962-logs-eol.md
+++ b/content/en/post/2025-08-14-rfc-6962-logs-eol.md
@@ -8,6 +8,10 @@ display_default_footer: true
 display_inline_newsletter_embed: false
 ---
 
+> **Update, August 18, 2025**
+> 
+> We have updated the read-only and shutdown dates to ensure that our new Static CT API logs are fully-trusted by browsers to avoid any disruption.
+
 Let’s Encrypt operates two types of Certificate Transparency (“CT”) logs—some implement the original [RFC 6962 API](https://datatracker.ietf.org/doc/html/rfc6962), and some that implement the newer [Static CT API](https://github.com/C2SP/C2SP/blob/main/static-ct-api.md). Today we are announcing that on **November 30, 2025**, we will make our RFC 6962 logs read-only. Past that date, we will write only to our Static CT logs. On **February 28, 2026**, we will entirely shut down our RFC 6962 logs. 
 
 End users (consumers or relying parties) of Web PKI certificates do not need to take any action. The work that needs to be done to make this transition will be handled by Let’s Encrypt and the browsers.


### PR DESCRIPTION
November 30 is shortly after we expect our new Sunlight logs to be Usable.
February 28 is 90 days later.
