### PR TITLE
Add CertLocker to ACME client implementations

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2026-07-22",
+	"lastmod": "2026-07-31",
 	"categories": [
 		"Bash",
 		"C",
@@ -900,6 +900,16 @@
 			"name": "CertKit",
 			"url": "https://www.certkit.io/",
 			"comments": "Deployable and SaaS certificate lifecycle management and monitoring",
+			"category": "Server",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "true"
+			}
+		},
+		{
+			"name": "CertLocker",
+			"url": "https://certlocker.io/acme-certificate-automation/",
+			"comments": "ACMEv2 certificate automation with deployment, endpoint probes, RBAC, audit logs, and tamper-evident renewal history",
 			"category": "Server",
 			"challenges": {
 				"HTTP-01": "true",


### PR DESCRIPTION
Adds CertLocker to the Server section of ACME client implementations.

CertLocker supports ACMEv2 certificate automation, automatic renewals, HTTP-01 and DNS-01 workflows, deployment tracking, endpoint verification, RBAC, and audit history.

The listing URL points to a dedicated ACME automation page with non-affiliation/trademark language for Let's Encrypt and ISRG.