### PR TITLE
[en] update chain section to use new Intermediate CAs

### DIFF
--- a/content/en/certificates.md
+++ b/content/en/certificates.md
@@ -2,7 +2,7 @@
 title: Chains of Trust
 linkTitle: Chains of Trust (Root and Intermediate Certificates)
 slug: certificates
-lastmod: 2025-08-19
+lastmod: 2025-09-03
 show_lastmod: 1
 ---
 


### PR DESCRIPTION
looks like the chain section wasn't updated when the new Intermediate CAs where added