### PR TITLE
Add CertMate to the Server client list

### DIFF
--- a/data/clients.json
+++ b/data/clients.json
@@ -1,5 +1,5 @@
 {
-	"lastmod": "2026-07-22",
+	"lastmod": "2026-08-29",
 	"categories": [
 		"Bash",
 		"C",
@@ -905,6 +905,17 @@
 				"HTTP-01": "true",
 				"DNS-01": "true"
 			}
+		},
+		{
+			"name": "CertMate",
+			"url": "https://github.com/fabriziosalmi/certmate",
+			"comments": "Self-hosted certificate lifecycle manager (web UI + REST API) automating issuance and renewal across 20+ DNS providers",
+			"category": "Server",
+			"challenges": {
+				"HTTP-01": "true",
+				"DNS-01": "true"
+			},
+			"last_commit": 1788269394
 		}
 	]
 }


### PR DESCRIPTION
This adds [CertMate](https://github.com/fabriziosalmi/certmate) to the Server section of the client list.

CertMate is an actively-maintained, MIT-licensed self-hosted certificate lifecycle manager (web UI + REST API) that wraps certbot to automate issuance and renewal against the ACMEv2 API across 20+ DNS providers (DNS-01), with HTTP-01 also supported.

Checklist from the [client-options docs](https://letsencrypt.org/docs/client-options/#acme-v2-compatible-clients):

- [x] Respects the Let's Encrypt trademark policy (referenced only descriptively as a supported CA).
- [x] Not browser-based; runs server-side and supports automatic renewals (a background scheduler renews certificates within their renewal window).
- [x] Performs routine renewals at randomized times — the renewal sweeps are jittered across a window so instances do not all contact the CA at the same time.
- [x] Added to the end of the relevant section (Server).
- [x] Updated the `lastmod` date stamp in `clients.json`.