### PR TITLE
Add haproxy to clients.json

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -90,6 +90,10 @@
 			"url": "https://about.gitlab.com"
 		},
 		{
+			"name": "HAproxy",
+			"url": "https://docs.haproxy.org/3.2/configuration.html#12.8"
+		},
+		{
 			"name": "ISPConfig",
 			"url": "https://www.ispconfig.org/"
 		},


### PR DESCRIPTION
Haproxy 3.2 and later supports generating certificates with ACME protocol.
