### PR TITLE
Add Chill SSL to list of monitoring options

### DIFF
--- a/content/en/docs/monitoring-options.md
+++ b/content/en/docs/monitoring-options.md
@@ -1,7 +1,7 @@
 ---
 title: Monitoring Service Options
 slug: monitoring-options
-lastmod: 2026-07-07
+lastmod: 2026-07-13
 show_lastmod: 1
 ---
 
@@ -19,6 +19,7 @@ There are a number of monitoring options out there, including:
 * [HeyOnCall](https://heyoncall.com/guides/ssl-certificate-expiration-monitoring) (self-hosted scripts)
 * [CertKit](https://www.certkit.io/)
 * [CertObserver](https://certobserver.com/)
+* [Chill SSL](https://www.chillssl.com/)
 
 Please note that all of these services are unaffiliated with ISRG / Let's Encrypt.
 


### PR DESCRIPTION
## Summary

- Adds [Chill SSL](https://www.chillssl.com/) to the monitoring options list on `/docs/monitoring-options/`
- Updates `lastmod` in `content/en/docs/monitoring-options.md`

Note: I'm the founder/owner of Chill SSL. Chill SSL helps users track SSL certificate expiration dates and receive timely notifications.

This follows up on #1926, which was merged and then reverted pending team review. I've been advised the listing can be resubmitted.

## Test plan

- [x] Verified locally with `hugo server -F` at `/docs/monitoring-options/`
- [x] Link format matches existing entries on the page
- [x] `lastmod` updated per repo guidelines


Made with [Cursor](https://cursor.com)