### PR TITLE
Add acme-agent to clients list

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -905,6 +905,17 @@
 				"HTTP-01": "true",
 				"DNS-01": "true"
 			}
+		},
+		{
+			"name": "acme-agent",
+			"url": "https://github.com/tmhal5l13/acme-agent",
+			"category": "Go",
+			"comments": "Centralized renewal hub for organizations not running Kubernetes: DNS provider credentials stay on one hub, each spoke generates its own key and drives its own ACME order via DNS-01, relayed through the hub.",
+			"challenges": {
+				"HTTP-01": "false",
+				"DNS-01": "true",
+				"TLS-ALPN-01": "false"
+			}
 		}
 	]
 }


### PR DESCRIPTION
Adding [acme-agent](https://github.com/tmhal5l13/acme-agent) to the client list.

A centralized ACME renewal hub for organizations not running Kubernetes: DNS provider credentials stay on one hub, each spoke generates its own key locally and drives its own ACME order via DNS-01, relayed through the hub. Private keys never leave the spoke that generated them.

- Supports DNS-01 only (deliberately, not listed as a gap)
- DNS providers: Route53 (including per-entry credentials for zones split across AWS accounts), Cloudflare, PowerDNS, rfc2136 (BIND, TSIG-authenticated)
- Renews at randomized times via jitter, per the client list requirements
- Supports External Account Binding (EAB), with end-to-end test coverage against a real EAB-enforcing ACME server

Since this PR was opened: added config hot-reload (`SIGHUP`, no restart needed to add a spoke or rotate DNS provider credentials) and a low-friction spoke enrollment flow (`acme-hub --generate-token` / `acme-spoke --load-token`) that removes manual file-copying from spoke setup entirely.
