### PR TITLE
Change certification practices to certification practice

### DIFF
--- a/i18n/am.toml
+++ b/i18n/am.toml
@@ -151,8 +151,8 @@ other = "Window Start"
 [certificate_transparency_window_end]
 other = "Window End"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Overview"

--- a/i18n/ca.toml
+++ b/i18n/ca.toml
@@ -151,8 +151,8 @@ other = "Window Start"
 [certificate_transparency_window_end]
 other = "Window End"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Vista general"

--- a/i18n/cs.toml
+++ b/i18n/cs.toml
@@ -151,7 +151,7 @@ other = "Začátek okna"
 [certificate_transparency_window_end]
 other = "Konec okna"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Prohlášení o certifikačních postupech"
 
 [overview]

--- a/i18n/da.toml
+++ b/i18n/da.toml
@@ -151,7 +151,7 @@ other = "Visningsvindue Start"
 [certificate_transparency_window_end]
 other = "Visningsvindue Slut"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Erklæring Om Certificeringspraksis"
 
 [overview]

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -151,8 +151,8 @@ other = "Begin des Zeitfensters"
 [certificate_transparency_window_end]
 other = "Ende des Zeitfensters"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Überblick"

--- a/i18n/el.toml
+++ b/i18n/el.toml
@@ -151,7 +151,7 @@ other = "Έναρξη Παραθύρου"
 [certificate_transparency_window_end]
 other = "Τέλος Παραθύρου"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Δήλωση Πρακτικών Πιστοποίησης"
 
 [overview]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -153,8 +153,8 @@ other = "Window Start"
 [certificate_transparency_window_end]
 other = "Window End"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Overview"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -151,8 +151,8 @@ other = "Window Start"
 [certificate_transparency_window_end]
 other = "Window End"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Overview"

--- a/i18n/fa.toml
+++ b/i18n/fa.toml
@@ -155,8 +155,8 @@ other = "Window Start"
 [certificate_transparency_window_end]
 other = "Window End"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Overview"

--- a/i18n/fi.toml
+++ b/i18n/fi.toml
@@ -151,7 +151,7 @@ other = "Aikajakson alku"
 [certificate_transparency_window_end]
 other = "Aikajakson loppu"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Sertifiointikäytäntöjä koskeva lausuma"
 
 [overview]

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -151,7 +151,7 @@ other = "Début de la période"
 [certificate_transparency_window_end]
 other = "Fin de la période"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Déclaration de pratiques de certification"
 
 [overview]

--- a/i18n/he.toml
+++ b/i18n/he.toml
@@ -151,8 +151,8 @@ other = "תחילת החלון"
 [certificate_transparency_window_end]
 other = "סוף החלון"
 
-[certification_practices_statement]
-other = "Certification Practices Statement - הצהרת תרגולות ניהול אישורים"
+[certification_practice_statement]
+other = "Certification Practice Statement - הצהרת תרגולות ניהול אישורים"
 
 [overview]
 other = "סקירה"

--- a/i18n/hr.toml
+++ b/i18n/hr.toml
@@ -151,7 +151,7 @@ other = "Početak perioda"
 [certificate_transparency_window_end]
 other = "Kraj perioda"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Izjava o certifikacijskim praksama"
 
 [overview]

--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -151,7 +151,7 @@ other = "Időszak kezdete"
 [certificate_transparency_window_end]
 other = "Időszak vége"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Nyilatkozat a tanúsítási gyakorlatról"
 
 [overview]

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -151,7 +151,7 @@ other = "Mulai Periode"
 [certificate_transparency_window_end]
 other = "Akhir Periode"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Pernyataan Praktik Sertifikasi"
 
 [overview]

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -151,7 +151,7 @@ other = "Inizio finestra"
 [certificate_transparency_window_end]
 other = "Fine finestra"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Dichiarazione sulle pratiche di certificazione"
 
 [overview]

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -151,8 +151,8 @@ other = "ウィンドウの起動"
 [certificate_transparency_window_end]
 other = "ウィンドウの終了"
 
-[certification_practices_statement]
-other = "Certification Practices ステートメント"
+[certification_practice_statement]
+other = "Certification Practice ステートメント"
 
 [overview]
 other = "概要"

--- a/i18n/kaa.toml
+++ b/i18n/kaa.toml
@@ -151,8 +151,8 @@ other = "Baslanıw waqtı"
 [certificate_transparency_window_end]
 other = "Tamamlanıw waqtı"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Overview"

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -151,7 +151,7 @@ other = "창 시작"
 [certificate_transparency_window_end]
 other = "창 종료"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "인증서 관행 지침"
 
 [overview]

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -151,7 +151,7 @@ other = "Początek okna"
 [certificate_transparency_window_end]
 other = "Koniec okna"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Oświadczenie dotyczące praktyk certyfikacyjnych"
 
 [overview]

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -151,7 +151,7 @@ other = "Início da Janela"
 [certificate_transparency_window_end]
 other = "Fim da Janela"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Declaração de Práticas de Certificação"
 
 [overview]

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -151,7 +151,7 @@ other = "Дата начала"
 [certificate_transparency_window_end]
 other = "Дата окончания"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Заявление о практике сертификации"
 
 [overview]

--- a/i18n/si.toml
+++ b/i18n/si.toml
@@ -151,7 +151,7 @@ other = "කවුළුව ආරම්භය"
 [certificate_transparency_window_end]
 other = "කවුළුව අවසානය"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "සහතික කිරීමේ පරිචය ප්‍රකාශය"
 
 [overview]

--- a/i18n/sr.toml
+++ b/i18n/sr.toml
@@ -151,8 +151,8 @@ other = "Window Start"
 [certificate_transparency_window_end]
 other = "Window End"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Overview"

--- a/i18n/sv.toml
+++ b/i18n/sv.toml
@@ -151,8 +151,8 @@ other = "Window Start"
 [certificate_transparency_window_end]
 other = "Window End"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Översikt"

--- a/i18n/ta.toml
+++ b/i18n/ta.toml
@@ -151,7 +151,7 @@ other = "சாளர தொடக்கம்"
 [certificate_transparency_window_end]
 other = "சாளர முடிவு"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "சான்றளிப்பு நடைமுறைகளின் அறிக்கை"
 
 [overview]

--- a/i18n/th.toml
+++ b/i18n/th.toml
@@ -151,7 +151,7 @@ other = "เวลาเริ่มต้น"
 [certificate_transparency_window_end]
 other = "เวลาสิ้นสุด"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "คำแถลงวิธีปฏิบัติด้านการรับรอง"
 
 [overview]

--- a/i18n/tr.toml
+++ b/i18n/tr.toml
@@ -151,7 +151,7 @@ other = "Pencere Başlangıçı"
 [certificate_transparency_window_end]
 other = "Pencere Bitişi"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Sertifika Uygulama Beyanı"
 
 [overview]

--- a/i18n/uk.toml
+++ b/i18n/uk.toml
@@ -151,7 +151,7 @@ other = "Запуск віконця"
 [certificate_transparency_window_end]
 other = "Кінець віконця"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Звіт про практику сертифікації"
 
 [overview]

--- a/i18n/uz.toml
+++ b/i18n/uz.toml
@@ -151,8 +151,8 @@ other = "Oyna boshlanishi"
 [certificate_transparency_window_end]
 other = "Oyna oxiri"
 
-[certification_practices_statement]
-other = "Certification Practices Statement"
+[certification_practice_statement]
+other = "Certification Practice Statement"
 
 [overview]
 other = "Umumiy ko‘rinish"

--- a/i18n/vi.toml
+++ b/i18n/vi.toml
@@ -151,7 +151,7 @@ other = "Khởi động Window"
 [certificate_transparency_window_end]
 other = "Kết thúc Window"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "Tuyên bố Chứng chỉ Thực hành"
 
 [overview]

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -148,7 +148,7 @@ other = "开始窗口"
 [certificate_transparency_window_end]
 other = "结束窗口"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "证书实践声明"
 
 [overview]

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -148,7 +148,7 @@ other = "開始視窗"
 [certificate_transparency_window_end]
 other = "結束視窗"
 
-[certification_practices_statement]
+[certification_practice_statement]
 other = "證書實踐宣告"
 
 [overview]

--- a/themes/le-2021/layouts/shortcodes/docs_index.html
+++ b/themes/le-2021/layouts/shortcodes/docs_index.html
@@ -21,7 +21,7 @@
 
 <ul>
     <li><a href="https://cp.letsencrypt.org">{{ i18n "certificate_policy" }}</a></li>
-    <li><a href="https://cps.letsencrypt.org">{{ i18n "certification_practices_statement" }}</a></li>
+    <li><a href="https://cps.letsencrypt.org">{{ i18n "certification_practice_statement" }}</a></li>
     <li>{{ template "link" (dict "context" . "page" "/docs/staging-environment") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/cert-compat") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/certificates") }}</li>

--- a/themes/le-2025/layouts/shortcodes/docs_index.html
+++ b/themes/le-2025/layouts/shortcodes/docs_index.html
@@ -21,7 +21,7 @@
 
 <ul>
     <li><a href="https://cp.letsencrypt.org">{{ i18n "certificate_policy" }}</a></li>
-    <li><a href="https://cps.letsencrypt.org">{{ i18n "certification_practices_statement" }}</a></li>
+    <li><a href="https://cps.letsencrypt.org">{{ i18n "certification_practice_statement" }}</a></li>
     <li>{{ template "link" (dict "context" . "page" "/docs/staging-environment") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/docs/cert-compat") }}</li>
     <li>{{ template "link" (dict "context" . "page" "/certificates") }}</li>


### PR DESCRIPTION
Several years ago we [changed from the plural Certification Practices Statement to the singular Certification Practice Statement](https://github.com/letsencrypt/cp-cps/pull/174). This PR makes us consistent with _that_. I've only updated the keyword in the translation files, not the actual translated text. That will need further review but I'm not sure of the process because there's no lastmod date in those files.

For posterity:
```
grep -rl Practices | xargs sed -i 's/Practices /Practice /g'
grep -rl practices | xargs sed -i 's/practices_s/practice_s/g
```