### PR TITLE
Add CoyoteCert to PHP libraries

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2025-09-05",
+	"lastmod": "2026-05-09",
 	"categories": [
 		"Bash",
 		"C",
@@ -917,6 +917,17 @@
 			"challenges": {
 				"HTTP-01": "true",
 				"DNS-01": "true"
+			}
+		},
+		{
+			"name": "CoyoteCert",
+			"url": "https://github.com/blendbyte/CoyoteCert",
+			"category": "PHP",
+			"comments": "Modern PHP 8.3+ ACME v2 client. Supports HTTP-01, DNS-01, TLS-ALPN-01, wildcards, IP SANs (RFC 8738), EAB, ARI (RFC 9773), and ACME profiles.",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "true",
+				"TLS-ALPN-01": "true"
 			}
 		}
 	]


### PR DESCRIPTION
This PR adds CoyoteCert to the PHP libraries section.

**CoyoteCert** is a modern ACME v2 client library for PHP 8.3+. It implements the full RFC 8555 protocol along with RFC 8738 (IP address identifiers) and RFC 9773 (Automatic Renewal Information). The library is framework-agnostic, has no SDK dependencies for its DNS providers, and supports HTTP-01, DNS-01, and TLS-ALPN-01 challenge types.

Built-in providers cover Let's Encrypt, ZeroSSL, Google Trust Services, SSL.com, and Buypass. Six DNS-01 handlers are included out of the box (Cloudflare, Hetzner, DigitalOcean, ClouDNS, Route53, and shell/exec).

- Repository: https://github.com/blendbyte/CoyoteCert
- Packagist: https://packagist.org/packages/blendbyte/coyotecert
- Documentation: see README.md in the repository

### Submission checklist

- [x] The client respects the Let's Encrypt trademark policy. CoyoteCert has no Let's Encrypt branding, logos, or implied affiliation.
- [x] The client is not browser-based and supports automatic renewals via `issueOrRenew()` and a CLI (`coyote issue`).
- [x] The client encourages routine renewals at randomized times. The README's automatic renewal examples include a `sleep $((RANDOM % 3600))` jitter in the cron command, with a note explaining why.
- [x] This commit adds CoyoteCert to the end of the PHP libraries section.
- [x] This commit updates the `lastmod` date stamp at the top of `clients.json`.