### PR TITLE
Improvements to CT doc

### DIFF
--- a/content/en/docs/ct-logs.html
+++ b/content/en/docs/ct-logs.html
@@ -1,12 +1,12 @@
 ---
 title: Certificate Transparency (CT) Logs
 slug: ct-logs
-lastmod: 2026-06-15
+lastmod: 2026-09-04
 show_lastmod: 1
 ---
 
 <p>
-  <a href="https://www.certificate-transparency.org/what-is-ct">Certificate Transparency (CT)</a>
+  <a href="https://certificate.transparency.dev/">Certificate Transparency (CT)</a>
   is a system for logging and monitoring the issuance of TLS certificates. CT
   greatly enhances everyone's ability to monitor and study certificate issuance,
   and these capabilities have led to numerous improvements to the CA ecosystem
@@ -49,7 +49,7 @@ Information about the various lifecycle states that a CT log progresses through 
   <a href="https://sunlight.dev">Sunlight</a>.
 </p>
 <p>
-  Information including accepted roots, public keys, log IDs, and shard intervals are available at each log's
+  Information including accepted roots, public keys, log IDs, and shard intervals is available at each log's
   landing page, linked below.
 </p>
 <p>Sycamore and Willow are our production CT logs, accepting certificates from trusted CAs.</p>
@@ -75,11 +75,17 @@ Information about the various lifecycle states that a CT log progresses through 
 
 <h2 id="log-operations">Log Operations</h2>
 <p>
+  The examples below use the Sycamore 2026h2 shard. Our logs are split into
+  temporal shards, and each shard only accepts certificates whose expiration
+  date falls within its interval, so pick the shard that matches your
+  certificate from the log's landing page.
+</p>
+<p>
   To enumerate the included roots for a particular CT log, you can run the
   following command in the terminal of your choice:
 </p>
 <pre>
-$ for i in $(curl -s https://oak.ct.letsencrypt.org/2020/ct/v1/get-roots | jq -r '.certificates[]'); do
+$ for i in $(curl -s https://log.sycamore.ct.letsencrypt.org/2026h2/ct/v1/get-roots | jq -r '.certificates[]'); do
     echo '------'; base64 -d &lt;&lt;&lt; "${i}" | openssl x509 -inform der -noout -issuer -serial
 done
 </pre>
@@ -108,7 +114,8 @@ sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' &gt; example.crt
   command to perform the add-chain operation (<a
     href="https://tools.ietf.org/html/rfc6962#section-4.1"
     >RFC 6962 section 4.1</a
-  >) to submit the certificate to a CT log. The output will contain a signature
+  >) to submit the certificate to a CT log. Our Static CT API logs accept the
+  same submission API as RFC 6962 logs. The output will contain a signature
   which is in fact an
   <a href="https://letsencrypt.org/2018/04/04/sct-encoding.html">SCT</a>. More
   on the signature in a moment.
@@ -119,18 +126,19 @@ $ curl \
    --data @example-json-bundle.json \
     -H "Content-Type: application/json" \
     -H "User-Agent: lets-encrypt-ct-log-example-1.0" \
-   https://oak.ct.letsencrypt.org/2020/ct/v1/add-chain
-{"sct_version":0,"id":"5xLysDd+GmL7jskMYYTx6ns3y1YdESZb8+DzS/JBVG4=","timestamp":1576689972016,"extensions":"","signature":"BAMARzBFAiEA4OmuTcft9Jq3XLtcdZz9XinXCvYEY1RdSQICXayMJ+0CIHuujkKBLmQz5Cl/VG6C354cP9gxW0dfgMWB+A2yHi+E"}
+   https://log.sycamore.ct.letsencrypt.org/2026h2/ct/v1/add-chain
+{"sct_version":0,"id":"bP5QGUOoXqkWvFLRM+TcyR7xQRx9JYQg0XOAnhgY6zo=","timestamp":1783737642362,"extensions":"AAAFABSjxQU=","signature":"BAMASDBGAiEAzgwvZXjfPivGYoUr2p9yvFsi/vgA3DHUX+vL0Izm2g8CIQCvtWiPPUTYmFztu9ntrtFrg65JVuuCAZKDd+C+QD6wig=="}
 </pre>
 
 <p>
-  To confirm that the CT log was signed by the Oak 2020 shard, we use the id
-  field from the command above and run it through the following command. The
-  result of this will output the Log ID of the CT log.
+  To confirm that the SCT was signed by the Sycamore 2026h2 shard, we use the
+  id field from the response above and run it through the following command.
+  The result is the Log ID of the shard, which you can compare against the Log
+  ID shown on the log's landing page.
 </p>
 <pre>
-$ base64 -d &lt;&lt;&lt; "5xLysDd+GmL7jskMYYTx6ns3y1YdESZb8+DzS/JBVG4=" | xxd -p -c 64 | sed -e 's/../&:/g' -e 's/:$//' | tr '[:lower:]' '[:upper:]'
-E7:12:F2:B0:37:7E:1A:62:FB:8E:C9:0C:61:84:F1:EA:7B:37:CB:56:1D:11:26:5B:F3:E0:F3:4B:F2:41:54:6E
+$ base64 -d &lt;&lt;&lt; "bP5QGUOoXqkWvFLRM+TcyR7xQRx9JYQg0XOAnhgY6zo=" | xxd -p -c 64 | sed -e 's/../&:/g' -e 's/:$//' | tr '[:lower:]' '[:upper:]'
+6C:FE:50:19:43:A8:5E:A9:16:BC:52:D1:33:E4:DC:C9:1E:F1:41:1C:7D:25:84:20:D1:73:80:9E:18:18:EB:3A
 </pre>
 
 <p>
@@ -141,10 +149,10 @@ E7:12:F2:B0:37:7E:1A:62:FB:8E:C9:0C:61:84:F1:EA:7B:37:CB:56:1D:11:26:5B:F3:E0:F3
   >, you could further decode this value.
 </p>
 <pre>
-$ base64 -d &lt;&lt;&lt; "BAMARzBFAiEA4OmuTcft9Jq3XLtcdZz9XinXCvYEY1RdSQICXayMJ+0CIHuujkKBLmQz5Cl/VG6C354cP9gxW0dfgMWB+A2yHi+E" | xxd -p -c 16 | sed -e 's/../&:/g' -e 's/:$//' | tr '[:lower:]' '[:upper:]'
-04:03:00:47:30:45:02:21:00:E0:E9:AE:4D:C7:ED:F4
-9A:B7:5C:BB:5C:75:9C:FD:5E:29:D7:0A:F6:04:63:54
-5D:49:02:02:5D:AC:8C:27:ED:02:20:7B:AE:8E:42:81
-2E:64:33:E4:29:7F:54:6E:82:DF:9E:1C:3F:D8:31:5B
-47:5F:80:C5:81:F8:0D:B2:1E:2F:84
+$ base64 -d &lt;&lt;&lt; "BAMASDBGAiEAzgwvZXjfPivGYoUr2p9yvFsi/vgA3DHUX+vL0Izm2g8CIQCvtWiPPUTYmFztu9ntrtFrg65JVuuCAZKDd+C+QD6wig==" | xxd -p -c 16 | sed -e 's/../&:/g' -e 's/:$//' | tr '[:lower:]' '[:upper:]'
+04:03:00:48:30:46:02:21:00:CE:0C:2F:65:78:DF:3E
+2B:C6:62:85:2B:DA:9F:72:BC:5B:22:FE:F8:00:DC:31
+D4:5F:EB:CB:D0:8C:E6:DA:0F:02:21:00:AF:B5:68:8F
+3D:44:D8:98:5C:ED:BB:D9:ED:AE:D1:6B:83:AE:49:56
+EB:82:01:92:83:77:E0:BE:40:3E:B0:8A
 </pre>


### PR DESCRIPTION
Most notably:
* Use a current working example for CT log commands
* The paragraph that said "the CT log was signed by the Oak 2020 shard" now says the SCT was signed by the shard