### PR TITLE
Add EudaCertMgr to the ACME client list

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2025-09-05",
+	"lastmod": "2026-06-15",
 	"categories": [
 		"Bash",
 		"C",
@@ -918,6 +918,11 @@
 				"HTTP-01": "true",
 				"DNS-01": "true"
 			}
+		},
+		{
+			"name": "EudaCertMgr",
+			"url": "https://eudasystems.com/eudacertmgr",
+			"category": "Server"
 		}
 	]
 }


### PR DESCRIPTION
EudaCertMgr is an on-premises certificate orchestrator that issues and renews via the Let's Encrypt ACMEv2 API and deploys to Linux and Windows fleets from a single host over SSH. This PR adds it to the ACME Client Implementations list.

The change appends EudaCertMgr to the **Server** section of `data/clients.json` and updates the `lastmod` stamp.

Confirming the listing criteria:
- Not browser-based.
- Performs fully automatic renewals (systemd timer) at randomized times within the renewal window; honors ARI/renewalInfo where advertised.
- Respects the Let's Encrypt trademark policy in all UI and docs.
- Publicly available at https://eudasystems.com/eudacertmgr.

Happy to adjust categorization or wording to match your conventions. Thanks for everything you've built.

Allen Swope — Product Manager, EudaCertMgr, Euda Systems, Inc