### PR TITLE
Subscriber Agreement 1.7 is now current

### DIFF
--- a/content/en/repository.html
+++ b/content/en/repository.html
@@ -16,8 +16,7 @@ do_not_translate: 1
 <!-- There is a redirect to allow a trailing dot on the Subscriber Agreement URL in netlify.toml.
      It should be updated when a new Subscriber Agreement is published. -->
 <ul>
-  <li><a href="/documents/LE-SA-v1.7-June-04-2026.pdf">v1.7, June 4, 2026</a> <b>(FUTURE EFFECTIVE DATE)</b></li>
-  <li><a href="/documents/LE-SA-v1.6-August-18-2025.pdf">v1.6, August 18, 2025</a> <b>(CURRENT)</b></li>
+  <li><a href="/documents/LE-SA-v1.7-June-04-2026.pdf">v1.7, June 4, 2026</a></li>
   <li><a href="/documents/LE-USG-SA-Amendment-Sept-22-2015.pdf">U.S. Government Amendment, September 22, 2015</a></li>
   <li><a href="/documents/LE-US-State-Local-SA-Amendment-Dec-28-2016.pdf">U.S. State and Local Government Amendment, December 28, 2016</a></li>
 </ul>

--- a/netlify.toml
+++ b/netlify.toml
@@ -326,14 +326,8 @@ force = true
 # Certbot (and other) clients link to the Terms of Service with a `.` after them
 # This is a convenience to allow copying the URL with that `.`
 # It should be updated on ToS changes, but is not a compliance-critical path.
-from = "/documents/LE-SA-v1.5-February-24-2025.pdf."
-to = "/documents/LE-SA-v1.5-February-24-2025.pdf"
-status = 301
-force = true
-
-[[redirects]]
-from = "/documents/LE-SA-v1.6-August-18-2025.pdf."
-to = "/documents/LE-SA-v1.6-August-18-2025.pdf"
+from = "/documents/LE-SA-v1.7-June-04-2026.pdf."
+to = "/documents/LE-SA-v1.7-June-04-2026.pdf"
 status = 301
 force = true
 


### PR DESCRIPTION
Update to remove the future/current language - 1.7 is now current.

Include a redirect for the 1.7 Subscriber Agreement in netlify.toml, and drop previous versions.
