### PR TITLE
Delete breard-r/acmed and icing/mod_md entries from clients.json

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -538,12 +538,6 @@
 			"last_commit": 1752945862
 		},
 		{
-			"name": "ACMEd",
-			"url": "https://github.com/breard-r/acmed",
-			"category": "Rust",
-			"last_commit": 1755965014
-		},
-		{
 			"name": "certman-operator",
 			"url": "https://github.com/openshift/certman-operator",
 			"category": "OpenShift",

--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2025-09-05",
+	"lastmod": "2026-11-11",
 	"categories": [
 		"Bash",
 		"C",

--- a/data/clients.json
+++ b/data/clients.json
@@ -568,13 +568,6 @@
 			"category": "C"
 		},
 		{
-			"name": "mod_md",
-			"url": "https://github.com/icing/mod_md",
-			"comments": "Separate, more frequent releases of the Apache module.",
-			"category": "C",
-			"last_commit": 1755595500
-		},
-		{
 			"name": "App Service Acmebot",
 			"url": "https://github.com/shibayan/appservice-acmebot",
 			"category": "Microsoft Azure",


### PR DESCRIPTION
Removed [breard-r/acmed](https://github.com/breard-r/acmed) and [icing/mod_md](https://github.com/icing/mod_md) entries from clients.json (repos archived by their owners on Feb 22, 2026 and Jun 9, 2026 respectively)
