### PR TITLE
Add Upcheck to list of monitoring options

### DIFF
--- a/content/en/docs/monitoring-options.md
+++ b/content/en/docs/monitoring-options.md
@@ -1,7 +1,7 @@
 ---
 title: Monitoring Service Options
 slug: monitoring-options
-lastmod: 2026-07-13
+lastmod: 2026-09-09
 show_lastmod: 1
 ---
 
@@ -20,6 +20,7 @@ There are a number of monitoring options out there, including:
 * [CertKit](https://www.certkit.io/)
 * [CertObserver](https://certobserver.com/)
 * [Chill SSL](https://www.chillssl.com/)
+* [Upcheck](https://upcheck.so/ssl-monitoring)
 
 Please note that all of these services are unaffiliated with ISRG / Let's Encrypt.
 


### PR DESCRIPTION
Adds [Upcheck](https://upcheck.so/ssl-monitoring) to the list on `/docs/monitoring-options/` and updates `lastmod`.

Upcheck monitors TLS certificates (validity, chain, hostname coverage, and expiration, with alerts ahead of expiry) alongside uptime, DNS, and domain expiration checks. It also provides free, no-signup certificate checking tools.

Disclaimer: I'm the founder of Upcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)