### PR TITLE
Add CertPost to list of monitoring options

### DIFF
--- a/content/en/docs/monitoring-options.md
+++ b/content/en/docs/monitoring-options.md
@@ -19,6 +19,7 @@ There are a number of monitoring options out there, including:
 * [HeyOnCall](https://heyoncall.com/guides/ssl-certificate-expiration-monitoring) (self-hosted scripts)
 * [CertKit](https://www.certkit.io/)
 * [CertObserver](https://certobserver.com/)
+* [CertPost](https://www.certpost.ai)
 * [Chill SSL](https://www.chillssl.com/)
 
 Please note that all of these services are unaffiliated with ISRG / Let's Encrypt.

--- a/content/en/docs/monitoring-options.md
+++ b/content/en/docs/monitoring-options.md
@@ -20,7 +20,7 @@ There are a number of monitoring options out there, including:
 * [CertKit](https://www.certkit.io/)
 * [CertObserver](https://certobserver.com/)
 * [Chill SSL](https://www.chillssl.com/)
-* * [CertPost](https://www.certpost.ai/)
+* [CertPost](https://www.certpost.ai/)
 
 Please note that all of these services are unaffiliated with ISRG / Let's Encrypt.
 

--- a/content/en/docs/monitoring-options.md
+++ b/content/en/docs/monitoring-options.md
@@ -1,7 +1,7 @@
 ---
 title: Monitoring Service Options
 slug: monitoring-options
-lastmod: 2026-07-13
+lastmod: 2026-08-24
 show_lastmod: 1
 ---
 
@@ -19,8 +19,8 @@ There are a number of monitoring options out there, including:
 * [HeyOnCall](https://heyoncall.com/guides/ssl-certificate-expiration-monitoring) (self-hosted scripts)
 * [CertKit](https://www.certkit.io/)
 * [CertObserver](https://certobserver.com/)
-* [CertPost](https://www.certpost.ai)
 * [Chill SSL](https://www.chillssl.com/)
+* * [CertPost](https://www.certpost.ai/)
 
 Please note that all of these services are unaffiliated with ISRG / Let's Encrypt.
 


### PR DESCRIPTION
## Summary

- Adds [CertPost](https://www.certpost.ai/) to the monitoring options list on `/docs/monitoring-options/`
- Updates `lastmod` in `content/en/docs/monitoring-options.md`

Note: I'm the founder of CertPost. It monitors TLS certificates by opening a live connection and reading the certificate the server actually serves, so a renewal that succeeds on disk but never reloads is still caught. It checks expiry, full chain including intermediates, hostname match and certificate changes, on any TLS port. Free plan covers 3 certificates with no card and no time limit.

English content only - no translated pages touched, since those are handled on Crowdin.

## Test plan

- [x] Verified locally with `hugo server -F` at `/docs/monitoring-options/`
- [x] Link format and bullet style match the existing entries
- [x] Link resolves to https://www.certpost.ai/