### PR TITLE
Add client data updates, last modification date script, and data about clients' last modification dates

### DIFF
--- a/client-data-lastmod.py
+++ b/client-data-lastmod.py
@@ -1,0 +1,61 @@
+# This script updates data/clients.json by cloning every referenced git
+# repository and noting the time of the most recent commit. The new
+# JSON data is saved into data/clients.json.new.
+
+import git
+import json
+import sys
+import tempfile
+import time
+
+try:
+    clients = json.load(open("data/clients.json"))
+except FileNotFoundError:
+    print("Could not open data/clients.json; wrong working dir?")
+    sys.exit(1)
+
+for client in clients["list"]:
+    name = client["name"]
+    if "url" in client:
+        url = client["url"]
+        # Remove any prior last_commit data, in case the repository can't be
+        # cloned this time.
+        if "last_commit" in client:
+            del client["last_commit"]
+        if "github.com/" in url or "gitlab.com/" in url or \
+                 "codeberg" in url or url.startswith("https://git."):
+            with tempfile.TemporaryDirectory() as tempdir:
+                try:
+                    print(name, "Cloning", url)
+                    repo = git.Repo.clone_from(url, tempdir)
+                    # committed_date is potentially newer than authored_date
+                    committed_date = repo.commit().committed_date
+                    committed_datetime = repo.commit().committed_datetime
+                    print(name, committed_datetime)
+                    client["last_commit"] = committed_date
+                    # If the repo didn't work before but did work this time,
+                    # remove the error notation.
+                    if "repo_error" in client:
+                        del client["repo_error"]
+                except Exception as e:
+                    # If the repo didn't work this time, note the error.
+                    print(name, "Error:", e)
+                    client["repo_error"] = 1
+        else:
+            print(name, "No detected git URL for client")
+    else:
+        print(name, "No URL for client")
+
+json.dump(clients, open("data/clients.json.new", "w"), indent="\t")
+
+# Sample jq processing:
+# 
+# jq -r '."list"[] | select(."last_commit")? | "\(now - .last_commit | round): \(.name)" '  < clients.json.new | sort -n
+#
+# We could also do this in native Python. The age of the last commit, in
+# seconds, would be
+#
+# int(time.time() - repo.commit().committed_date)
+#
+# so an action could be taken based on this (removing the entry, saving
+# it in a different file, giving it an additional field, etc.).

--- a/client-data-prune.py
+++ b/client-data-prune.py
@@ -1,0 +1,35 @@
+# This script updates data/clients.json by removing all clients
+# with last_commit older than a specified value. The new JSON data
+# is saved into data/clients.json.new.
+
+year = 365 * 86400
+cutoff = 2 * year
+
+import json
+import sys
+import time
+
+try:
+    clients = json.load(open("data/clients.json"))
+except FileNotFoundError:
+    print("Could not open data/clients.json; wrong working dir?")
+    sys.exit(1)
+
+new_list = []
+old_clients = len(clients["list"])
+for client in clients["list"]:
+    name = client["name"]
+    if "last_commit" in client:
+        age = int(time.time() - client["last_commit"])
+        if age < cutoff:
+            new_list.append(client)
+        else:
+            print("Dropping {} (age = {})".format(name, age))
+    else:
+        # No last_commit data for this client
+        new_list.append(client)
+
+print("Old: {}  New: {}".format(old_clients, len(new_list)))
+clients["list"] = new_list
+
+json.dump(clients, open("data/clients.json.new", "w"), indent="\t")

--- a/content/en/docs/client-options.md
+++ b/content/en/docs/client-options.md
@@ -42,5 +42,7 @@ Before submitting a pull request please make sure:
 1. The client respects the [Let's Encrypt trademark policy](https://www.abetterinternet.org/trademarks).
 1. The client is not browser-based and supports automatic renewals.
 1. The client performs [routine renewals at randomized times](/docs/integration-guide#when-to-renew), or encourages that configuration.
-1. Your commit adds your client to the **end** of the relevant sections (Don't forget the "acme_v2" if appropriate!).
+1. Your commit adds your client to the **end** of the relevant sections.
 1. Your commit updates the `lastmod` date stamp at the top of `clients.json`.
+
+We may periodically remove listings of projects that appear to be no longer developed. If development work on a project resumes, feel free to submit a new pull request to add that project again.

--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2025-08-27",
+	"lastmod": "2025-08-28",
 	"categories": [
 		"Bash",
 		"C",

--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2025-07-11",
+	"lastmod": "2025-08-27",
 	"categories": [
 		"Bash",
 		"C",
@@ -139,15 +139,23 @@
 		},
 		{
 			"name": "WildFly Application Server",
-			"url": "https://developer.jboss.org/people/fjuma/blog/2018/08/31/obtaining-certificates-from-lets-encrypt-using-the-wildfly-cli"
+			"url": "https://wildfly-security.github.io/wildfly-elytron/blog/obtaining-certificates-from-lets-encrypt-using-the-wildfly-cli"
 		},
 		{
 			"name": "Zappa",
 			"url": "https://github.com/Miserlou/Zappa#lets-encrypt-ssl-domain-certification-and-installation"
 		},
 		{
+			"name": "Domain Admin",
+			"url": "https://github.com/mouday/domain-admin"
+		},
+		{
 			"name": "Proxmox Virtual Environment",
 			"url": "https://pve.proxmox.com/wiki/Certificate_Management#sysadmin_certs_get_trusted_acme_cert"
+		},
+		{
+			"name": "Pomerium",
+			"url": "https://www.pomerium.com/"
 		}
 	],
 	"list": [
@@ -214,14 +222,28 @@
 			"url": "https://hub.docker.com/r/neilpang/acme.sh",
 			"category": "Docker"
 		},
-	        {
+		{
 			"name": "letsproxy",
 			"url": "https://hub.docker.com/r/neilpang/letsproxy",
 			"category": "Docker"
 		},
 		{
+			"name": "docker-nginx",
+			"comment": "Chinese language",
+			"url": "https://hub.docker.com/r/xiaojun207/nginx",
+			"acme_v2": "true",
+			"category": "Docker"
+		},
+		{
+			"name": "docker-openresty",
+			"comment": "Chinese language",
+			"url": "https://hub.docker.com/r/xiaojun207/openresty",
+			"acme_v2": "true",
+			"category": "Docker"
+		},
+		{
 			"name": "Caddy",
-			"url": "https://caddyserver.com",
+			"url": "https://caddyserver.com/",
 			"category": "Go",
 			"challenges": {
 				"HTTP-01": "true",
@@ -289,19 +311,34 @@
 			"category": "nginx"
 		},
 		{
-			"name": "Nginx ACME",
+			"name": "Angie ACME module",
+			"url": "https://en.angie.software/angie/docs/configuration/modules/http/http_acme/",
+			"category": "nginx",
+			"comments": "built-in module for Angie server, no extra dependencies, simple configuration, reload-less auto retrieval",
+			"acme_v2": "true"
+		},
+		{
+			"name": "ngx_http_acme_module",
+			"url": "https://github.com/nginx/nginx-acme",
+			"category": "nginx",
+			"comments": "built-in ACME module from upstream nginx developers",
+			"acme_v2": "true"
+		},
+		{
+			"name": "acme-nginx",
 			"url": "https://github.com/kshcherban/acme-nginx",
 			"category": "nginx"
 		},
-	        {
+		{
 			"name": "docker-openresty",
-			"url": "https://github.com/xiaojun207/docker-openresty⁠",
+			"url": "https://github.com/xiaojun207/docker-openresty\u2060",
 			"category": "nginx",
 			"comments": "An Openresty image with auto ssl, using acme.sh",
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true"
-			}
+			},
+			"repo_error": 1
 		},
 		{
 			"name": "docker-nginx",
@@ -588,7 +625,7 @@
 			"name": "Key Vault Acmebot",
 			"url": "https://github.com/shibayan/keyvault-acmebot",
 			"category": "Microsoft Azure",
-			"comments": "(Work with Azure Key Vault Certificates)"
+			"comments": "(Works with Azure Key Vault Certificates)"
 		},
 		{
 			"name": "Acme PHP",
@@ -647,7 +684,7 @@
 			"name": "CertMatica",
 			"url": "https://www.rhpconsult.com/products.html",
 			"category": "Domino",
-			"comments": "(ACME certificate installation and renewals for HCL Domino™ servers)"
+			"comments": "(ACME certificate installation and renewals for HCL Domino\u2122 servers)"
 		},
 		{
 			"name": "acme component",
@@ -698,7 +735,7 @@
 				"TLS-SNI-02": "false"
 			},
 			"comments": "PKI for internet server infrastructure, supporting distribution of certs, FreeBSD jails, DNS DANE support"
-    },
+		},
 		{
 			"name": "acmetk",
 			"url": "https://github.com/noahkw/acmetk",
@@ -707,8 +744,8 @@
 				"DNS-01": "true"
 			},
 			"comments": "acmetk is an ACMEv2 proxy to centralize certificate requests and challenges within an organisation and direct them using a single account to Let's Encrypt or other ACMEv2 capable CA's."
-    },
-    {
+		},
+		{
 			"name": "ACMEz",
 			"url": "https://github.com/mholt/acmez",
 			"category": "Go",
@@ -805,7 +842,7 @@
 			"name": "HCL Domino",
 			"url": "https://help.hcltechsw.com/domino/12.0.0/admin/secu_le_using_certificate_manager.html",
 			"category": "Domino",
-			"comments": "(Full ACME V2 flow integration for HCL Domino™ servers)",
+			"comments": "(Full ACME V2 flow integration for HCL Domino\u2122 servers)",
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true",
@@ -819,7 +856,8 @@
 			"category": "Go",
 			"comments": "(Supports certificate sharing across instances/pods and split-horizon DNS with acme-proxy)",
 			"library": "Go",
-			"library_url": "https://github.com/Cloud-Foundations/golib/blob/master/pkg/crypto/certmanager"
+			"library_url": "https://github.com/Cloud-Foundations/golib/blob/master/pkg/crypto/certmanager",
+			"repo_error": 1
 		},
 		{
 			"name": "KCert",
@@ -845,10 +883,46 @@
 			}
 		},
 		{
+			"name": "Cert Warden",
+			"url": "https://github.com/gregtwallace/certwarden",
+			"category": "Go",
+			"comments": "(Server to centrally manage and serve certificates)",
+			"acme_v2": "true",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "true",
+				"TLS-SNI-01": "false",
+				"TLS-SNI-02": "false"
+			}
+		},
+		{
+			"name": "acme-bot",
+			"url": "https://git.serenity-island.net/sie-foss/acme-bot",
+			"category": "Node.js",
+			"acme_v2": "true",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "true",
+				"TLS-ALPN-01": "true"
+			}
+		},
+		{
 			"name": "instant-acme",
 			"library": "Rust",
 			"library_url": "https://github.com/instant-labs/instant-acme",
 			"comments": "is an async, pure-Rust ACME (RFC 8555) client which relies on Tokio"
+		},
+		{
+			"name": "Server-SSL.js",
+			"url": "https://github.com/FirstTimeEZ/server-ssl",
+			"category": "Node.js",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "false",
+				"TLS-SNI-01": "false",
+				"TLS-SNI-02": "false"
+			},
+			"comments": "(Easy to configure SSL Web Server for development or production)"
 		},
 		{
 			"name": "rustls-acme",
@@ -857,10 +931,58 @@
 			"comments": "provides TLS certificate management and serving using rustls"
 		},
 		{
+			"name": "renewc",
+			"url": "https://github.com/dvdsk/renewc",
+			"category": "Rust",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "false",
+				"TLS-SNI-01": "false",
+				"TLS-SNI-02": "false"
+			},
+			"comments": "Easy certificate tool: helpful diagnostics, no requirements, no installation needed"
+		},
+		{
 			"name": "tokio-rustls-acme",
 			"library": "Rust",
 			"library_url": "https://github.com/n0-computer/tokio-rustls-acme",
 			"comments": "is an easy-to-use, async ACME client library for rustls"
+		},
+		{
+			"name": "simple-acme",
+			"url": "https://www.simple-acme.com/",
+			"category": "Windows / IIS",
+			"comments": "Spiritual successor to win-acme, also works on Linux!",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "true",
+				"TLS-ALPN-01": "true"
+			}
+		},
+		{
+			"name": "Auto Encrypt",
+			"url": "https://codeberg.org/small-tech/auto-encrypt",
+			"category": "Node.js",
+			"library": "Node.js",
+			"comments": "Automatically provisions and renews TLS certificates from Let\u2019s Encrypt on Node.js https servers",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "false",
+				"TLS-SNI-01": "false",
+				"TLS-SNI-02": "false"
+			}
+		},
+		{
+			"name": "Certimate",
+			"url": "https://github.com/certimate-go/certimate",
+			"category": "Go",
+			"comments": "manage certificates for multiple platforms with a visual workflow"
+		},
+		{
+			"name": "Certimate",
+			"url": "https://hub.docker.com/r/certimate/certimate",
+			"category": "Docker",
+			"comments": "manage certificates for multiple platforms with a visual workflow"
 		}
 	]
 }

--- a/data/clients.json
+++ b/data/clients.json
@@ -344,14 +344,14 @@
 		},
 		{
 			"name": "docker-openresty",
-			"url": "https://github.com/xiaojun207/docker-openresty\u2060",
+			"url": "https://github.com/xiaojun207/docker-openresty",
 			"category": "nginx",
 			"comments": "An Openresty image with auto ssl, using acme.sh",
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true"
 			},
-			"repo_error": 1
+			"last_commit": 1731303904
 		},
 		{
 			"name": "docker-nginx",

--- a/data/clients.json
+++ b/data/clients.json
@@ -194,9 +194,7 @@
 			"library": "Perl",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "true",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "true"
 			},
 			"last_commit": 1706753440
 		},
@@ -750,9 +748,7 @@
 			"library": "4D",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "false",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "false"
 			},
 			"last_commit": 1725525243
 		},
@@ -790,9 +786,7 @@
 			"category": "Python",
 			"challenges": {
 				"HTTP-01": "false",
-				"DNS-01": "true",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "true"
 			},
 			"comments": "PKI for internet server infrastructure, supporting distribution of certs, FreeBSD jails, DNS DANE support",
 			"last_commit": 1597158843
@@ -849,9 +843,7 @@
 			"category": "Node.js",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "false",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "false"
 			},
 			"comments": "(Express middleware for storing certificates securely on Azure Key Vault)",
 			"last_commit": 1610261413
@@ -863,9 +855,7 @@
 			"comments": "(ACME V2 integration with acme_certificate module. Supports multiple providers for challenges)",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "true",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "true"
 			},
 			"last_commit": 1751892729
 		},
@@ -898,8 +888,6 @@
 			"challenges": {
 				"HTTP-01": "false",
 				"DNS-01": "true",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false",
 				"TLS-ALPN-01": "false"
 			},
 			"last_commit": 1619846494
@@ -911,9 +899,7 @@
 			"comments": "(Full ACME V2 flow integration for HCL Domino\u2122 servers)",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "true",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "true"
 			}
 		},
 		{
@@ -931,9 +917,7 @@
 			"category": "Kubernetes",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "false",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "false"
 			},
 			"last_commit": 1753655362
 		},
@@ -944,9 +928,7 @@
 			"comments": "(The simplest ACME Issuer for Azure Key Vault)",
 			"challenges": {
 				"HTTP-01": "false",
-				"DNS-01": "true",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "true"
 			},
 			"last_commit": 1736400502
 		},
@@ -957,9 +939,7 @@
 			"comments": "(Server to centrally manage and serve certificates)",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "true",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "true"
 			},
 			"last_commit": 1752099923
 		},
@@ -986,9 +966,7 @@
 			"category": "Node.js",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "false",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "false"
 			},
 			"comments": "(Easy to configure SSL Web Server for development or production)",
 			"last_commit": 1735365148
@@ -1005,9 +983,7 @@
 			"category": "Rust",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "false",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "false"
 			},
 			"comments": "Easy certificate tool: helpful diagnostics, no requirements, no installation needed",
 			"last_commit": 1734969060
@@ -1037,9 +1013,7 @@
 			"comments": "Automatically provisions and renews TLS certificates from Let\u2019s Encrypt on Node.js https servers",
 			"challenges": {
 				"HTTP-01": "true",
-				"DNS-01": "false",
-				"TLS-SNI-01": "false",
-				"TLS-SNI-02": "false"
+				"DNS-01": "false"
 			},
 			"last_commit": 1748361438
 		},

--- a/data/clients.json
+++ b/data/clients.json
@@ -263,14 +263,6 @@
 			}
 		},
 		{
-			"name": "acmetool",
-			"url": "https://github.com/hlandau/acmetool",
-			"category": "Go",
-			"library": "Go",
-			"library_url": "https://github.com/hlandau/acmeapi",
-			"last_commit": 1673175643
-		},
-		{
 			"name": "Lets-proxy2",
 			"url": "https://github.com/rekby/lets-proxy2",
 			"category": "Go",
@@ -310,12 +302,6 @@
 				"HTTP-01": "true"
 			},
 			"last_commit": 1734020437
-		},
-		{
-			"name": "lua-resty-auto-ssl",
-			"url": "https://github.com/GUI/lua-resty-auto-ssl",
-			"category": "nginx",
-			"last_commit": 1611444054
 		},
 		{
 			"name": "Angie ACME module",
@@ -359,24 +345,6 @@
 			"last_commit": 1731400480
 		},
 		{
-			"name": "Greenlock for Express.js",
-			"url": "https://git.coolaj86.com/coolaj86/greenlock-express.js",
-			"category": "Node.js",
-			"last_commit": 1596518306
-		},
-		{
-			"name": "Greenlock for node.js",
-			"url": "https://git.coolaj86.com/coolaj86/greenlock.js",
-			"library": "Node.js",
-			"last_commit": 1596518079
-		},
-		{
-			"name": "openshift-acme",
-			"url": "https://github.com/tnozicka/openshift-acme",
-			"category": "OpenShift",
-			"last_commit": 1618242901
-		},
-		{
 			"name": "Crypt::LE (previously ZeroSSL project)",
 			"url": "https://github.com/do-know/Crypt-LE",
 			"category": "Windows / IIS",
@@ -412,12 +380,6 @@
 			"last_commit": 1750172572
 		},
 		{
-			"name": "simp_le",
-			"url": "https://github.com/zenhack/simp_le",
-			"category": "Python",
-			"last_commit": 1681761430
-		},
-		{
 			"name": "acmebot",
 			"url": "https://github.com/plinss/acmebot",
 			"category": "Python",
@@ -450,18 +412,6 @@
 			"last_commit": 1755010866
 		},
 		{
-			"name": "acme-distributed",
-			"url": "https://github.com/jannfis/acme-distributed",
-			"category": "Ruby",
-			"last_commit": 1595248357
-		},
-		{
-			"name": "Combine-acme: Generate and upload crt to CloudFlare(enterprise) and GCP.",
-			"url": "https://gitlab.com/6318613/combine-acme",
-			"category": "Ruby",
-			"last_commit": 1590509247
-		},
-		{
 			"name": "win-acme",
 			"url": "https://www.win-acme.com",
 			"category": "Windows / IIS",
@@ -478,26 +428,11 @@
 			"last_commit": 1755926018
 		},
 		{
-			"name": "Certes",
-			"url": "https://github.com/fszlin/certes",
-			"category": "Windows / IIS",
-			"library": ".NET",
-			"library_comments": "(.NET Standard)",
-			"last_commit": 1672779593
-		},
-		{
 			"name": "ACME-PS",
 			"url": "https://github.com/PKISharp/ACMESharpCore-PowerShell",
 			"category": "Windows / IIS",
 			"category_comments": "(PowerShell)",
 			"last_commit": 1718865358
-		},
-		{
-			"name": "PKISharp/ACMESharpCore",
-			"url": "https://github.com/PKISharp/acmesharpcore",
-			"library": ".NET",
-			"library_comments": "(.NET Standard)",
-			"last_commit": 1653344648
 		},
 		{
 			"name": "DelphiACME",
@@ -562,22 +497,10 @@
 			}
 		},
 		{
-			"name": "LEClient PHP library",
-			"url": "https://github.com/yourivw/LEClient",
-			"library": "PHP",
-			"last_commit": 1624186302
-		},
-		{
 			"name": "le-acme2-php library",
 			"url": "https://github.com/fbett/le-acme2-php",
 			"library": "PHP",
 			"last_commit": 1733958006
-		},
-		{
-			"name": "stonemax/acme2 PHP client",
-			"url": "https://github.com/stonemax/acme2",
-			"library": "PHP",
-			"last_commit": 1558079364
 		},
 		{
 			"name": "itr-acme-client PHP library",
@@ -654,13 +577,6 @@
 			"last_commit": 1755595500
 		},
 		{
-			"name": "Azure WebApp SSL Manager",
-			"url": "https://github.com/n3wt0n/AzureWebAppSSLManager",
-			"category": "Microsoft Azure",
-			"comments": "(Serverless, Compatible with any App Service, requires Azure DNS)",
-			"last_commit": 1622446679
-		},
-		{
 			"name": "App Service Acmebot",
 			"url": "https://github.com/shibayan/appservice-acmebot",
 			"category": "Microsoft Azure",
@@ -679,12 +595,6 @@
 			"url": "https://github.com/acmephp/acmephp",
 			"category": "PHP",
 			"last_commit": 1732189591
-		},
-		{
-			"name": "Acme PHP Library",
-			"url": "https://github.com/acmephp/core",
-			"library": "PHP",
-			"last_commit": 1654018600
 		},
 		{
 			"name": "lua-resty-acme",
@@ -781,17 +691,6 @@
 			"comments": "(GUI, CLI)"
 		},
 		{
-			"name": "serverPKI",
-			"url": "https://github.com/mc3/serverPKI",
-			"category": "Python",
-			"challenges": {
-				"HTTP-01": "false",
-				"DNS-01": "true"
-			},
-			"comments": "PKI for internet server infrastructure, supporting distribution of certs, FreeBSD jails, DNS DANE support",
-			"last_commit": 1597158843
-		},
-		{
 			"name": "acmetk",
 			"url": "https://github.com/noahkw/acmetk",
 			"category": "Python",
@@ -838,17 +737,6 @@
 			"last_commit": 1739033891
 		},
 		{
-			"name": "acme-http-01-azure-key-vault-middleware",
-			"url": "https://github.com/compulim/acme-http-01-azure-key-vault-middleware",
-			"category": "Node.js",
-			"challenges": {
-				"HTTP-01": "true",
-				"DNS-01": "false"
-			},
-			"comments": "(Express middleware for storing certificates securely on Azure Key Vault)",
-			"last_commit": 1610261413
-		},
-		{
 			"name": "Ansible collection: acme",
 			"url": "https://github.com/T-Systems-MMS/ansible-collection-acme",
 			"category": "Configuration management tools",
@@ -878,19 +766,6 @@
 				"TLS-ALPN-01": "true"
 			},
 			"category": "Configuration management tools"
-		},
-		{
-			"name": "wdfcert.sh",
-			"url": "https://github.com/WolfWings/wdfcert.sh",
-			"category": "Bash",
-			"comments": "(Only supports DNS-01 challenges and ECDSA-384 bit keys for both accounts and certificates, native Joker DNS support including wildcard plus root domain support for single-TXT-record DNS providers)",
-			"library": "Perl",
-			"challenges": {
-				"HTTP-01": "false",
-				"DNS-01": "true",
-				"TLS-ALPN-01": "false"
-			},
-			"last_commit": 1619846494
 		},
 		{
 			"name": "HCL Domino",

--- a/data/clients.json
+++ b/data/clients.json
@@ -163,7 +163,8 @@
 			"name": "GetSSL",
 			"url": "https://github.com/srvrco/getssl",
 			"category": "Bash",
-			"comments": "(bash, also automates certs on remote hosts via ssh)"
+			"comments": "(bash, also automates certs on remote hosts via ssh)",
+			"last_commit": 1752653548
 		},
 		{
 			"name": "acme.sh",
@@ -172,7 +173,8 @@
 			"comments": "(Compatible to bash, dash and sh)",
 			"challenges": {
 				"TLS-ALPN-01": "true"
-			}
+			},
+			"last_commit": 1750882526
 		},
 		{
 			"name": "dehydrated",
@@ -181,7 +183,8 @@
 			"comments": "(Compatible to bash and zsh)",
 			"challenges": {
 				"TLS-ALPN-01": "true"
-			}
+			},
+			"last_commit": 1751706825
 		},
 		{
 			"name": "acme",
@@ -194,7 +197,8 @@
 				"DNS-01": "true",
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
-			}
+			},
+			"last_commit": 1706753440
 		},
 		{
 			"name": "OpenBSD acme-client",
@@ -205,12 +209,14 @@
 			"name": "acme-lw",
 			"url": "https://github.com/jmccl/acme-lw",
 			"category": "C++",
-			"library": "C++"
+			"library": "C++",
+			"last_commit": 1753072399
 		},
 		{
 			"name": "certificaat",
 			"url": "https://github.com/danielsz/certificaat",
-			"category": "Clojure"
+			"category": "Clojure",
+			"last_commit": 1695879839
 		},
 		{
 			"name": "Crypt::LE",
@@ -265,13 +271,15 @@
 			"url": "https://github.com/hlandau/acmetool",
 			"category": "Go",
 			"library": "Go",
-			"library_url": "https://github.com/hlandau/acmeapi"
+			"library_url": "https://github.com/hlandau/acmeapi",
+			"last_commit": 1673175643
 		},
 		{
 			"name": "Lets-proxy2",
 			"url": "https://github.com/rekby/lets-proxy2",
 			"category": "Go",
-			"comments": "(Reverse proxy to handle https/tls)"
+			"comments": "(Reverse proxy to handle https/tls)",
+			"last_commit": 1712003998
 		},
 		{
 			"name": "autocert",
@@ -289,7 +297,8 @@
 		{
 			"name": "PJAC",
 			"url": "https://github.com/porunov/acme_client",
-			"category": "Java"
+			"category": "Java",
+			"last_commit": 1704758849
 		},
 		{
 			"name": "ManageEngine Key Manager Plus",
@@ -303,12 +312,14 @@
 			"comments": "JavaScript library compatible with the 'ngx_http_js_module' runtime (NJS), allows for the automatic issue of TLS/SSL certificates for NGINX without restarts",
 			"challenges": {
 				"HTTP-01": "true"
-			}
+			},
+			"last_commit": 1734020437
 		},
 		{
 			"name": "lua-resty-auto-ssl",
 			"url": "https://github.com/GUI/lua-resty-auto-ssl",
-			"category": "nginx"
+			"category": "nginx",
+			"last_commit": 1611444054
 		},
 		{
 			"name": "Angie ACME module",
@@ -322,12 +333,14 @@
 			"url": "https://github.com/nginx/nginx-acme",
 			"category": "nginx",
 			"comments": "built-in ACME module from upstream nginx developers",
-			"acme_v2": "true"
+			"acme_v2": "true",
+			"last_commit": 1756222263
 		},
 		{
 			"name": "acme-nginx",
 			"url": "https://github.com/kshcherban/acme-nginx",
-			"category": "nginx"
+			"category": "nginx",
+			"last_commit": 1748437818
 		},
 		{
 			"name": "docker-openresty",
@@ -348,27 +361,32 @@
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true"
-			}
+			},
+			"last_commit": 1731400480
 		},
 		{
 			"name": "Greenlock for Express.js",
 			"url": "https://git.coolaj86.com/coolaj86/greenlock-express.js",
-			"category": "Node.js"
+			"category": "Node.js",
+			"last_commit": 1596518306
 		},
 		{
 			"name": "Greenlock for node.js",
 			"url": "https://git.coolaj86.com/coolaj86/greenlock.js",
-			"library": "Node.js"
+			"library": "Node.js",
+			"last_commit": 1596518079
 		},
 		{
 			"name": "openshift-acme",
 			"url": "https://github.com/tnozicka/openshift-acme",
-			"category": "OpenShift"
+			"category": "OpenShift",
+			"last_commit": 1618242901
 		},
 		{
 			"name": "Crypt::LE (previously ZeroSSL project)",
 			"url": "https://github.com/do-know/Crypt-LE",
-			"category": "Windows / IIS"
+			"category": "Windows / IIS",
+			"last_commit": 1717259806
 		},
 		{
 			"name": "Crypt::LE",
@@ -379,7 +397,8 @@
 		{
 			"name": "kelunik/acme-client",
 			"url": "https://github.com/kelunik/acme-client",
-			"category": "PHP"
+			"category": "PHP",
+			"last_commit": 1754767672
 		},
 		{
 			"name": "FreeSSL.tech Auto",
@@ -389,27 +408,32 @@
 		{
 			"name": "Yet another ACME client",
 			"url": "https://github.com/afosto/yaac",
-			"category": "PHP"
+			"category": "PHP",
+			"last_commit": 1743168770
 		},
 		{
 			"name": "ACME Tiny",
 			"url": "https://github.com/diafygi/acme-tiny",
-			"category": "Python"
+			"category": "Python",
+			"last_commit": 1750172572
 		},
 		{
 			"name": "simp_le",
 			"url": "https://github.com/zenhack/simp_le",
-			"category": "Python"
+			"category": "Python",
+			"last_commit": 1681761430
 		},
 		{
 			"name": "acmebot",
 			"url": "https://github.com/plinss/acmebot",
-			"category": "Python"
+			"category": "Python",
+			"last_commit": 1755050228
 		},
 		{
 			"name": "sewer",
 			"url": "https://github.com/komuw/sewer",
-			"category": "Python"
+			"category": "Python",
+			"last_commit": 1732464692
 		},
 		{
 			"name": "acme-dns-tiny",
@@ -421,23 +445,27 @@
 			"name": "Automatoes",
 			"url": "https://github.com/candango/automatoes",
 			"category": "Python",
-			"comments": "ACME V2 ManuaLE replacement with new features"
+			"comments": "ACME V2 ManuaLE replacement with new features",
+			"last_commit": 1750650174
 		},
 		{
 			"name": "unixcharles/acme-client",
 			"url": "https://github.com/unixcharles/acme-client",
 			"category": "Ruby",
-			"library": "Ruby"
+			"library": "Ruby",
+			"last_commit": 1755010866
 		},
 		{
 			"name": "acme-distributed",
 			"url": "https://github.com/jannfis/acme-distributed",
-			"category": "Ruby"
+			"category": "Ruby",
+			"last_commit": 1595248357
 		},
 		{
 			"name": "Combine-acme: Generate and upload crt to CloudFlare(enterprise) and GCP.",
 			"url": "https://gitlab.com/6318613/combine-acme",
-			"category": "Ruby"
+			"category": "Ruby",
+			"last_commit": 1590509247
 		},
 		{
 			"name": "win-acme",
@@ -452,37 +480,43 @@
 			"name": "Posh-ACME",
 			"url": "https://github.com/rmbolger/Posh-ACME",
 			"category": "Windows / IIS",
-			"category_comments": "(PowerShell)"
+			"category_comments": "(PowerShell)",
+			"last_commit": 1755926018
 		},
 		{
 			"name": "Certes",
 			"url": "https://github.com/fszlin/certes",
 			"category": "Windows / IIS",
 			"library": ".NET",
-			"library_comments": "(.NET Standard)"
+			"library_comments": "(.NET Standard)",
+			"last_commit": 1672779593
 		},
 		{
 			"name": "ACME-PS",
 			"url": "https://github.com/PKISharp/ACMESharpCore-PowerShell",
 			"category": "Windows / IIS",
-			"category_comments": "(PowerShell)"
+			"category_comments": "(PowerShell)",
+			"last_commit": 1718865358
 		},
 		{
 			"name": "PKISharp/ACMESharpCore",
 			"url": "https://github.com/PKISharp/acmesharpcore",
 			"library": ".NET",
-			"library_comments": "(.NET Standard)"
+			"library_comments": "(.NET Standard)",
+			"last_commit": 1653344648
 		},
 		{
 			"name": "DelphiACME",
 			"url": "https://github.com/tothpaul/DelphiACME",
 			"library": "Delphi",
-			"comments": "(Embarcadero Delphi)"
+			"comments": "(Embarcadero Delphi)",
+			"last_commit": 1699259278
 		},
 		{
 			"name": "eggsampler/acme",
 			"url": "https://github.com/eggsampler/acme",
-			"library": "Go"
+			"library": "Go",
+			"last_commit": 1755935011
 		},
 		{
 			"name": "ACME4J",
@@ -490,34 +524,40 @@
 			"library": "Java",
 			"challenges": {
 				"TLS-ALPN-01": "true"
-			}
+			},
+			"last_commit": 1755333811
 		},
 		{
 			"name": "kelunik/acme",
 			"url": "https://github.com/kelunik/acme",
-			"library": "PHP"
+			"library": "PHP",
+			"last_commit": 1754766452
 		},
 		{
 			"name": "kelunik/acme-client",
 			"url": "https://github.com/kelunik/acme-client",
 			"category": "Windows / IIS",
-			"comments": "(PHP)"
+			"comments": "(PHP)",
+			"last_commit": 1754767672
 		},
 		{
 			"name": "ACMECert PHP library",
 			"url": "https://github.com/skoerfgen/ACMECert",
-			"library": "PHP"
+			"library": "PHP",
+			"last_commit": 1753557316
 		},
 		{
 			"name": "txacme",
 			"url": "https://github.com/mithrandi/txacme",
 			"library": "Python",
-			"comments": "(Twisted client for Python 2 / 3)"
+			"comments": "(Twisted client for Python 2 / 3)",
+			"last_commit": 1754406886
 		},
 		{
 			"name": "publishlab/node-acme-client",
 			"url": "https://github.com/publishlab/node-acme-client",
-			"library": "Node.js"
+			"library": "Node.js",
+			"last_commit": 1721135886
 		},
 		{
 			"name": "Net::ACME2",
@@ -530,22 +570,26 @@
 		{
 			"name": "LEClient PHP library",
 			"url": "https://github.com/yourivw/LEClient",
-			"library": "PHP"
+			"library": "PHP",
+			"last_commit": 1624186302
 		},
 		{
 			"name": "le-acme2-php library",
 			"url": "https://github.com/fbett/le-acme2-php",
-			"library": "PHP"
+			"library": "PHP",
+			"last_commit": 1733958006
 		},
 		{
 			"name": "stonemax/acme2 PHP client",
 			"url": "https://github.com/stonemax/acme2",
-			"library": "PHP"
+			"library": "PHP",
+			"last_commit": 1558079364
 		},
 		{
 			"name": "itr-acme-client PHP library",
 			"url": "https://github.com/ITronic/itr-acme-client",
-			"category": "PHP"
+			"category": "PHP",
+			"last_commit": 1716657486
 		},
 		{
 			"name": "Certify The Web (Windows)",
@@ -563,28 +607,33 @@
 		{
 			"name": "WinCertes Windows client",
 			"url": "https://github.com/aloopkin/WinCertes",
-			"category": "Windows / IIS"
+			"category": "Windows / IIS",
+			"last_commit": 1699896742
 		},
 		{
 			"name": "uacme",
 			"url": "https://github.com/ndilieto/uacme/",
-			"category": "C"
+			"category": "C",
+			"last_commit": 1752945862
 		},
 		{
 			"name": "ACMEd",
 			"url": "https://github.com/breard-r/acmed",
-			"category": "Rust"
+			"category": "Rust",
+			"last_commit": 1755965014
 		},
 		{
 			"name": "certman-operator",
 			"url": "https://github.com/openshift/certman-operator",
-			"category": "OpenShift"
+			"category": "OpenShift",
+			"last_commit": 1756224347
 		},
 		{
 			"name": "acme-lw-d",
 			"url": "https://github.com/cschlote/acme-lw-d",
 			"category": "D",
-			"library": "D"
+			"library": "D",
+			"last_commit": 1721591385
 		},
 		{
 			"name": "acme-client-portable",
@@ -607,35 +656,41 @@
 			"name": "mod_md",
 			"url": "https://github.com/icing/mod_md",
 			"comments": "Separate, more frequent releases of the Apache module.",
-			"category": "C"
+			"category": "C",
+			"last_commit": 1755595500
 		},
 		{
 			"name": "Azure WebApp SSL Manager",
 			"url": "https://github.com/n3wt0n/AzureWebAppSSLManager",
 			"category": "Microsoft Azure",
-			"comments": "(Serverless, Compatible with any App Service, requires Azure DNS)"
+			"comments": "(Serverless, Compatible with any App Service, requires Azure DNS)",
+			"last_commit": 1622446679
 		},
 		{
 			"name": "App Service Acmebot",
 			"url": "https://github.com/shibayan/appservice-acmebot",
 			"category": "Microsoft Azure",
-			"comments": "(Compatible to Azure Web Apps / Functions / Web App for Containers)"
+			"comments": "(Compatible to Azure Web Apps / Functions / Web App for Containers)",
+			"last_commit": 1756155435
 		},
 		{
 			"name": "Key Vault Acmebot",
 			"url": "https://github.com/shibayan/keyvault-acmebot",
 			"category": "Microsoft Azure",
-			"comments": "(Works with Azure Key Vault Certificates)"
+			"comments": "(Works with Azure Key Vault Certificates)",
+			"last_commit": 1756130953
 		},
 		{
 			"name": "Acme PHP",
 			"url": "https://github.com/acmephp/acmephp",
-			"category": "PHP"
+			"category": "PHP",
+			"last_commit": 1732189591
 		},
 		{
 			"name": "Acme PHP Library",
 			"url": "https://github.com/acmephp/core",
-			"library": "PHP"
+			"library": "PHP",
+			"last_commit": 1654018600
 		},
 		{
 			"name": "lua-resty-acme",
@@ -643,29 +698,34 @@
 			"category": "nginx",
 			"challenges": {
 				"TLS-ALPN-01": "true"
-			}
+			},
+			"last_commit": 1732900409
 		},
 		{
 			"name": "acertmgr",
 			"url": "https://github.com/moepman/acertmgr",
-			"category": "Python"
+			"category": "Python",
+			"last_commit": 1755979683
 		},
 		{
 			"name": "acme-cert-tool",
 			"url": "https://github.com/mk-fg/acme-cert-tool",
-			"category": "Python"
+			"category": "Python",
+			"last_commit": 1753003264
 		},
 		{
 			"name": "ght-acme.sh",
 			"url": "https://github.com/bruncsak/ght-acme.sh",
 			"category": "Bash",
-			"comments": "(batch update of http-01 and dns-01 challenges is available)"
+			"comments": "(batch update of http-01 and dns-01 challenges is available)",
+			"last_commit": 1740420193
 		},
 		{
 			"name": "GetCert2",
 			"url": "https://github.com/GeorgeSchiro/GetCert2",
 			"category": "Windows / IIS",
-			"comments": "(simple GUI - .Net, C#, WPF, WCF)"
+			"comments": "(simple GUI - .Net, C#, WPF, WCF)",
+			"last_commit": 1740276187
 		},
 		{
 			"name": "esp32-acme-client",
@@ -678,7 +738,8 @@
 			"name": "bacme",
 			"url": "https://gitlab.com/sinclair2/bacme",
 			"category": "Bash",
-			"comments": "(simple yet complete scripting of certificate generation)"
+			"comments": "(simple yet complete scripting of certificate generation)",
+			"last_commit": 1721236113
 		},
 		{
 			"name": "CertMatica",
@@ -696,12 +757,14 @@
 				"DNS-01": "false",
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
-			}
+			},
+			"last_commit": 1725525243
 		},
 		{
 			"name": "RW ACME client",
 			"url": "https://github.com/RogierW/rw-acme-client",
-			"category": "PHP"
+			"category": "PHP",
+			"last_commit": 1749640654
 		},
 		{
 			"name": "cert-manager",
@@ -710,7 +773,8 @@
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true"
-			}
+			},
+			"last_commit": 1756255143
 		},
 		{
 			"name": "Certera",
@@ -734,7 +798,8 @@
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
 			},
-			"comments": "PKI for internet server infrastructure, supporting distribution of certs, FreeBSD jails, DNS DANE support"
+			"comments": "PKI for internet server infrastructure, supporting distribution of certs, FreeBSD jails, DNS DANE support",
+			"last_commit": 1597158843
 		},
 		{
 			"name": "acmetk",
@@ -743,13 +808,15 @@
 			"challenges": {
 				"DNS-01": "true"
 			},
-			"comments": "acmetk is an ACMEv2 proxy to centralize certificate requests and challenges within an organisation and direct them using a single account to Let's Encrypt or other ACMEv2 capable CA's."
+			"comments": "acmetk is an ACMEv2 proxy to centralize certificate requests and challenges within an organisation and direct them using a single account to Let's Encrypt or other ACMEv2 capable CA's.",
+			"last_commit": 1750083158
 		},
 		{
 			"name": "ACMEz",
 			"url": "https://github.com/mholt/acmez",
 			"category": "Go",
-			"library": "Go"
+			"library": "Go",
+			"last_commit": 1756227889
 		},
 		{
 			"name": "Step CLI",
@@ -760,7 +827,8 @@
 			"name": "J8a",
 			"url": "https://github.com/simonmittag/j8a",
 			"category": "Go",
-			"comments": "(Reverse proxy for JSON APIs with auto-renewing TLS 1.3)"
+			"comments": "(Reverse proxy for JSON APIs with auto-renewing TLS 1.3)",
+			"last_commit": 1745968592
 		},
 		{
 			"name": "CycloneACME",
@@ -776,7 +844,8 @@
 		{
 			"name": "acme-redirect",
 			"url": "https://github.com/kpcyrd/acme-redirect",
-			"category": "Rust"
+			"category": "Rust",
+			"last_commit": 1739033891
 		},
 		{
 			"name": "acme-http-01-azure-key-vault-middleware",
@@ -788,7 +857,8 @@
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
 			},
-			"comments": "(Express middleware for storing certificates securely on Azure Key Vault)"
+			"comments": "(Express middleware for storing certificates securely on Azure Key Vault)",
+			"last_commit": 1610261413
 		},
 		{
 			"name": "Ansible collection: acme",
@@ -801,7 +871,8 @@
 				"DNS-01": "true",
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
-			}
+			},
+			"last_commit": 1751892729
 		},
 		{
 			"name": "Pulumi ACME Provider",
@@ -836,7 +907,8 @@
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false",
 				"TLS-ALPN-01": "false"
-			}
+			},
+			"last_commit": 1619846494
 		},
 		{
 			"name": "HCL Domino",
@@ -868,7 +940,8 @@
 				"DNS-01": "false",
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
-			}
+			},
+			"last_commit": 1753655362
 		},
 		{
 			"name": "Az-Acme",
@@ -880,7 +953,8 @@
 				"DNS-01": "true",
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
-			}
+			},
+			"last_commit": 1736400502
 		},
 		{
 			"name": "Cert Warden",
@@ -893,7 +967,8 @@
 				"DNS-01": "true",
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
-			}
+			},
+			"last_commit": 1752099923
 		},
 		{
 			"name": "acme-bot",
@@ -904,7 +979,8 @@
 				"HTTP-01": "true",
 				"DNS-01": "true",
 				"TLS-ALPN-01": "true"
-			}
+			},
+			"last_commit": 1697144891
 		},
 		{
 			"name": "instant-acme",
@@ -922,7 +998,8 @@
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
 			},
-			"comments": "(Easy to configure SSL Web Server for development or production)"
+			"comments": "(Easy to configure SSL Web Server for development or production)",
+			"last_commit": 1735365148
 		},
 		{
 			"name": "rustls-acme",
@@ -940,7 +1017,8 @@
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
 			},
-			"comments": "Easy certificate tool: helpful diagnostics, no requirements, no installation needed"
+			"comments": "Easy certificate tool: helpful diagnostics, no requirements, no installation needed",
+			"last_commit": 1734969060
 		},
 		{
 			"name": "tokio-rustls-acme",
@@ -970,13 +1048,15 @@
 				"DNS-01": "false",
 				"TLS-SNI-01": "false",
 				"TLS-SNI-02": "false"
-			}
+			},
+			"last_commit": 1748361438
 		},
 		{
 			"name": "Certimate",
 			"url": "https://github.com/certimate-go/certimate",
 			"category": "Go",
-			"comments": "manage certificates for multiple platforms with a visual workflow"
+			"comments": "manage certificates for multiple platforms with a visual workflow",
+			"last_commit": 1756184811
 		},
 		{
 			"name": "Certimate",

--- a/data/clients.json
+++ b/data/clients.json
@@ -237,14 +237,12 @@
 			"name": "docker-nginx",
 			"comment": "Chinese language",
 			"url": "https://hub.docker.com/r/xiaojun207/nginx",
-			"acme_v2": "true",
 			"category": "Docker"
 		},
 		{
 			"name": "docker-openresty",
 			"comment": "Chinese language",
 			"url": "https://hub.docker.com/r/xiaojun207/openresty",
-			"acme_v2": "true",
 			"category": "Docker"
 		},
 		{
@@ -325,15 +323,13 @@
 			"name": "Angie ACME module",
 			"url": "https://en.angie.software/angie/docs/configuration/modules/http/http_acme/",
 			"category": "nginx",
-			"comments": "built-in module for Angie server, no extra dependencies, simple configuration, reload-less auto retrieval",
-			"acme_v2": "true"
+			"comments": "built-in module for Angie server, no extra dependencies, simple configuration, reload-less auto retrieval"
 		},
 		{
 			"name": "ngx_http_acme_module",
 			"url": "https://github.com/nginx/nginx-acme",
 			"category": "nginx",
 			"comments": "built-in ACME module from upstream nginx developers",
-			"acme_v2": "true",
 			"last_commit": 1756222263
 		},
 		{
@@ -600,7 +596,7 @@
 			"name": "Ansible acme_certificate module",
 			"url": "https://docs.ansible.com/ansible/latest/collections/community/crypto/acme_certificate_module.html",
 			"challenges": {
-				"TLS-ALPN-01": "ansible >= 2.7"
+				"TLS-ALPN-01": "true"
 			},
 			"category": "Configuration management tools"
 		},
@@ -865,7 +861,6 @@
 			"url": "https://github.com/T-Systems-MMS/ansible-collection-acme",
 			"category": "Configuration management tools",
 			"comments": "(ACME V2 integration with acme_certificate module. Supports multiple providers for challenges)",
-			"acme_v2": "true",
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true",
@@ -877,11 +872,10 @@
 		{
 			"name": "Pulumi ACME Provider",
 			"url": "https://www.pulumi.com/registry/packages/acme/",
-			"acme_v2": "pulumi-acme >= 0.0.1",
 			"challenges": {
-				"HTTP-01": "pulumi-acme >= 0.0.1",
-				"DNS-01": "pulumi-acme >= 0.0.1",
-				"TLS-ALPN-01": "pulumi-acme >= 0.0.1"
+				"HTTP-01": "true",
+				"DNS-01": "true",
+				"TLS-ALPN-01": "true"
 			},
 			"category": "Configuration management tools"
 		},
@@ -889,9 +883,9 @@
 			"name": "Terraform ACME Provider",
 			"url": "https://registry.terraform.io/providers/vancluever/acme/latest",
 			"challenges": {
-				"HTTP-01": "terraform-provider-acme >= 2.4.0",
-				"DNS-01": "terraform-provider-acme >= 1.0.0",
-				"TLS-ALPN-01": "terraform-provider-acme >= 2.4.0"
+				"HTTP-01": "true",
+				"DNS-01": "true",
+				"TLS-ALPN-01": "true"
 			},
 			"category": "Configuration management tools"
 		},
@@ -961,7 +955,6 @@
 			"url": "https://github.com/gregtwallace/certwarden",
 			"category": "Go",
 			"comments": "(Server to centrally manage and serve certificates)",
-			"acme_v2": "true",
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true",
@@ -974,7 +967,6 @@
 			"name": "acme-bot",
 			"url": "https://git.serenity-island.net/sie-foss/acme-bot",
 			"category": "Node.js",
-			"acme_v2": "true",
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true",


### PR DESCRIPTION
This PR includes commits to manually incorporate data from all pending client PRs (those tagged as client-options, at https://github.com/letsencrypt/website/pulls?q=is%3Apr+is%3Aopen+label%3Aclient-options).

It also includes a new Python script to add the last commit date to each client based its detected git repository URL, if any. That script has been run once, and the results are also included in the PR.

This data can be used to split out clients that are no longer being maintained into a separate JSON file, or to hide them on the Let's Encrypt site.

I added an additional script that uses the data to entirely remove such clients from the JSON file.