### PR TITLE
Enforce PMA approval for changes to our Certificate and Policy and Legal Repositories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 /content/en/documents/ @letsencrypt/pma
 /static/audits/ @letsencrypt/pma
 /static/certs/ @letsencrypt/pma
+netlify.toml @letsencrypt/pma

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+/content/en/certificates.md @letsencrypt/pma
+/content/en/repository.html @letsencrypt/pma
+/content/en/documents/ @letsencrypt/pma
+/static/audits/ @letsencrypt/pma
+/static/certs/ @letsencrypt/pma


### PR DESCRIPTION
Per Section 1.6.1 of our CP/CPS, our Certificate Repository is https://letsencrypt.org/certificates/. That page's source is /content/en/certificates.md and the certificate files found in /static/certs/ and its subdirectories.

Per the same, our Policy and Legal Repository is https://letsencrypt.org/repository/. That page's source is /content/en/repository.html, as well as the audit documents from /static/audits/ and the CPS and Subscriber Agreement documents from /content/en/documents/.

Although changes to these files already require approval from PMA by policy, that requirement is not technically enforced by GitHub itself. Add a CODEOWNERS file to do so.