### PR TITLE
Update website to read stats from new distribution

### DIFF
--- a/_maintenance_update_graph_data.sh.example
+++ b/_maintenance_update_graph_data.sh.example
@@ -2,9 +2,9 @@
 
 set -eu
 
-outFile="$(dirname "$0")/js/cert-timeline.tsv"
+outFile="$(dirname "$0")/js/cert-daily-stats.tsv"
 
 # Download to a temp file, then move over-top the original, so that the update is
 # atomic from the perspective of the webserver
-curl --silent https://ct.tacticalsecret.com/cert-timeline.tsv > "${outFile}.bak"
+curl --silent https://ct.tacticalsecret.com/cert-daily-stats.tsv > "${outFile}.bak"
 mv "${outFile}.bak" "${outFile}"

--- a/config/_default/server.toml
+++ b/config/_default/server.toml
@@ -18,7 +18,7 @@ Permissions-Policy = """
     fullscreen=(self),
     interest-cohort=()
 """
-# "connect-src https://d4twhgtvn0ff5.cloudfront.net/" for stats graphs
+# "connect-src https://d4twhgtvn0ff5.cloudfront.net/ and https://d1dfn7jg27m4cf.cloudfront.net/" for stats graphs
 # "img-src data: blob:" is for Plotly download feature
 # "script-src unsafe-eval unsafe-inline data:": For Google Analytics
 # "form-action" is NOT set, so it allows everything (it doesn't default to default-src). If restricted, It must allow at least www.paypal.com and its redirects
@@ -79,6 +79,7 @@ Content-Security-Policy = """
     ;
     connect-src 'self'
         https://d4twhgtvn0ff5.cloudfront.net/
+        https://d1dfn7jg27m4cf.cloudfront.net/
         https://donorbox.org
         https://doublethedonation.com
         https://letsencrypt-merch.myshopify.com

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,7 +28,7 @@ Permissions-Policy = """
     fullscreen=(self),
     interest-cohort=()
 """
-# "connect-src https://d4twhgtvn0ff5.cloudfront.net/" for stats graphs
+# "connect-src https://d4twhgtvn0ff5.cloudfront.net/ and https://d1dfn7jg27m4cf.cloudfront.net/" for stats graphs
 # "img-src data: blob:" is for Plotly download feature
 # "script-src unsafe-eval unsafe-inline data:": For Google Analytics
 # "form-action" is NOT set, so it allows everything (it doesn't default to default-src). If restricted, It must allow at least www.paypal.com and its redirects
@@ -89,6 +89,7 @@ Content-Security-Policy = """
     ;
     connect-src 'self'
         https://d4twhgtvn0ff5.cloudfront.net/
+        https://d1dfn7jg27m4cf.cloudfront.net/
         https://donorbox.org
         https://doublethedonation.com
         https://letsencrypt-merch.myshopify.com

--- a/static/js/cert-daily-stats.tsv
+++ b/static/js/cert-daily-stats.tsv
@@ -1,3 +1,4 @@
+date	certs_issued	certs_active	fqdns_active	reg_domains_active
 2015-10-08	2	2	1	1
 2015-10-09	4	6	5	2
 2015-10-10	1	7	6	2

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -327,7 +327,7 @@ function doPlot() {
 
   var statsPath;
   if ( location.hostname === "letsencrypt.org" ) {
-    path = "https://dxxxx.cloudfront.net/";
+    path = "https://d1dfn7jg27m4cf.cloudfront.net/";
   } else {
     path = "/js/"; // in dev, will use old data.
   }

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -325,7 +325,14 @@ function doPlot() {
     path = "/js/"; // in dev, will use old data.
   }
 
-  fetch(path+"cert-timeline.tsv")
+  var statsPath;
+  if ( location.hostname === "letsencrypt.org" ) {
+    path = "https://dxxxx.cloudfront.net/";
+  } else {
+    path = "/js/"; // in dev, will use old data.
+  }
+
+  fetch(statsPath+"cert-daily-stats.tsv")
   .then(response => {
     return response.text();
   }).then(tsvListener);

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -327,9 +327,9 @@ function doPlot() {
 
   var statsPath;
   if ( location.hostname === "letsencrypt.org" ) {
-    path = "https://d1dfn7jg27m4cf.cloudfront.net/";
+    statsPath = "https://d1dfn7jg27m4cf.cloudfront.net/";
   } else {
-    path = "/js/"; // in dev, will use old data.
+    statsPath = "/js/"; // in dev, will use old data.
   }
 
   fetch(statsPath+"cert-daily-stats.tsv")

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -319,17 +319,17 @@ function doPlot() {
   }
 
   var path;
-  if ( location.hostname === "letsencrypt.org" ) {
-    path = "https://d4twhgtvn0ff5.cloudfront.net/";
-  } else {
+  if ( location.hostname === "localhost" ) {
     path = "/js/"; // in dev, will use old data.
+  } else {
+    path = "https://d4twhgtvn0ff5.cloudfront.net/";
   }
 
   var statsPath;
-  if ( location.hostname === "letsencrypt.org" ) {
-    statsPath = "https://d1dfn7jg27m4cf.cloudfront.net/";
-  } else {
+  if ( location.hostname === "localhost" ) {
     statsPath = "/js/"; // in dev, will use old data.
+  } else {
+    statsPath = "https://d1dfn7jg27m4cf.cloudfront.net/";
   }
 
   fetch(statsPath+"cert-daily-stats.tsv")


### PR DESCRIPTION
Update source of certificate daily stats, which is now `cert-daily-stats.tsv` from a different distribution URL. Other artifacts are still retrieved from the old distribution URL.

New TSV file has the same columns in the same order as old TSV file. Only difference is the new TSV file has headers, which will get safely skipped.