### PR TITLE
Host cp.letsencrypt.org and cps.letsencrypt.org

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -328,13 +328,13 @@ status = 301
 force = true
 
 [[redirects]]
-from = "https://cp-test.letsencrypt.org/*"
+from = "https://cp.letsencrypt.org/*"
 to = "https://letsencrypt.org/documents/isrg-cp-cps-v5.9/"
 status = 302
 force = true
 
 [[redirects]]
-from = "https://cps-test.letsencrypt.org/*"
+from = "https://cps.letsencrypt.org/*"
 to = "https://letsencrypt.org/documents/isrg-cp-cps-v5.9/"
 status = 302
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -338,3 +338,15 @@ from = "https://cps.letsencrypt.org/*"
 to = "https://letsencrypt.org/documents/isrg-cp-cps-v5.9/"
 status = 302
 force = true
+
+[[redirects]]
+from = "https://cp.root-x1.letsencrypt.org/*"
+to = "https://letsencrypt.org/documents/isrg-cp-cps-v5.9/"
+status = 302
+force = true
+
+[[redirects]]
+from = "https://cps.root-x1.letsencrypt.org/*"
+to = "https://letsencrypt.org/documents/isrg-cp-cps-v5.9/"
+status = 302
+force = true


### PR DESCRIPTION
The -test redirects worked well, so move the real redirects here.
