### PR TITLE
Add Middleware in the SSL monitoring options list

### DIFF
--- a/content/en/docs/monitoring-options.md
+++ b/content/en/docs/monitoring-options.md
@@ -18,6 +18,7 @@ There are a number of monitoring options out there, including:
 * [Host-Tracker](https://www.host-tracker.com/)
 * [HeyOnCall](https://heyoncall.com/guides/ssl-certificate-expiration-monitoring) (self-hosted scripts)
 * [CertKit](https://www.certkit.io/)
+* [Middleware](https://middleware.io/product/synthetic-monitoring/)
 
 Please note that all of these services are unaffiliated with ISRG / Let's Encrypt.
 


### PR DESCRIPTION
Middleware is an alternative to Datadog but it's less costly and has better UI. It offers to monitor SSL, uptime etc using it's synthetic monitoring feature.

It is a valuable addition to the list for any tech team looking for a observability platform.

Link - https://middleware.io/product/synthetic-monitoring/

# Important

- If this PR updates a file in `content/en` with a `lastmod` field, it **must** be updated.

- If this PR is a translation, please read [TRANSLATION.md](./TRANSLATION.md) first.
