### PR TITLE
Fix mobile menu collapsing on scroll in iOS Safari

### DIFF
--- a/themes/le-2025/assets/js/le-2025-theme.js
+++ b/themes/le-2025/assets/js/le-2025-theme.js
@@ -308,8 +308,13 @@ const Menu = {
           mainNav.classList.remove('hidden');
           mobileMenuToggle.setAttribute('aria-expanded', 'false');
         } else if (isMobile && mainNav && mobileMenuToggle) {
-          // Only hide the nav when in true mobile mode (< 768px)
-          mainNav.classList.add('hidden');
+          // Only hide the nav when in true mobile mode (< 768px) and the menu
+          // is not intentionally open. On iOS Safari, scrolling fires a resize
+          // event (address bar hide/show changes innerHeight), which would
+          // otherwise collapse an open menu mid-scroll.
+          if (mobileMenuToggle.getAttribute('aria-expanded') !== 'true') {
+            mainNav.classList.add('hidden');
+          }
         } else {
           // For tablet sizes (768px-1023px), keep the nav visible
           mainNav.classList.remove('hidden');


### PR DESCRIPTION
## What this fixes

On iPhone and iPad, opening the mobile navigation menu and then scrolling down causes the menu to snap closed before you can tap a link. This makes it impossible to navigate the site using the mobile menu on iOS Safari — a potentially significant issue given how much traffic comes from mobile devices.

## Why it happens

iOS Safari fires a `resize` event whenever the user scrolls, because the browser address bar slides away as you scroll down (changing the visible height of the page). The menu's resize handler interpreted this as a layout change and hid the navigation menu — even if the user had just opened it intentionally.

## The fix

A one-line guard checks whether the menu is currently open before hiding it. If the user has the menu open, the resize event from scrolling is ignored. The menu still closes correctly in all other cases (e.g. rotating the device, resizing a browser window on desktop).

## Steps to reproduce (before fix)

1. Open [letsencrypt.org](https://letsencrypt.org/) on iPhone in Safari
2. Tap the hamburger menu (☰) to open navigation
3. Tap **About Us** to expand the submenu
4. Swipe up to scroll down the page
5. Menu collapses — links become unreachable

## Test plan

- [x] Reproduced the bug on iPhone Safari (confirmed above steps)
- [x] Verified fix on iPhone Safari: menu stays open when scrolling
- [x] Verified menu still closes correctly when rotating device (expected behaviour)